### PR TITLE
compare data set path case insensitively - attempted resolution for #76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## 0.16.1
+ - Attempt to fix an issue where saving data sets ceases to work without any error message
 ## 0.16.0
  - Add the ability to display data set attributes by right clicking on a data set
  - Add the ability to save all spool content by clicking a download icon next to the job. Thanks @crshnburn

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-extension-for-zowe",
   "displayName": "Zowe",
   "description": "VS Code extension, powered by Zowe CLI, that streamlines interaction with mainframe data sets, USS files, and jobs",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "publisher": "Zowe",
   "repository": {
     "url": "https://github.com/zowe/vscode-extension-for-zowe"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -87,12 +87,13 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("zowe.pattern", (node) => enterPattern(node, datasetProvider));
     vscode.commands.registerCommand("zowe.ZoweNode.openPS", (node) => openPS(node));
     vscode.workspace.onDidSaveTextDocument(async (savedFile) => {
-        log.debug("File was saved -- determining whether the file is a USS file or Data set.\n Comparing %s against directory %s and %s",
+        log.debug("File was saved -- determining whether the file is a USS file or Data set.\n Comparing (case insensitive) "+
+        "%s against directory %s and %s",
             savedFile.fileName, DS_DIR, USS_DIR);
-        if (savedFile.fileName.indexOf(DS_DIR) >= 0) {
+        if (savedFile.fileName.toUpperCase().indexOf(DS_DIR.toUpperCase()) >= 0) {
             log.debug("File is a data set-- saving ");
             await saveFile(savedFile, datasetProvider); // TODO MISSED TESTING
-        } else if (savedFile.fileName.indexOf(USS_DIR) >= 0) {
+        } else if (savedFile.fileName.toUpperCase().indexOf(USS_DIR.toUpperCase()) >= 0) {
             log.debug("File is a USS file -- saving");
             await saveUSSFile(savedFile, ussFileProvider); // TODO MISSED TESTING
         } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1016,8 +1016,8 @@ export async function safeSave(node: ZoweNode) {
             file: getDocumentFilePath(label, node)
         });
         const document = await vscode.workspace.openTextDocument(getDocumentFilePath(label, node));
-        vscode.window.showTextDocument(document);
-        vscode.window.activeTextEditor.document.save();
+        await vscode.window.showTextDocument(document);
+        await vscode.window.activeTextEditor.document.save();
     } catch (err) {
         if (err.message.includes("not found")) {
             vscode.window.showInformationMessage(`Unable to find file: ${label} was probably deleted.`);


### PR DESCRIPTION
Attempt to deal with #76  (unknown if this will fix the issue for users) by comparing the temporary data set directory case insensitively

Also `await` functions used in safeSave(). Maybe there was a bit of a race condition