### PR TITLE
Add command to download all Spool content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## 0.16.0
  - Add the ability to display data set attributes by right clicking on a data set
+ - Add the ability to save all spool content by right clicking on a job. Thanks @crshnburn
 ## 0.15.1
  - Add a delete session menu item for sessions in the jobs view. Thanks @crshnburn
  - Prevent the delete menu item for USS files and directories appearing on the context menu for sessions. Thanks @crshnburn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## 0.16.0
  - Add the ability to display data set attributes by right clicking on a data set
- - Add the ability to save all spool content by right clicking on a job. Thanks @crshnburn
+ - Add the ability to save all spool content by clicking a download icon next to the job. Thanks @crshnburn
 ## 0.15.1
  - Add a delete session menu item for sessions in the jobs view. Thanks @crshnburn
  - Prevent the delete menu item for USS files and directories appearing on the context menu for sessions. Thanks @crshnburn

--- a/__tests__/ProfileLoader.test.ts
+++ b/__tests__/ProfileLoader.test.ts
@@ -1,0 +1,65 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+jest.mock("child_process");
+import * as child_process from "child_process";
+
+import { loadNamedProfile, loadAllProfiles, loadDefaultProfile } from "../src/ProfileLoader";
+
+
+describe("ProfileLoader", ()=>{
+
+    const profileOne = {name: "profile1", profile: {}, type: "zosmf"};
+    const profileTwo = {name: "profile2", profile: {}, type: "zosmf"};
+
+    (child_process.spawnSync as any) = jest.fn((program: string, args: string[], options: any)=>{
+        
+        const createFakeChildProcess =(status: number, stdout:string, stderr: string) =>{
+            return {
+                status,
+                stdout: {
+                    toString : jest.fn(()=>{ 
+                        return stdout;
+                    })
+                },
+                stderr: {
+                    toString : jest.fn(()=>{ 
+                        return stderr;
+                    })
+                },
+            };
+        };
+
+        if (args[0].indexOf("getAllProfiles") >=0){
+            return createFakeChildProcess(0, JSON.stringify([profileOne, profileTwo]), "");
+        } else {
+            // load default profile            
+            return createFakeChildProcess(0, JSON.stringify(profileOne), "");
+        }
+    })
+
+    it("should return a named profile", ()=>{
+
+       const loadedProfile = loadNamedProfile("profile1");
+       expect(loadedProfile).toEqual(profileOne);
+    });
+
+    it ("should return all profiles ", ()=>{
+        const loadedProfiles = loadAllProfiles();
+        expect(loadedProfiles).toEqual([profileOne, profileTwo]);
+    });
+
+    it("should return a default profile", ()=>{
+
+        const loadedProfile = loadDefaultProfile();
+        expect(loadedProfile).toEqual(profileOne);
+     });
+});

--- a/__tests__/extension.test.ts
+++ b/__tests__/extension.test.ts
@@ -302,7 +302,7 @@ describe("Extension Unit Tests", async () => {
                     getChildren: mockGetUSSChildren,
                 }
         });
-        expect(registerCommand.mock.calls.length).toBe(40);
+        expect(registerCommand.mock.calls.length).toBe(41);
         expect(registerCommand.mock.calls[0][0]).toBe("zowe.addSession");
         expect(registerCommand.mock.calls[0][1]).toBeInstanceOf(Function);
         expect(registerCommand.mock.calls[1][0]).toBe("zowe.addFavorite");

--- a/__tests__/extension.test.ts
+++ b/__tests__/extension.test.ts
@@ -302,7 +302,7 @@ describe("Extension Unit Tests", async () => {
                     getChildren: mockGetUSSChildren,
                 }
         });
-        expect(registerCommand.mock.calls.length).toBe(41);
+        expect(registerCommand.mock.calls.length).toBe(42);
         expect(registerCommand.mock.calls[0][0]).toBe("zowe.addSession");
         expect(registerCommand.mock.calls[0][1]).toBeInstanceOf(Function);
         expect(registerCommand.mock.calls[1][0]).toBe("zowe.addFavorite");

--- a/package.json
+++ b/package.json
@@ -267,6 +267,14 @@
       {
         "command": "zowe.removeJobsSession",
         "title": "Remove Profile"
+      },
+      {
+        "command": "zowe.downloadSpool",
+        "title": "Download Spool",
+        "icon": {
+          "light": "./resources/light/download.svg",
+          "dark": "./resources/dark/download.svg"
+        }
       }
     ],
     "menus": {
@@ -484,6 +492,11 @@
         {
           "when": "viewItem == job",
           "command": "zowe.runStopCommand"
+        },
+        {
+          "when": "viewItem == job",
+          "command": "zowe.downloadSpool",
+          "group": "inline"
         }
       ],
       "commandPalette": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -171,8 +171,42 @@ export async function activate(context: vscode.ExtensionContext) {
         setPrefix(node, jobsProvider);
     });
     vscode.commands.registerCommand("zowe.removeJobsSession", (node) => jobsProvider.deleteSession(node));
+    vscode.commands.registerCommand("zowe.downloadSpool", (job) => downloadSpool(job));
 }
 
+/**
+ * Download all the spool content for the specified job.
+ * 
+ * @param job The job to download the spool content from
+ */
+export async function downloadSpool(job: Job){
+    try {
+        let dirUri = await vscode.window.showOpenDialog({
+            openLabel: "Select",
+            canSelectFolders:true,
+            canSelectFiles: false,
+            canSelectMany: false
+        });
+        if (dirUri !== undefined) {
+            zowe.DownloadJobs.downloadAllSpoolContentCommon(job.session, {
+                jobid: job.job.jobid,
+                jobname: job.job.jobname,
+                outDir: dirUri[0].fsPath
+            });
+        }
+    } catch (error) {
+        vscode.window.showErrorMessage(error.message);
+    }
+
+}
+
+/**
+ * Switch the download type and redownload the file.
+ * 
+ * @param node The file that is going to be downloaded
+ * @param binary Whether the file should be downloaded as binary or not
+ * @param ussFileProvider Our USSTree object
+ */
 export async function changeFileType(node: ZoweUSSNode, binary: boolean, ussFileProvider: USSTree) {
     node.setBinary(binary);
     await openUSS(node, true);
@@ -1100,7 +1134,7 @@ export async function getSpoolContent(session: AbstractSession, spool: IJobFile)
         const document = await vscode.workspace.openTextDocument({ content: spoolContent });
         await vscode.window.showTextDocument(document);
     } catch (error) {
-        console.log(error);
+        vscode.window.showErrorMessage(error.message);
     }
 }
 


### PR DESCRIPTION
Resolves #77

Add a download menu item inline on jobs which allows the user to specify a directory where all the spool content is downloaded.