### PR TITLE
Add information messages in sessions nodes

### DIFF
--- a/__tests__/ZoweNode.test.ts
+++ b/__tests__/ZoweNode.test.ts
@@ -131,9 +131,10 @@ describe("Unit Tests (Jest)", async () => {
     it("Checks that passing a session node that is not dirty the getChildren() method is exited early", async () => {
         // Creating a rootNode
         const rootNode = new ZoweNode("root", vscode.TreeItemCollapsibleState.Collapsed, null, session);
+        const infoChild = new ZoweNode("Use the search button to display datasets", vscode.TreeItemCollapsibleState.None, rootNode, null, true);
         rootNode.contextValue = "session";
         rootNode.dirty = false;
-        await expect(await rootNode.getChildren()).toEqual([]);
+        await expect(await rootNode.getChildren()).toEqual([infoChild]);
     });
 
     /*************************************************************************************************************
@@ -142,8 +143,9 @@ describe("Unit Tests (Jest)", async () => {
     it("Checks that passing a session node with no hlq the getChildren() method is exited early", async () => {
         // Creating a rootNode
         const rootNode = new ZoweNode("root", vscode.TreeItemCollapsibleState.Collapsed, null, session);
+        const infoChild = new ZoweNode("Use the search button to display datasets", vscode.TreeItemCollapsibleState.None, rootNode, null, true);
         rootNode.contextValue = "session";
-        await expect(await rootNode.getChildren()).toEqual([]);
+        await expect(await rootNode.getChildren()).toEqual([infoChild]);
     });
 
     /*************************************************************************************************************

--- a/src/ZoweNode.ts
+++ b/src/ZoweNode.ts
@@ -35,9 +35,11 @@ export class ZoweNode extends vscode.TreeItem {
      * @param {Session} session
      */
     constructor(public mLabel: string, public mCollapsibleState: vscode.TreeItemCollapsibleState,
-                public mParent: ZoweNode, private session: Session) {
+                public mParent: ZoweNode, private session: Session, information: boolean = false) {
         super(mLabel, mCollapsibleState);
-        if (mCollapsibleState !== vscode.TreeItemCollapsibleState.None) {
+        if (information) {
+            this.contextValue = "information";
+        } else if (mCollapsibleState !== vscode.TreeItemCollapsibleState.None) {
             this.contextValue = "pds";
         } else if (mParent && mParent.mParent !== null) {
             this.contextValue = "member";
@@ -52,9 +54,14 @@ export class ZoweNode extends vscode.TreeItem {
      * @returns {Promise<ZoweNode[]>}
      */
     public async getChildren(): Promise<ZoweNode[]> {
-        if ((!this.pattern && this.contextValue === "session") || this.contextValue === "ds" || this.contextValue === "member") {
+        if ((!this.pattern && this.contextValue === "session")){ 
+            return [new ZoweNode("Use the search button to display datasets", vscode.TreeItemCollapsibleState.None, this, null, true)];
+        }
+
+        if (this.contextValue === "ds" || this.contextValue === "member" || this.contextValue === "information") {
             return [];
         }
+
         if (!this.dirty || this.mLabel === "Favorites") {
             return this.children;
         }
@@ -118,7 +125,11 @@ export class ZoweNode extends vscode.TreeItem {
         if (this.contextValue === "session") {
             this.dirty = false;
         }
-        return this.children = Object.keys(elementChildren).sort().map((labels) => elementChildren[labels]);
+        if(Object.keys(elementChildren).length === 0) {
+            return this.children = [new ZoweNode("No datasets found", vscode.TreeItemCollapsibleState.None, this, null, true)];
+        } else {
+            return this.children = Object.keys(elementChildren).sort().map((labels) => elementChildren[labels]);
+        }
     }
 
     /**


### PR DESCRIPTION
Resolves #3 by adding information nodes to a session when it is first added to indicate a search should be performed, and then if the search returns an empty list of datasets a message to indicate this has happened.