### PR TITLE
Fix context menu items for Jobs and USS sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## 0.15.1
+ - Add a delete session menu item for sessions in the jobs view. Thanks @crshnburn
+ - Prevent the delete menu item for USS files and directories appearing on the context menu for sessions. Thanks @crshnburn
+ - Fixed an issue where adding a profile to the USS explorer incorrectly referenced data sets 
 ## 0.15.0
  - The extension is now compatible with installations which use a secure credential management plugin
    for profiles in Zowe CLI

--- a/__tests__/extension.test.ts
+++ b/__tests__/extension.test.ts
@@ -286,7 +286,7 @@ describe("Extension Unit Tests", async () => {
                     getChildren: mockGetUSSChildren,
                 }
         });
-        expect(registerCommand.mock.calls.length).toBe(39);
+        expect(registerCommand.mock.calls.length).toBe(40);
         expect(registerCommand.mock.calls[0][0]).toBe("zowe.addSession");
         expect(registerCommand.mock.calls[0][1]).toBeInstanceOf(Function);
         expect(registerCommand.mock.calls[1][0]).toBe("zowe.addFavorite");

--- a/__tests__/extension.test.ts
+++ b/__tests__/extension.test.ts
@@ -1160,7 +1160,7 @@ describe("Extension Unit Tests", async () => {
         expect(showQuickPick.mock.calls[0][1]).toEqual({
             canPickMany: false,
             ignoreFocusOut: true,
-            placeHolder: "Select a Profile to Add to the Data Set Explorer"
+            placeHolder: "Select a Profile to Add to the USS Explorer"
         });
 
         showInformationMessage.mockReset();

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-extension-for-zowe",
   "displayName": "Zowe",
   "description": "VS Code extension, powered by Zowe CLI, that streamlines interaction with mainframe data sets, USS files, and jobs",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "publisher": "Zowe",
   "repository": {
     "url": "https://github.com/zowe/vscode-extension-for-zowe"

--- a/package.json
+++ b/package.json
@@ -263,6 +263,10 @@
           "light": "./resources/light/plus.svg",
           "dark": "./resources/dark/plus.svg"
         }
+      },
+      {
+        "command": "zowe.removeJobsSession",
+        "title": "Remove Profile"
       }
     ],
     "menus": {
@@ -463,6 +467,10 @@
         {
           "when": "viewItem == server",
           "command": "zowe.setPrefix"
+        },
+        {
+          "when": "viewItem == server",
+          "command": "zowe.removeJobsSession"
         },
         {
           "when": "viewItem == job",

--- a/package.json
+++ b/package.json
@@ -314,7 +314,7 @@
           "group": "navigation"
         },
         {
-          "when": "view == zowe.uss.explorer",
+          "when": "view == zowe.uss.explorer && viewItem != uss_session",
           "command": "zowe.uss.deleteNode",
           "group": "navigation"
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -336,7 +336,7 @@ export async function addUSSSession(ussFileProvider: USSTree) {
     }
     if (profileNamesList.length) {
         const quickPickOptions: vscode.QuickPickOptions = {
-            placeHolder: "Select a Profile to Add to the Data Set Explorer",
+            placeHolder: "Select a Profile to Add to the USS Explorer",
             ignoreFocusOut: true,
             canPickMany: false
         };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -168,6 +168,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("zowe.setPrefix", (node) => {
         setPrefix(node, jobsProvider);
     });
+    vscode.commands.registerCommand("zowe.removeJobsSession", (node) => jobsProvider.deleteSession(node));
 }
 
 export async function changeFileType(node: ZoweUSSNode, binary: boolean, ussFileProvider: USSTree) {

--- a/src/zosjobs.ts
+++ b/src/zosjobs.ts
@@ -64,6 +64,12 @@ export class ZosJobsProvider implements vscode.TreeDataProvider<Job> {
         this.refresh();
     }
 
+    public deleteSession(node: Job) {
+        // Removes deleted session from mSessionNodes
+        this.mSessionNodes = this.mSessionNodes.filter((tempNode) => tempNode.label !== node.label);
+        this.refresh();
+    }
+
     /**
      * Called whenever the tree needs to be refreshed, and fires the data change event
      *


### PR DESCRIPTION
Resolves #68

1. Add a delete session menu item for sessions in the jobs view
2. Prevent the delete menu item for USS files and directories appearing on the context menu for sessions