### PR TITLE
Add tests for jobs and spool processing

### DIFF
--- a/__tests__/extension.test.ts
+++ b/__tests__/extension.test.ts
@@ -1586,8 +1586,7 @@ describe("Extension Unit Tests", async () => {
 
         expect(showInputBox.mock.calls.length).toBe(1);
         expect(showInputBox.mock.calls[0][0]).toEqual({
-            prompt: "Prefix",
-            value: node.prefix
+            prompt: "Prefix"
         });
         expect(showInformationMessage.mock.calls.length).toBe(0);
 
@@ -1605,7 +1604,6 @@ describe("Extension Unit Tests", async () => {
         expect(showInputBox.mock.calls.length).toBe(1);
         expect(showInputBox.mock.calls[0][0]).toEqual({
             prompt: "Owner",
-            value: node.owner
         });
         expect(showInformationMessage.mock.calls.length).toBe(0);
     })

--- a/__tests__/extension.test.ts
+++ b/__tests__/extension.test.ts
@@ -30,6 +30,7 @@ import * as path from "path";
 import * as brightside from "@brightside/core";
 import * as fs from "fs";
 import * as profileLoader from "../src/ProfileLoader";
+import { Job } from "../src/zosjobs";
 
 describe("Extension Unit Tests", async () => {
     // Globals
@@ -40,6 +41,50 @@ describe("Extension Unit Tests", async () => {
         protocol: "https",
         type: "basic",
     });
+
+    const iJob: brightside.IJob = {
+        jobid: "JOB1234",
+        jobname: "TESTJOB",
+        "files-url": "fake/files",
+        "job-correlator": "correlator",
+        "phase-name": "PHASE",
+        "reason-not-running": "",
+        "step-data": [{
+            "proc-step-name": "",
+            "program-name": "",
+            "step-name": "",
+            "step-number": 1,
+            active: "",
+            smfid: ""
+            
+        }],
+        class: "A",
+        owner: "USER",
+        phase: 0,
+        retcode: "",
+        status: "ACTIVE",
+        subsystem: "SYS",
+        type: "JOB",
+        url: "fake/url"
+    }
+
+    const iJobFile: brightside.IJobFile = {
+        "byte-count": 128,
+        "job-correlator": "",
+        "record-count": 1,
+        "records-url": "fake/records",
+        class: "A",
+        ddname: "STDOUT",
+        id: 100,
+        jobid: "100",
+        jobname: "TESTJOB",
+        lrecl: 80,
+        procstep: "",
+        recfm: "FB",
+        stepname: "",
+        subsystem: ""
+    }
+
     const sessNode = new ZoweNode("sestest", vscode.TreeItemCollapsibleState.Expanded, null, session);
     sessNode.contextValue = "session";
     sessNode.pattern = "test hlq";
@@ -48,6 +93,7 @@ describe("Extension Unit Tests", async () => {
     ussNode.contextValue = "uss_session";
     ussNode.fullPath = "/u/myuser";
 
+    const jobNode = new Job("jobtest", vscode.TreeItemCollapsibleState.Expanded, session, iJob);
 
     const mkdirSync = jest.fn();
     const getAllProfileNames = jest.fn();
@@ -102,6 +148,12 @@ describe("Extension Unit Tests", async () => {
     const save = jest.fn();
     const isFile = jest.fn();
     const load = jest.fn();
+    const DeleteJobs = jest.fn();
+    const deleteJob = jest.fn();
+    const GetJobs = jest.fn();
+    const getSpoolContentById = jest.fn();
+    const IssueCommand = jest.fn();
+    const issueSimple = jest.fn();
     const ProgressLocation = jest.fn().mockImplementation(() => {
         return {
             Notification: 15
@@ -127,6 +179,14 @@ describe("Extension Unit Tests", async () => {
             refresh: mockUSSRefresh,
             getChildren: mockGetUSSChildren,
         };
+    });
+    const JobsTree = jest.fn().mockImplementation(() => {
+        return {
+            mSessionNodes: [],
+            getChildren: jest.fn(),
+            addSession: jest.fn(),
+            refresh: jest.fn(),
+        }
     });
     // const lstatSync = jest.fn().mockImplementation(() => {
     //     return { lstat };
@@ -158,6 +218,10 @@ describe("Extension Unit Tests", async () => {
     const testUSSTree = USSTree();
     testUSSTree.mSessionNodes = [];
     testUSSTree.mSessionNodes.push(ussNode);
+
+    const testJobsTree = JobsTree();
+    testJobsTree.mSessionNodes = [];
+    testJobsTree.mSessionNodes.push(jobNode);
 
     Object.defineProperty(profileLoader, "loadNamedProfile", {value: jest.fn()});
     Object.defineProperty(profileLoader, "loadAllProfiles", {
@@ -217,6 +281,12 @@ describe("Extension Unit Tests", async () => {
     // Object.defineProperty(fs, "lstatSync", { value: lstatSync });
     // Object.defineProperty(fs, "lstat", { value: lstat });
     Object.defineProperty(Download, "ussFile", {value: ussFile});
+    Object.defineProperty(brightside, "DeleteJobs", {value: DeleteJobs});
+    Object.defineProperty(DeleteJobs, "deleteJob", {value: deleteJob});
+    Object.defineProperty(brightside, "GetJobs", {value: GetJobs});
+    Object.defineProperty(GetJobs, "getSpoolContentById", {value: getSpoolContentById});
+    Object.defineProperty(brightside, "IssueCommand", {value: IssueCommand});
+    Object.defineProperty(IssueCommand, "issueSimple", {value: issueSimple});
 
     it("Testing that activate correctly executes", async () => {
         createTreeView.mockReturnValue("testDisposable");
@@ -351,6 +421,42 @@ describe("Extension Unit Tests", async () => {
         expect(registerCommand.mock.calls[22][1]).toBeInstanceOf(Function);
         expect(registerCommand.mock.calls[23][0]).toBe("zowe.uss.removeSession");
         expect(registerCommand.mock.calls[23][1]).toBeInstanceOf(Function);
+        expect(registerCommand.mock.calls[24][0]).toBe("zowe.uss.createFile");
+        expect(registerCommand.mock.calls[24][1]).toBeInstanceOf(Function);
+        expect(registerCommand.mock.calls[25][0]).toBe("zowe.uss.createFolder");
+        expect(registerCommand.mock.calls[25][1]).toBeInstanceOf(Function);
+        expect(registerCommand.mock.calls[26][0]).toBe("zowe.uss.deleteNode");
+        expect(registerCommand.mock.calls[26][1]).toBeInstanceOf(Function);
+        expect(registerCommand.mock.calls[27][0]).toBe("zowe.uss.binary");
+        expect(registerCommand.mock.calls[27][1]).toBeInstanceOf(Function);
+        expect(registerCommand.mock.calls[28][0]).toBe("zowe.uss.text");
+        expect(registerCommand.mock.calls[28][1]).toBeInstanceOf(Function);
+        expect(registerCommand.mock.calls[29][0]).toBe("zowe.showDSAttributes");
+        expect(registerCommand.mock.calls[29][1]).toBeInstanceOf(Function);
+        expect(registerCommand.mock.calls[30][0]).toBe("zowe.zosJobsSelectjob");
+        expect(registerCommand.mock.calls[30][1]).toBeInstanceOf(Function);
+        expect(registerCommand.mock.calls[31][0]).toBe("zowe.zosJobsOpenspool");
+        expect(registerCommand.mock.calls[31][1]).toBeInstanceOf(Function);
+        expect(registerCommand.mock.calls[32][0]).toBe("zowe.deleteJob");
+        expect(registerCommand.mock.calls[32][1]).toBeInstanceOf(Function);
+        expect(registerCommand.mock.calls[33][0]).toBe("zowe.runModifyCommand");
+        expect(registerCommand.mock.calls[33][1]).toBeInstanceOf(Function);
+        expect(registerCommand.mock.calls[34][0]).toBe("zowe.runStopCommand");
+        expect(registerCommand.mock.calls[34][1]).toBeInstanceOf(Function);
+        expect(registerCommand.mock.calls[35][0]).toBe("zowe.refreshServer");
+        expect(registerCommand.mock.calls[35][1]).toBeInstanceOf(Function);
+        expect(registerCommand.mock.calls[36][0]).toBe("zowe.refreshAllJobs");
+        expect(registerCommand.mock.calls[36][1]).toBeInstanceOf(Function);
+        expect(registerCommand.mock.calls[37][0]).toBe("zowe.addJobsSession");
+        expect(registerCommand.mock.calls[37][1]).toBeInstanceOf(Function);
+        expect(registerCommand.mock.calls[38][0]).toBe("zowe.setOwner");
+        expect(registerCommand.mock.calls[38][1]).toBeInstanceOf(Function);
+        expect(registerCommand.mock.calls[39][0]).toBe("zowe.setPrefix");
+        expect(registerCommand.mock.calls[39][1]).toBeInstanceOf(Function);
+        expect(registerCommand.mock.calls[40][0]).toBe("zowe.removeJobsSession");
+        expect(registerCommand.mock.calls[40][1]).toBeInstanceOf(Function);
+        expect(registerCommand.mock.calls[41][0]).toBe("zowe.downloadSpool");
+        expect(registerCommand.mock.calls[41][1]).toBeInstanceOf(Function);
         expect(onDidSaveTextDocument.mock.calls.length).toBe(1);
         expect(existsSync.mock.calls.length).toBe(3);
         expect(existsSync.mock.calls[0][0]).toBe(extension.BRIGHTTEMPFOLDER);
@@ -577,6 +683,55 @@ describe("Extension Unit Tests", async () => {
 
         try {
             await extension.addSession(testTree);
+            // tslint:disable-next-line:no-empty
+        } catch (err) {
+        }
+
+        expect(showErrorMessage.mock.calls.length).toBe(1);
+        expect(showErrorMessage.mock.calls[0][0]).toEqual("Unable to load all profiles: testError");
+
+    });
+
+    it("Testing that addJobsSession is executed successfully", async () => {
+        showQuickPick.mockReset();
+
+        (profileLoader.loadAllProfiles as any).mockReset();
+        (profileLoader.loadAllProfiles as any).mockReturnValueOnce([{ name: "firstName" }, { name: "secondName" }]);
+        await extension.addJobsSession(testJobsTree);
+
+        //expect(showQuickPick.mock.calls.length).toBe(1);
+        expect(showQuickPick.mock.calls[0][0]).toEqual(["firstName", "secondName"]);
+        // tslint:disable-next-line
+        expect(showQuickPick.mock.calls[0][1]).toEqual({
+            canPickMany: false,
+            ignoreFocusOut: true,
+            placeHolder: "Select a Profile to Add to the Jobs Explorer"
+        });
+
+        showInformationMessage.mockReset();
+        (profileLoader.loadAllProfiles as any).mockReset();
+        (profileLoader.loadAllProfiles as any).mockReturnValueOnce([]);
+
+        await extension.addJobsSession(testJobsTree);
+
+        expect(showInformationMessage.mock.calls.length).toBe(1);
+        expect(showInformationMessage.mock.calls[0][0]).toEqual("No more profiles to add");
+
+        showInformationMessage.mockReset();
+        (profileLoader.loadAllProfiles as any).mockReset();
+        (profileLoader.loadAllProfiles as any).mockReturnValueOnce([]);
+        await extension.addJobsSession(testJobsTree);
+
+        expect(showInformationMessage.mock.calls.length).toBe(1);
+        expect(showInformationMessage.mock.calls[0][0]).toEqual("No more profiles to add");
+
+        showErrorMessage.mockReset();
+        (profileLoader.loadAllProfiles as any).mockImplementationOnce(() => {
+            throw (Error("testError"));
+        });
+
+        try {
+            await extension.addJobsSession(testJobsTree);
             // tslint:disable-next-line:no-empty
         } catch (err) {
         }
@@ -1419,4 +1574,76 @@ describe("Extension Unit Tests", async () => {
 
         await extension.saveUSSFile(testDoc3, testUSSTree);
     });
+
+    it("tests that the prefix is set correctly on the job", async () => {
+        showInformationMessage.mockReset();
+        showInputBox.mockReset();
+
+        const node = new Job("job", vscode.TreeItemCollapsibleState.None, session, iJob);
+
+        showInputBox.mockReturnValueOnce("*");
+        await extension.setPrefix(node, testJobsTree);
+
+        expect(showInputBox.mock.calls.length).toBe(1);
+        expect(showInputBox.mock.calls[0][0]).toEqual({
+            prompt: "Prefix",
+            value: node.prefix
+        });
+        expect(showInformationMessage.mock.calls.length).toBe(0);
+
+    });
+
+    it("tests that the owner is set correctly on the job", async () => {
+        showInformationMessage.mockReset();
+        showInputBox.mockReset();
+
+        const node = new Job("job", vscode.TreeItemCollapsibleState.None, session, iJob);
+
+        showInputBox.mockReturnValueOnce("OWNER");
+        await extension.setOwner(node, testJobsTree);
+
+        expect(showInputBox.mock.calls.length).toBe(1);
+        expect(showInputBox.mock.calls[0][0]).toEqual({
+            prompt: "Owner",
+            value: node.owner
+        });
+        expect(showInformationMessage.mock.calls.length).toBe(0);
+    })
+
+    it("tests that the user is informed when a job is deleted", async () => {
+        showInformationMessage.mockReset();
+        await extension.deleteJob(jobNode);
+        expect(showInformationMessage.mock.calls.length).toBe(1);
+        expect(showInformationMessage.mock.calls[0][0]).toEqual(
+            `Job ${jobNode.job.jobname}(${jobNode.job.jobid}) deleted` 
+        )
+    })
+
+    it("tests that the spool content is opened in a new document", async () => {
+        showTextDocument.mockReset();
+        await extension.getSpoolContent(session, iJobFile);
+        expect(showTextDocument.mock.calls.length).toBe(1);
+    });
+
+    it("tests that a stop command is issued", async () => {
+        showInformationMessage.mockReset();
+        issueSimple.mockReturnValueOnce({commandResponse: "fake response"})
+        await extension.stopCommand(jobNode);
+        expect(showInformationMessage.mock.calls.length).toBe(1);
+        expect(showInformationMessage.mock.calls[0][0]).toEqual(
+            "Command response: fake response"
+        );
+    });
+
+    it("tests that a modify command is issued", async () => {
+        showInformationMessage.mockReset();
+        showInputBox.mockReset();
+        showInputBox.mockReturnValue("modify");
+        issueSimple.mockReturnValueOnce({commandResponse: "fake response"});
+        await extension.modifyCommand(jobNode);
+        expect(showInformationMessage.mock.calls.length).toBe(1);
+        expect(showInformationMessage.mock.calls[0][0]).toEqual(
+            "Command response: fake response"
+        );
+    })
 });

--- a/__tests__/zosjobs.test.ts
+++ b/__tests__/zosjobs.test.ts
@@ -1,0 +1,157 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+jest.mock("vscode");
+jest.mock("Session");
+jest.mock("@brightside/core");
+jest.mock("@brightside/imperative");
+import * as vscode from "vscode";
+import * as brightside from "@brightside/core";
+import { ZosSpoolProvider } from "../src/zosspool"
+import { Session } from "@brightside/imperative"
+
+import * as profileLoader from "../src/ProfileLoader";
+import { Job, ZosJobsProvider } from "../src/zosjobs";
+
+describe("ZosJobsProvider Unit Tets", async () => {
+    const ZosmfSession = jest.fn();
+    const createBasicZosmfSession = jest.fn();
+    const GetJobs = jest.fn();
+    const getJobsByOwnerAndPrefix = jest.fn();
+
+    Object.defineProperty(brightside, "ZosmfSession", { value: ZosmfSession });
+    Object.defineProperty(ZosmfSession, "createBasicZosmfSession", { value: createBasicZosmfSession });
+    Object.defineProperty(brightside, "GetJobs", {value: GetJobs});
+    Object.defineProperty(GetJobs, "getJobsByOwnerAndPrefix", {value: getJobsByOwnerAndPrefix});
+
+    const testJobsProvider = new ZosJobsProvider();
+
+    const session = new Session({
+        user: "fake",
+        password: "fake",
+        hostname: "fake",
+        protocol: "https",
+        type: "basic",
+    });
+
+    Object.defineProperty(profileLoader, "loadNamedProfile", {
+        value: jest.fn((name: string) => {
+            return { name };
+        })
+    });
+    Object.defineProperty(profileLoader, "loadAllProfiles", {
+        value: jest.fn(() => {
+            return [{ name: "profile1" }, { name: "profile2" }]
+        })
+    });
+    Object.defineProperty(profileLoader, "loadDefaultProfile", {
+        value: jest.fn(() => {
+            return { name: "defaultprofile" };
+        })
+    });
+
+    const iJob: brightside.IJob = {
+        jobid: "JOB1234",
+        jobname: "TESTJOB",
+        "files-url": "fake/files",
+        "job-correlator": "correlator",
+        "phase-name": "PHASE",
+        "reason-not-running": "",
+        "step-data": [{
+            "proc-step-name": "",
+            "program-name": "",
+            "step-name": "",
+            "step-number": 1,
+            active: "",
+            smfid: ""
+
+        }],
+        class: "A",
+        owner: "USER",
+        phase: 0,
+        retcode: "",
+        status: "ACTIVE",
+        subsystem: "SYS",
+        type: "JOB",
+        url: "fake/url"
+    }
+
+    const iJobComplete: brightside.IJob = {
+        jobid: "JOB1235",
+        jobname: "TESTJOB",
+        "files-url": "fake/files",
+        "job-correlator": "correlator",
+        "phase-name": "PHASE",
+        "reason-not-running": "",
+        "step-data": [{
+            "proc-step-name": "",
+            "program-name": "",
+            "step-name": "",
+            "step-number": 1,
+            active: "",
+            smfid: ""
+
+        }],
+        class: "A",
+        owner: "USER",
+        phase: 0,
+        retcode: "0",
+        status: "ACTIVE",
+        subsystem: "SYS",
+        type: "JOB",
+        url: "fake/url"
+    }
+
+    it("should add the session to the tree", async () => {
+        createBasicZosmfSession.mockReturnValue(session);
+        await testJobsProvider.addSession("fake");
+        expect(testJobsProvider.mSessionNodes[0]).toBeDefined();
+        expect(testJobsProvider.mSessionNodes[0].mLabel).toEqual("fake")
+        expect(testJobsProvider.mSessionNodes[0].tooltip).toEqual("fake - owner: fake prefix: *")
+    })
+
+    it("should delete the session", async () => {
+        testJobsProvider.deleteSession(testJobsProvider.mSessionNodes[0]);
+        expect(testJobsProvider.mSessionNodes.length).toBe(0);
+    })
+
+    it("should get the jobs of the session", async () => {
+        createBasicZosmfSession.mockReturnValue(session);
+        getJobsByOwnerAndPrefix.mockReturnValue([iJob, iJobComplete]);
+        await testJobsProvider.addSession("fake");
+        let jobs = await testJobsProvider.mSessionNodes[0].getChildren();
+        expect(jobs.length).toBe(2);
+        expect(jobs[0].job.jobid).toEqual(iJob.jobid);
+        expect(jobs[0].tooltip).toEqual("TESTJOB(JOB1234)")
+        expect(jobs[1].job.jobid).toEqual(iJobComplete.jobid);
+        expect(jobs[1].tooltip).toEqual("TESTJOB(JOB1235) - 0")
+    });
+
+    it("should set the owner to the session userid", async () => {
+        createBasicZosmfSession.mockReturnValue(session);
+        let jobs = await testJobsProvider.mSessionNodes[0].getChildren();
+        let job = jobs[0];
+        job.owner = "";
+        expect(job.owner).toEqual("fake");
+        job.owner = "new";
+        expect(job.owner).toEqual("new");
+    })
+
+    it("should set the prefix to the default", async () => {
+        createBasicZosmfSession.mockReturnValue(session);
+        let jobs = await testJobsProvider.mSessionNodes[0].getChildren();
+        let job = jobs[0];
+        job.prefix = "";
+        expect(job.prefix).toEqual("*");
+        job.prefix = "zowe*";
+        expect(job.prefix).toEqual("zowe*");
+    })
+});

--- a/__tests__/zosspool.test.ts
+++ b/__tests__/zosspool.test.ts
@@ -1,0 +1,97 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+jest.mock("vscode");
+jest.mock("Session");
+jest.mock("@brightside/core");
+jest.mock("@brightside/imperative");
+import * as vscode from "vscode";
+import * as brightside from "@brightside/core";
+import { ZosSpoolProvider } from "../src/zosspool"
+import { Session } from "@brightside/imperative"
+import { Job } from "../src/zosjobs";
+
+describe("ZosSpoolProvider Unit Tets", async () => {
+    const GetJobs = jest.fn();
+    const getSpoolFiles = jest.fn();
+
+    Object.defineProperty(brightside, "GetJobs", {value: GetJobs});
+    Object.defineProperty(GetJobs, "getSpoolFiles", {value: getSpoolFiles});
+
+    const testSpoolProvider = new ZosSpoolProvider();
+
+    const session = new Session({
+        user: "fake",
+        password: "fake",
+        hostname: "fake",
+        protocol: "https",
+        type: "basic",
+    });
+
+    const iJob: brightside.IJob = {
+        jobid: "JOB1234",
+        jobname: "TESTJOB",
+        "files-url": "fake/files",
+        "job-correlator": "correlator",
+        "phase-name": "PHASE",
+        "reason-not-running": "",
+        "step-data": [{
+            "proc-step-name": "",
+            "program-name": "",
+            "step-name": "",
+            "step-number": 1,
+            active: "",
+            smfid: ""
+
+        }],
+        class: "A",
+        owner: "USER",
+        phase: 0,
+        retcode: "",
+        status: "ACTIVE",
+        subsystem: "SYS",
+        type: "JOB",
+        url: "fake/url"
+    }
+
+    const iJobFile: brightside.IJobFile = {
+        "byte-count": 128,
+        "job-correlator": "",
+        "record-count": 1,
+        "records-url": "fake/records",
+        class: "A",
+        ddname: "STDOUT",
+        id: 100,
+        jobid: "100",
+        jobname: "TESTJOB",
+        lrecl: 80,
+        procstep: "",
+        recfm: "FB",
+        stepname: "",
+        subsystem: ""
+    }
+
+    const jobNode = new Job("jobtest", vscode.TreeItemCollapsibleState.Expanded, session, iJob);
+
+    it("Tests setting the job", async () => {
+        testSpoolProvider.setJob(jobNode);
+        expect(testSpoolProvider.mSessionNode).toBeDefined();
+        expect(testSpoolProvider.mSessionNode.job).toEqual(jobNode);
+    })
+
+    it("Tests the children are the spool files", async () => {
+        testSpoolProvider.setJob(jobNode);
+        getSpoolFiles.mockReturnValue([iJobFile]);
+        let spoolFiles = await testSpoolProvider.mSessionNode.getChildren()
+        expect(spoolFiles.length).toBe(1);
+        expect(spoolFiles[0].mLabel).toEqual("STDOUT(100)");
+    })
+})

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1196,7 +1196,7 @@ export async function stopCommand(job: Job) {
 export async function deleteJob(job: Job) {
     try {
         await zowe.DeleteJobs.deleteJob(job.session, job.job.jobname, job.job.jobid);
-        vscode.window.showInformationMessage(`Job ${job.job.jobname}(${job.job.jobid} deleted)`);
+        vscode.window.showInformationMessage(`Job ${job.job.jobname}(${job.job.jobid}) deleted`);
     } catch (error) {
         vscode.window.showErrorMessage(error.message);
     }

--- a/src/zosjobs.ts
+++ b/src/zosjobs.ts
@@ -136,6 +136,10 @@ export class Job extends vscode.TreeItem {
         }
     }
 
+    get owner() {
+        return this._owner;
+    }
+
     set prefix(newPrefix: string) {
         if(newPrefix !== undefined) {
             if(newPrefix.length === 0){
@@ -144,5 +148,9 @@ export class Job extends vscode.TreeItem {
                 this._prefix = newPrefix;
             }
         }
+    }
+
+    get prefix() {
+        return this._prefix;
     }
 }


### PR DESCRIPTION
Resolves #80 by adding new tests for the functionality that shows jobs and spool content.