### PR TITLE
Load profile information from the right location

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -112,7 +112,7 @@ export async function submitJcl(datasetProvider: DatasetTree) {
     } else {
         // if submitting from favorites, a session might not exist for this node
         const zosmfProfile = await new CliProfileManager({
-            profileRootDirectory: path.join(os.homedir(), ".brightside", "profiles"),
+            profileRootDirectory: path.join(os.homedir(), ".zowe", "profiles"),
             type: "zosmf"
         }).load({name: sesName});
         documentSession = zowe.ZosmfSession.createBasicZosmfSession(zosmfProfile.profile);


### PR DESCRIPTION
Resolves #25 by using the `.zowe` directory in the users home directory as the location for the profiles.

Signed-off-by: Andrew Smithson <smithson@uk.ibm.com>