### PR TITLE
Toggle download as binary to avoid conversion

### DIFF
--- a/__tests__/extension.test.ts
+++ b/__tests__/extension.test.ts
@@ -286,7 +286,7 @@ describe("Extension Unit Tests", async () => {
                     getChildren: mockGetUSSChildren,
                 }
         });
-        expect(registerCommand.mock.calls.length).toBe(27);
+        expect(registerCommand.mock.calls.length).toBe(29);
         expect(registerCommand.mock.calls[0][0]).toBe("zowe.addSession");
         expect(registerCommand.mock.calls[0][1]).toBeInstanceOf(Function);
         expect(registerCommand.mock.calls[1][0]).toBe("zowe.addFavorite");
@@ -1242,7 +1242,7 @@ describe("Extension Unit Tests", async () => {
         expect(ussFile.mock.calls.length).toBe(1);
         expect(ussFile.mock.calls[0][0]).toBe(session);
         expect(ussFile.mock.calls[0][1]).toBe(node.fullPath);
-        expect(ussFile.mock.calls[0][2]).toEqual({ file: extension.getUSSDocumentFilePath(node) });
+        expect(ussFile.mock.calls[0][2]).toEqual({ file: extension.getUSSDocumentFilePath(node), binary: node.binary });
         expect(openTextDocument.mock.calls.length).toBe(1);
         expect(openTextDocument.mock.calls[0][0]).toBe(extension.getUSSDocumentFilePath(node));
         expect(showTextDocument.mock.calls.length).toBe(1);

--- a/package.json
+++ b/package.json
@@ -190,6 +190,14 @@
       {
         "command": "zowe.uss.removeSession",
         "title": "Remove Profile"
+      },
+      {
+        "command": "zowe.uss.binary",
+        "title": "Toggle Binary"
+      },
+      {
+        "command": "zowe.uss.text",
+        "title": "Toggle Text"
       }
     ],
     "menus": {
@@ -229,6 +237,16 @@
         {
           "when": "view == zowe.uss.explorer",
           "command": "zowe.uss.deleteNode",
+          "group": "navigation"
+        },
+        {
+          "when": "view == zowe.uss.explorer && viewItem == textFile",
+          "command": "zowe.uss.binary",
+          "group": "navigation"
+        },
+        {
+          "when": "view == zowe.uss.explorer && viewItem == binaryFile",
+          "command": "zowe.uss.text",
           "group": "navigation"
         },
         {

--- a/src/ZoweUSSNode.ts
+++ b/src/ZoweUSSNode.ts
@@ -24,6 +24,7 @@ export class ZoweUSSNode extends vscode.TreeItem {
     public command: vscode.Command;
     public fullPath = "";
     public dirty = true;
+    public binary = false;
     public children: ZoweUSSNode[] = [];
 
     /**
@@ -41,7 +42,7 @@ export class ZoweUSSNode extends vscode.TreeItem {
         if (mCollapsibleState !== vscode.TreeItemCollapsibleState.None) {
             this.contextValue = "directory";
         } else {
-            this.contextValue = "file";
+            this.contextValue = "textFile";
         }
         if (parentPath)
             this.fullPath = this.tooltip = parentPath+'/'+mLabel;
@@ -124,5 +125,15 @@ export class ZoweUSSNode extends vscode.TreeItem {
      */
     public getSessionNode(): ZoweUSSNode {
         return this.session ? this : this.mParent.getSessionNode();
+    }
+
+    public setBinary(binary: boolean) {
+        this.binary = binary;
+        if(this.binary){
+            this.contextValue = "binaryFile";
+        } else {
+            this.contextValue = "textFile";
+        }
+        this.dirty = true;
     }
 }

--- a/src/ZoweUSSNode.ts
+++ b/src/ZoweUSSNode.ts
@@ -99,7 +99,7 @@ export class ZoweUSSNode extends vscode.TreeItem {
                     } else {
                         // Creates a ZoweUSSNode for a file
                         let temp;
-                        if(this.binaryFiles.hasOwnProperty(item.name)) {
+                        if(this.getSessionNode().binaryFiles.hasOwnProperty(this.fullPath + '/' + item.name)) {
                             temp = new ZoweUSSNode(item.name, vscode.TreeItemCollapsibleState.None, this, null, this.fullPath, true);
                         } else {
                             temp = new ZoweUSSNode(item.name, vscode.TreeItemCollapsibleState.None, this, null, this.fullPath);
@@ -139,10 +139,10 @@ export class ZoweUSSNode extends vscode.TreeItem {
         this.binary = binary;
         if(this.binary){
             this.contextValue = "binaryFile";
-            this.mParent.binaryFiles[this.mLabel] = true;
+            this.getSessionNode().binaryFiles[this.fullPath] = true;
         } else {
             this.contextValue = "textFile";
-            delete this.mParent.binaryFiles[this.mLabel];
+            delete this.getSessionNode().binaryFiles[this.fullPath];
         }
         this.dirty = true;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,6 +119,8 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("zowe.uss.createFile", async (node) => ussActions.createUSSNode(node, ussFileProvider, "file"));
     vscode.commands.registerCommand("zowe.uss.createFolder", async (node) => ussActions.createUSSNode(node, ussFileProvider, "directory"));
     vscode.commands.registerCommand("zowe.uss.deleteNode", async (node) => ussActions.deleteUSSNode(node, ussFileProvider, getUSSDocumentFilePath(node)));
+    vscode.commands.registerCommand("zowe.uss.binary", async (node) => {node.setBinary(true); ussFileProvider.refresh();});
+    vscode.commands.registerCommand("zowe.uss.text", async (node) => {node.setBinary(false); ussFileProvider.refresh()});
 }
 
 /**
@@ -968,7 +970,7 @@ export async function saveUSSFile(doc: vscode.TextDocument, ussFileProvider: USS
             location: vscode.ProgressLocation.Notification,
             title: "Saving file..."
         }, () => {
-            return zowe.Upload.fileToUSSFile(documentSession, doc.fileName, remote);  // TODO MISSED TESTING
+            return zowe.Upload.fileToUSSFile(documentSession, doc.fileName, remote, sesNode.binary);  // TODO MISSED TESTING
         });
         if (response.success) {
             vscode.window.showInformationMessage(response.commandResponse);
@@ -1005,7 +1007,8 @@ export async function openUSS(node: ZoweUSSNode) {
         // if local copy exists, open that instead of pulling from mainframe
         if (!fs.existsSync(getUSSDocumentFilePath(node))) {
             await zowe.Download.ussFile(node.getSession(), node.fullPath, {
-                file: getUSSDocumentFilePath(node)
+                file: getUSSDocumentFilePath(node),
+                binary: node.binary
             });
         }
         const document = await vscode.workspace.openTextDocument(getUSSDocumentFilePath(node));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,8 +119,14 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("zowe.uss.createFile", async (node) => ussActions.createUSSNode(node, ussFileProvider, "file"));
     vscode.commands.registerCommand("zowe.uss.createFolder", async (node) => ussActions.createUSSNode(node, ussFileProvider, "directory"));
     vscode.commands.registerCommand("zowe.uss.deleteNode", async (node) => ussActions.deleteUSSNode(node, ussFileProvider, getUSSDocumentFilePath(node)));
-    vscode.commands.registerCommand("zowe.uss.binary", async (node) => {node.setBinary(true); ussFileProvider.refresh();});
-    vscode.commands.registerCommand("zowe.uss.text", async (node) => {node.setBinary(false); ussFileProvider.refresh()});
+    vscode.commands.registerCommand("zowe.uss.binary", async (node) => changeFileType(node, true, ussFileProvider));
+    vscode.commands.registerCommand("zowe.uss.text", async (node) => changeFileType(node, false, ussFileProvider));
+}
+
+export async function changeFileType(node: ZoweUSSNode, binary: boolean, ussFileProvider: USSTree) {
+    node.setBinary(binary);
+    await openUSS(node, true);
+    ussFileProvider.refresh();
 }
 
 /**
@@ -988,7 +994,7 @@ export async function saveUSSFile(doc: vscode.TextDocument, ussFileProvider: USS
  *
  * @param {ZoweUSSNode} node
  */
-export async function openUSS(node: ZoweUSSNode) {
+export async function openUSS(node: ZoweUSSNode, download = false) {
  
     try {
         let label: string;
@@ -1005,7 +1011,7 @@ export async function openUSS(node: ZoweUSSNode) {
         }
         log.debug("requesting to open a uss file " + label);
         // if local copy exists, open that instead of pulling from mainframe
-        if (!fs.existsSync(getUSSDocumentFilePath(node))) {
+        if (download || !fs.existsSync(getUSSDocumentFilePath(node))) {
             await zowe.Download.ussFile(node.getSession(), node.fullPath, {
                 file: getUSSDocumentFilePath(node),
                 binary: node.binary


### PR DESCRIPTION
Resolves #57 as a workaround.

Adds a new menu item which allows to toggle between downloading the file
as text which will do data conversion even if the file doesn't require it
or binary which will just get the contents of the file allowing editing
of non EBCDIC files in an editor.