### PR TITLE
display stderr of profile process if we fail to retrieve profiles

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -13,3 +13,4 @@ src/**
 tsconfig.json
 tslint.json
 *.vsix
+logs

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -13,4 +13,4 @@ src/**
 tsconfig.json
 tslint.json
 *.vsix
-logs
+logs/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## 0.16.2
+ - Add the stderr of the getDefaultProfile or getAllProfiles process to display in the error message to the user
 ## 0.16.1
  - Attempt to fix an issue where saving data sets ceases to work without any error message
 ## 0.16.0
@@ -11,17 +13,17 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## 0.15.1
  - Add a delete session menu item for sessions in the jobs view. Thanks @crshnburn
  - Prevent the delete menu item for USS files and directories appearing on the context menu for sessions. Thanks @crshnburn
- - Fixed an issue where adding a profile to the USS explorer incorrectly referenced data sets 
+ - Fixed an issue where adding a profile to the USS explorer incorrectly referenced data sets
 ## 0.15.0
  - The extension is now compatible with installations which use a secure credential management plugin
    for profiles in Zowe CLI
 ## 0.14.0
  - All zowe views now part of single Zowe view container. Thanks Colin Stone
 ## 0.13.0
- - Added the ability to list and view spool of z/OS Jobs. Thanks @crshnburn 
+ - Added the ability to list and view spool of z/OS Jobs. Thanks @crshnburn
 ## 0.12.0
  - Added GIFs to README for USS use cases. Thanks Colin Stone
- - Added the ability to toggle binary mode or text mode on USS files. Thanks @crshnburn 
+ - Added the ability to toggle binary mode or text mode on USS files. Thanks @crshnburn
 ## 0.11.0
  - Create and delete functionality for USS Files and directories added as menu items.
 ## 0.10.4
@@ -45,12 +47,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 please update your zowe CLI to the latest available version, recreate your profiles, and update this extension. That should solve any issues you are having.
 
 ## 0.8.0
-- Introduced capability to submit jobs from the editor. Thanks @crshnburn 
+- Introduced capability to submit jobs from the editor. Thanks @crshnburn
 ## 0.7.0
 - Updated for compatibility with Zowe CLI >=2.0.0. You must now have plain text profiles and Zowe CLI 2.0.0 or greater to use this extension. If you have previously created profiles, please update or recreate them with Zowe CLI.
 - Log files now go to `~/.vscode/extensions/zowe.vscode-extension-for-zowe-x.x.x/logs`
 
-## 0.6.5 
+## 0.6.5
 - Fixed issue with platform-specific folder separator, added progress bar when saving
 ## 0.6.4
 - Make favorites persistent after upgrading the extension

--- a/__tests__/ZoweNode.test.ts
+++ b/__tests__/ZoweNode.test.ts
@@ -71,7 +71,7 @@ describe("Unit Tests (Jest)", async () => {
             new ZoweNode("BRTVS99.DDIR", vscode.TreeItemCollapsibleState.Collapsed, rootNode, null),
         ];
         sampleChildren[0].command = { command: "zowe.ZoweNode.openPS", title: "", arguments: [sampleChildren[0]] };
-
+        
         // Checking that the rootChildren are what they are expected to be
         expect(rootChildren).toEqual(sampleChildren);
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-extension-for-zowe",
   "displayName": "Zowe",
   "description": "VS Code extension, powered by Zowe CLI, that streamlines interaction with mainframe data sets, USS files, and jobs",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "publisher": "Zowe",
   "repository": {
     "url": "https://github.com/zowe/vscode-extension-for-zowe"

--- a/src/ProfileLoader.ts
+++ b/src/ProfileLoader.ts
@@ -28,7 +28,7 @@ export function loadAllProfiles(): IProfileLoaded[] {
     if (getProfileProcess.stdout.toString().length === 0) {
         throw new Error("Error attempting to load all zosmf profiles. Please " +
             "ensure that you have created at least one profile with Zowe CLI " +
-            "before attempting to use this extension.");
+            "before attempting to use this extension. Error text:" + getProfileProcess.stderr.toString());
     }
 
     return JSON.parse(getProfileProcess.stdout.toString());
@@ -62,7 +62,7 @@ export function loadDefaultProfile(): IProfileLoaded {
     if (getProfileProcess.stdout.toString().length === 0) {
         throw new Error("Error attempting to load the default zosmf profile for Zowe CLI. Please " +
             "ensure that you have created at least one profile with Zowe CLI " +
-            "before attempting to use this extension.");
+            "before attempting to use this extension. Error text:" + getProfileProcess.stderr.toString());
     }
     return JSON.parse(getProfileProcess.stdout.toString());
 }

--- a/src/ProfileLoader.ts
+++ b/src/ProfileLoader.ts
@@ -20,7 +20,7 @@ import { IProfileLoaded } from "@brightside/imperative";
  */
 export function loadAllProfiles(): IProfileLoaded[] {
     const getProfileProcess = spawnSync("node", [path.join(__dirname, "getAllProfiles.js")]);
-
+ 
     if (getProfileProcess.status !== 0) {
         throw new Error("Failed to spawn process to retrieve profile contents!\n" +
             getProfileProcess.stderr.toString());


### PR DESCRIPTION
In order to debug issues loading profiles more, I added the stderr of the getDefaultProfile or getAllProfiles process to display in the error message to the user. This should make it easier to debug issues loading profiles