### PR TITLE
USS Favorites

### DIFF
--- a/__tests__/extension.test.ts
+++ b/__tests__/extension.test.ts
@@ -30,6 +30,7 @@ import * as path from "path";
 import * as brightside from "@brightside/core";
 import * as fs from "fs";
 import * as profileLoader from "../src/ProfileLoader";
+import * as ussNodeActions from "../src/uss/ussNodeActions"
 import { Job } from "../src/zosjobs";
 
 describe("Extension Unit Tests", async () => {
@@ -322,6 +323,7 @@ describe("Extension Unit Tests", async () => {
                 "[test]: brtvs99.test.search{session}",
             ]
         });
+        spyOn(ussNodeActions, "initializeUSSFavorites").and.returnValue(undefined);
         const extensionMock = jest.fn(() => (<vscode.ExtensionContext>{
             subscriptions: [],
             extensionPath: path.join(__dirname, "..")
@@ -372,7 +374,7 @@ describe("Extension Unit Tests", async () => {
                     getChildren: mockGetUSSChildren,
                 }
         });
-        expect(registerCommand.mock.calls.length).toBe(42);
+        expect(registerCommand.mock.calls.length).toBe(44);
         expect(registerCommand.mock.calls[0][0]).toBe("zowe.addSession");
         expect(registerCommand.mock.calls[0][1]).toBeInstanceOf(Function);
         expect(registerCommand.mock.calls[1][0]).toBe("zowe.addFavorite");
@@ -409,54 +411,58 @@ describe("Extension Unit Tests", async () => {
         expect(registerCommand.mock.calls[16][1]).toBeInstanceOf(Function);
         expect(registerCommand.mock.calls[17][0]).toBe("zowe.submitMember");
         expect(registerCommand.mock.calls[17][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[18][0]).toBe("zowe.uss.addSession");
+        expect(registerCommand.mock.calls[18][0]).toBe("zowe.showDSAttributes");
         expect(registerCommand.mock.calls[18][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[19][0]).toBe("zowe.uss.refreshAll");
+        expect(registerCommand.mock.calls[19][0]).toBe("zowe.uss.addFavorite");
         expect(registerCommand.mock.calls[19][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[20][0]).toBe("zowe.uss.refreshUSS");
+        expect(registerCommand.mock.calls[20][0]).toBe("zowe.uss.removeFavorite");
         expect(registerCommand.mock.calls[20][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[21][0]).toBe("zowe.uss.fullPath");
+        expect(registerCommand.mock.calls[21][0]).toBe("zowe.uss.addSession");
         expect(registerCommand.mock.calls[21][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[22][0]).toBe("zowe.uss.ZoweUSSNode.open");
+        expect(registerCommand.mock.calls[22][0]).toBe("zowe.uss.refreshAll");
         expect(registerCommand.mock.calls[22][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[23][0]).toBe("zowe.uss.removeSession");
+        expect(registerCommand.mock.calls[23][0]).toBe("zowe.uss.refreshUSS");
         expect(registerCommand.mock.calls[23][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[24][0]).toBe("zowe.uss.createFile");
+        expect(registerCommand.mock.calls[24][0]).toBe("zowe.uss.fullPath");
         expect(registerCommand.mock.calls[24][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[25][0]).toBe("zowe.uss.createFolder");
+        expect(registerCommand.mock.calls[25][0]).toBe("zowe.uss.ZoweUSSNode.open");
         expect(registerCommand.mock.calls[25][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[26][0]).toBe("zowe.uss.deleteNode");
+        expect(registerCommand.mock.calls[26][0]).toBe("zowe.uss.removeSession");
         expect(registerCommand.mock.calls[26][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[27][0]).toBe("zowe.uss.binary");
+        expect(registerCommand.mock.calls[27][0]).toBe("zowe.uss.createFile");
         expect(registerCommand.mock.calls[27][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[28][0]).toBe("zowe.uss.text");
+        expect(registerCommand.mock.calls[28][0]).toBe("zowe.uss.createFolder");
         expect(registerCommand.mock.calls[28][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[29][0]).toBe("zowe.showDSAttributes");
+        expect(registerCommand.mock.calls[29][0]).toBe("zowe.uss.deleteNode");
         expect(registerCommand.mock.calls[29][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[30][0]).toBe("zowe.zosJobsSelectjob");
+        expect(registerCommand.mock.calls[30][0]).toBe("zowe.uss.binary");
         expect(registerCommand.mock.calls[30][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[31][0]).toBe("zowe.zosJobsOpenspool");
+        expect(registerCommand.mock.calls[31][0]).toBe("zowe.uss.text");
         expect(registerCommand.mock.calls[31][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[32][0]).toBe("zowe.deleteJob");
+        expect(registerCommand.mock.calls[32][0]).toBe("zowe.zosJobsSelectjob");
         expect(registerCommand.mock.calls[32][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[33][0]).toBe("zowe.runModifyCommand");
+        expect(registerCommand.mock.calls[33][0]).toBe("zowe.zosJobsOpenspool");
         expect(registerCommand.mock.calls[33][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[34][0]).toBe("zowe.runStopCommand");
+        expect(registerCommand.mock.calls[34][0]).toBe("zowe.deleteJob");
         expect(registerCommand.mock.calls[34][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[35][0]).toBe("zowe.refreshServer");
+        expect(registerCommand.mock.calls[35][0]).toBe("zowe.runModifyCommand");
         expect(registerCommand.mock.calls[35][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[36][0]).toBe("zowe.refreshAllJobs");
+        expect(registerCommand.mock.calls[36][0]).toBe("zowe.runStopCommand");
         expect(registerCommand.mock.calls[36][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[37][0]).toBe("zowe.addJobsSession");
+        expect(registerCommand.mock.calls[37][0]).toBe("zowe.refreshServer");
         expect(registerCommand.mock.calls[37][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[38][0]).toBe("zowe.setOwner");
+        expect(registerCommand.mock.calls[38][0]).toBe("zowe.refreshAllJobs");
         expect(registerCommand.mock.calls[38][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[39][0]).toBe("zowe.setPrefix");
+        expect(registerCommand.mock.calls[39][0]).toBe("zowe.addJobsSession");
         expect(registerCommand.mock.calls[39][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[40][0]).toBe("zowe.removeJobsSession");
+        expect(registerCommand.mock.calls[40][0]).toBe("zowe.setOwner");
         expect(registerCommand.mock.calls[40][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[41][0]).toBe("zowe.downloadSpool");
+        expect(registerCommand.mock.calls[41][0]).toBe("zowe.setPrefix");
         expect(registerCommand.mock.calls[41][1]).toBeInstanceOf(Function);
+        expect(registerCommand.mock.calls[42][0]).toBe("zowe.removeJobsSession");
+        expect(registerCommand.mock.calls[42][1]).toBeInstanceOf(Function);
+        expect(registerCommand.mock.calls[43][0]).toBe("zowe.downloadSpool");
+        expect(registerCommand.mock.calls[43][1]).toBeInstanceOf(Function);
         expect(onDidSaveTextDocument.mock.calls.length).toBe(1);
         expect(existsSync.mock.calls.length).toBe(3);
         expect(existsSync.mock.calls[0][0]).toBe(extension.BRIGHTTEMPFOLDER);
@@ -1467,6 +1473,36 @@ describe("Extension Unit Tests", async () => {
         expect(showErrorMessage.mock.calls.length).toBe(2);
         expect(showErrorMessage.mock.calls[0][0]).toBe("open() called from invalid node.");
         expect(showErrorMessage.mock.calls[1][0]).toBe("open() called from invalid node.");
+    });
+
+    it("Tests that openUSS executes successfully with favorited files", async () => {
+        ussFile.mockReset();
+        openTextDocument.mockReset();
+        showTextDocument.mockReset();
+
+        openTextDocument.mockResolvedValueOnce("test.doc");
+
+        // Set up mock favorite session
+        const favoriteSession = new ZoweUSSNode("Favorites", vscode.TreeItemCollapsibleState.Collapsed, null, session, null);
+        favoriteSession.contextValue = "favorite";
+
+        // Set up favorited nodes (directly under Favorites)
+        const favoriteFile = new ZoweUSSNode("favFile", vscode.TreeItemCollapsibleState.None, favoriteSession, null, "/");
+        favoriteFile.contextValue = "textfilef";
+        const favoriteParent = new ZoweUSSNode("favParent", vscode.TreeItemCollapsibleState.Collapsed, favoriteSession, null, "/");
+        favoriteParent.contextValue = "directoryf";
+        // Set up child of favoriteDir - make sure we can open the child of a favorited directory
+        const child = new ZoweUSSNode("favChild", vscode.TreeItemCollapsibleState.Collapsed, favoriteParent, null, "/favDir");
+        child.contextValue = "textfile";
+
+        // For each node, make sure that code below the log.debug statement is execute
+        await extension.openUSS(favoriteFile);
+        expect(showTextDocument.mock.calls.length).toBe(1);
+        showTextDocument.mockReset();
+
+        await extension.openUSS(child);
+        expect(showTextDocument.mock.calls.length).toBe(1);
+        showTextDocument.mockReset();
     });
 
     it("Testing that saveUSSFile is executed successfully", async () => {

--- a/__tests__/integrationTests/extension.test.ts
+++ b/__tests__/integrationTests/extension.test.ts
@@ -488,7 +488,8 @@ describe("Extension Integration Tests - USS", () => {
             // Create the TreeView using ussFileProvider to create tree structure
             const ussTestTreeView = vscode.window.createTreeView("zowe.uss.explorer", {treeDataProvider: ussFileProvider});
 
-            const allNodes = await getAllUSSNodes(ussFileProvider.mSessionNodes);
+            const nonFavorites = ussFileProvider.mSessionNodes.filter((node) => node.contextValue !== "favorite" );
+            const allNodes = await getAllUSSNodes(nonFavorites);
             for (const node of allNodes) {
                 // For each node, select that node in TreeView by calling reveal()
                 await ussTestTreeView.reveal(node);

--- a/__tests__/uss/ussNodeActions.test.ts
+++ b/__tests__/uss/ussNodeActions.test.ts
@@ -14,6 +14,8 @@ import { ZoweUSSNode } from "../../src/ZoweUSSNode";
 import * as brtimperative from "@brightside/imperative";
 import * as brightside from "@brightside/core";
 import { createUSSNode, deleteUSSNode } from "../../src/uss/ussNodeActions";
+import * as ussNodeActions from "../../src/uss/ussNodeActions";
+import * as utils from "../../src/utils";
 
 const Create = jest.fn();
 const Delete = jest.fn();
@@ -25,6 +27,7 @@ const mockGetUSSChildren = jest.fn();
 const showInputBox = jest.fn();
 const showErrorMessage = jest.fn();
 const showQuickPick = jest.fn();
+const getConfiguration = jest.fn();
 
 function getUSSNode() {
     const ussNode = new ZoweUSSNode("usstest", vscode.TreeItemCollapsibleState.Expanded, null, session, null);
@@ -38,6 +41,7 @@ function getUSSTree() {
     const USSTree = jest.fn().mockImplementation(() => {
         return {
             mSessionNodes: [],
+            mFavorites: [],
             addSession: mockAddUSSSession,
             refresh: mockUSSRefresh,
             getChildren: mockGetUSSChildren,
@@ -60,13 +64,15 @@ const session = new brtimperative.Session({
 const ussNode = getUSSNode();
 const testUSSTree = getUSSTree();
 
-Object.defineProperty(brightside, "Create", {value: Create});
-Object.defineProperty(brightside, "Delete", {value: Delete});
+Object.defineProperty(brightside, "Create", { value: Create });
+Object.defineProperty(brightside, "Delete", { value: Delete });
 Object.defineProperty(Create, "uss", { value: uss });
 Object.defineProperty(Delete, "ussFile", { value: ussFile });
-Object.defineProperty(vscode.window, "showInputBox", {value: showInputBox});
-Object.defineProperty(vscode.window, "showErrorMessage", {value: showErrorMessage});
-Object.defineProperty(vscode.window, "showQuickPick", {value: showQuickPick});
+Object.defineProperty(vscode.window, "showInputBox", { value: showInputBox });
+Object.defineProperty(vscode.window, "showErrorMessage", { value: showErrorMessage });
+Object.defineProperty(vscode.window, "showQuickPick", { value: showQuickPick });
+Object.defineProperty(vscode.workspace, "getConfiguration", { value: getConfiguration });
+
 
 describe("ussNodeActions", async () => {
     beforeEach(() => {
@@ -106,5 +112,32 @@ describe("ussNodeActions", async () => {
             await deleteUSSNode(ussNode, testUSSTree, "");
             expect(testUSSTree.refresh).not.toHaveBeenCalled();
         });
+    });
+    describe("initializingUSSFavorites", () => {
+        it("initializeUSSFavorites is executed successfully", async () => {
+            getConfiguration.mockReturnValueOnce({
+                get: (setting: string) => [
+                    "[test]: /u/aDir{directory}",
+                    "[test]: /u/myFile.txt{textFile}",
+                ]
+            });
+
+            spyOn(utils, "getSession").and.returnValue(null);
+            await ussNodeActions.initializeUSSFavorites(testUSSTree);
+            expect(testUSSTree.mFavorites.length).toEqual(2);
+
+            const expectedUSSFavorites: ZoweUSSNode[] = [
+                new ZoweUSSNode("/u/aDir", vscode.TreeItemCollapsibleState.Collapsed, undefined, null, "", false, "test"),
+                new ZoweUSSNode("/u/myFile.txt", vscode.TreeItemCollapsibleState.None, undefined, null, "", false, "test"),
+            ];
+
+            expectedUSSFavorites.map(node => node.contextValue += "f");
+            expectedUSSFavorites.forEach(node => {
+                if (node.contextValue != "directoryf") {
+                    node.command = { command: "zowe.uss.ZoweUSSNode.open", title: "Open", arguments: [node] };
+                }
+            })
+            expect(testUSSTree.mFavorites).toEqual(expectedUSSFavorites);
+        })
     });
 });

--- a/package.json
+++ b/package.json
@@ -62,11 +62,11 @@
     "commands": [
       {
         "command": "zowe.uss.createFile",
-        "title": "Create file"
+        "title": "Create File"
       },
       {
         "command": "zowe.uss.createFolder",
-        "title": "Create directory"
+        "title": "Create Directory"
       },
       {
         "command": "zowe.uss.deleteNode",
@@ -74,6 +74,10 @@
       },
       {
         "command": "zowe.addFavorite",
+        "title": "Add Favorite"
+      },
+      {
+        "command": "zowe.uss.addFavorite",
         "title": "Add Favorite"
       },
       {
@@ -138,6 +142,10 @@
       },
       {
         "command": "zowe.removeFavorite",
+        "title": "Remove Favorite"
+      },
+      {
+        "command": "zowe.uss.removeFavorite",
         "title": "Remove Favorite"
       },
       {
@@ -326,7 +334,27 @@
           "group": "navigation"
         },
         {
-          "when": "view == zowe.uss.explorer && viewItem != uss_session",
+          "when": "view == zowe.uss.explorer && viewItem == directory",
+          "command": "zowe.uss.addFavorite",
+         "group": "navigation"
+        },
+        {
+          "when": "view == zowe.uss.explorer && viewItem == directoryf",
+          "command": "zowe.uss.createFile",
+          "group": "navigation"
+        },
+        {
+          "when": "view == zowe.uss.explorer && viewItem == directoryf",
+          "command": "zowe.uss.createFolder",
+          "group": "navigation"
+        },
+        {
+          "when": "view == zowe.uss.explorer && viewItem == directoryf",
+          "command": "zowe.uss.removeFavorite",
+          "group": "navigation"
+        },
+        {
+          "when": "view == zowe.uss.explorer && viewItem != uss_session && viewItem != favorite && viewItem != textFilef && viewItem != binaryFilef && viewItem != directoryf",
           "command": "zowe.uss.deleteNode",
           "group": "navigation"
         },
@@ -336,8 +364,38 @@
           "group": "navigation"
         },
         {
+          "when": "view == zowe.uss.explorer && viewItem == textFile",
+          "command": "zowe.uss.addFavorite",
+          "group": "navigation"
+        },
+        {
+          "when": "view == zowe.uss.explorer && viewItem == textFilef",
+          "command": "zowe.uss.binary",
+          "group": "navigation"
+        },
+        {
+          "when": "view == zowe.uss.explorer && viewItem == textFilef",
+          "command": "zowe.uss.removeFavorite",
+          "group": "navigation"
+        },
+        {
           "when": "view == zowe.uss.explorer && viewItem == binaryFile",
           "command": "zowe.uss.text",
+          "group": "navigation"
+        },
+        {
+          "when": "view == zowe.uss.explorer && viewItem == binaryFile",
+          "command": "zowe.uss.addFavorite",
+          "group": "navigation"
+        },
+        {
+          "when": "view == zowe.uss.explorer && viewItem == binaryFilef",
+          "command": "zowe.uss.text",
+          "group": "navigation"
+        },
+        {
+          "when": "view == zowe.uss.explorer && viewItem == binaryFilef",
+          "command": "zowe.uss.removeFavorite",
           "group": "navigation"
         },
         {
@@ -657,6 +715,14 @@
             "favorites": []
           },
           "description": "Toggle if favorite files persist locally",
+          "scope": "window"
+        },
+        "Zowe-USS-Persistent-Favorites": {
+          "default": {
+            "persistence": true,
+            "favorites": []
+          },
+          "description": "Toggle is favorite files exist locally",
           "scope": "window"
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,6 +49,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     let datasetProvider: DatasetTree;
     let ussFileProvider: USSTree;
+    let jobsProvider: ZosJobsProvider;
 
     try {
         // Initialize Imperative Logger
@@ -73,6 +74,7 @@ export async function activate(context: vscode.ExtensionContext) {
     }
 
     await initializeFavorites(datasetProvider);
+    await ussActions.initializeUSSFavorites(ussFileProvider);
 
     // Attaches the TreeView as a subscriber to the refresh event of datasetProvider
     const disposable1 = vscode.window.createTreeView("zowe.explorer", { treeDataProvider: datasetProvider });
@@ -112,6 +114,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("zowe.removeSavedSearch", async (node) => datasetProvider.removeFavorite(node));
     vscode.commands.registerCommand("zowe.submitJcl", async () => submitJcl(datasetProvider));
     vscode.commands.registerCommand("zowe.submitMember", async (node) => submitMember(node));
+    vscode.commands.registerCommand("zowe.showDSAttributes", (node) => showDSAttributes(node, datasetProvider));
     vscode.workspace.onDidChangeConfiguration(async (e) => {
         if (e.affectsConfiguration("Zowe-Persistent-Favorites")) {
             const setting: any = { ...vscode.workspace.getConfiguration().get("Zowe-Persistent-Favorites") };
@@ -122,6 +125,8 @@ export async function activate(context: vscode.ExtensionContext) {
         }
     });
 
+    vscode.commands.registerCommand("zowe.uss.addFavorite", async (node) => ussFileProvider.addUSSFavorite(node));
+    vscode.commands.registerCommand("zowe.uss.removeFavorite", async (node) => ussFileProvider.removeUSSFavorite(node));
     vscode.commands.registerCommand("zowe.uss.addSession", async () => addUSSSession(ussFileProvider));
     vscode.commands.registerCommand("zowe.uss.refreshAll", () => refreshAllUSS(ussFileProvider));
     vscode.commands.registerCommand("zowe.uss.refreshUSS", (node) => refreshUSS(node));
@@ -133,9 +138,17 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("zowe.uss.deleteNode", async (node) => ussActions.deleteUSSNode(node, ussFileProvider, getUSSDocumentFilePath(node)));
     vscode.commands.registerCommand("zowe.uss.binary", async (node) => changeFileType(node, true, ussFileProvider));
     vscode.commands.registerCommand("zowe.uss.text", async (node) => changeFileType(node, false, ussFileProvider));
-    vscode.commands.registerCommand("zowe.showDSAttributes", (node) => showDSAttributes(node, datasetProvider));
+    vscode.workspace.onDidChangeConfiguration(async (e) => {
+        if (e.affectsConfiguration("Zowe-USS-Persistent-Favorites")) {
+            const ussSetting: any = { ...vscode.workspace.getConfiguration().get("Zowe-USS-Persistent-Favorites") };
+            if (!ussSetting.persistence) {
+                ussSetting.favorites = [];
+                await vscode.workspace.getConfiguration().update("Zowe-USS-Persistent-Favorites", ussSetting, vscode.ConfigurationTarget.Global);
+            }
+        }
+    });
 
-    let jobsProvider: ZosJobsProvider;
+    // JES
     try {
         // Initialize dataset provider with the created session and the selected pattern
         jobsProvider = new ZosJobsProvider();
@@ -749,7 +762,8 @@ export async function enterUSSPattern(node: ZoweUSSNode, ussFileProvider: USSTre
     // change label so the treeview updates
     node.label = node.label + " ";
     node.label.trim();
-    node.tooltip = node.fullPath = remotepath;
+    // Sanitization: Replace multiple preceding forward slashes with just one forward slash
+    node.tooltip = node.fullPath = remotepath.replace(/\/\/+/, "/");
     node.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
     node.dirty = true;
     ussFileProvider.refresh();
@@ -1156,7 +1170,12 @@ export async function openUSS(node: ZoweUSSNode, download = false) {
     try {
         let label: string;
         switch (node.mParent.contextValue) {
+            case ("favorite"):
+                label = node.mLabel.substring(node.mLabel.indexOf(":") + 1).trim();
+                break;
+            // Handle file path for files in directories and favorited directories
             case ("directory"):
+            case ("directoryf"):
                 label = node.fullPath;
                 break;
             case ("uss_session"):

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,28 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import * as path from "path";
+import * as os from "os";
+import * as zowe from "@brightside/core";
+import { CliProfileManager } from "@brightside/imperative";
+
+/*
+ * Created this file to be a place where commonly used functions will be defined.
+ * I noticed we have a lot of repetition of some common
+ * functionality in many places.
+ */
+export async function getSession(profileName: string) {
+    const zosmfProfile = await new CliProfileManager({
+        profileRootDirectory: path.join(os.homedir(), ".zowe", "profiles"),
+        type: "zosmf"
+    }).load({name: profileName});
+    return zowe.ZosmfSession.createBasicZosmfSession(zosmfProfile.profile);
+}


### PR DESCRIPTION
Add basic favorite functionality for USS explorer:
- Add files and directories as favorites
- Remove files and directories from favorites
- Expand favorited directories and open favorited files
- Sanitize search input starting with more than one slash
- Unit tests for the added functionalities

Related issues:
- #37 (Introduce Favorites functionality to USS extension)
- zowe/zowe-cli#297 (VSCode USS File extension - Favorites)