### PR TITLE
JCL Submission improvements

### DIFF
--- a/__tests__/extension.test.ts
+++ b/__tests__/extension.test.ts
@@ -388,7 +388,7 @@ describe("Extension Unit Tests", async () => {
                     getChildren: mockGetUSSChildren,
                 }
         });
-        expect(registerCommand.mock.calls.length).toBe(44);
+        expect(registerCommand.mock.calls.length).toBe(46);
         expect(registerCommand.mock.calls[0][0]).toBe("zowe.addSession");
         expect(registerCommand.mock.calls[0][1]).toBeInstanceOf(Function);
         expect(registerCommand.mock.calls[1][0]).toBe("zowe.addFavorite");
@@ -459,11 +459,11 @@ describe("Extension Unit Tests", async () => {
         expect(registerCommand.mock.calls[33][1]).toBeInstanceOf(Function);
         expect(registerCommand.mock.calls[34][0]).toBe("zowe.deleteJob");
         expect(registerCommand.mock.calls[34][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[35][0]).toBe("zowe.refreshJobsServer");
+        expect(registerCommand.mock.calls[35][0]).toBe("zowe.runModifyCommand");
         expect(registerCommand.mock.calls[35][1]).toBeInstanceOf(Function);
         expect(registerCommand.mock.calls[36][0]).toBe("zowe.runStopCommand");
         expect(registerCommand.mock.calls[36][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[37][0]).toBe("zowe.refreshServer");
+        expect(registerCommand.mock.calls[37][0]).toBe("zowe.refreshJobsServer");
         expect(registerCommand.mock.calls[37][1]).toBeInstanceOf(Function);
         expect(registerCommand.mock.calls[38][0]).toBe("zowe.refreshAllJobs");
         expect(registerCommand.mock.calls[38][1]).toBeInstanceOf(Function);
@@ -473,10 +473,14 @@ describe("Extension Unit Tests", async () => {
         expect(registerCommand.mock.calls[40][1]).toBeInstanceOf(Function);
         expect(registerCommand.mock.calls[41][0]).toBe("zowe.setPrefix");
         expect(registerCommand.mock.calls[41][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[42][0]).toBe("zowe.getJobJcl");
+        expect(registerCommand.mock.calls[42][0]).toBe("zowe.removeJobsSession");
         expect(registerCommand.mock.calls[42][1]).toBeInstanceOf(Function);
-        expect(registerCommand.mock.calls[43][0]).toBe("zowe.setJobSpool");
+        expect(registerCommand.mock.calls[43][0]).toBe("zowe.downloadSpool");
         expect(registerCommand.mock.calls[43][1]).toBeInstanceOf(Function);
+        expect(registerCommand.mock.calls[44][0]).toBe("zowe.getJobJcl");
+        expect(registerCommand.mock.calls[44][1]).toBeInstanceOf(Function);
+        expect(registerCommand.mock.calls[45][0]).toBe("zowe.setJobSpool");
+        expect(registerCommand.mock.calls[45][1]).toBeInstanceOf(Function);
         expect(onDidSaveTextDocument.mock.calls.length).toBe(1);
         expect(existsSync.mock.calls.length).toBe(3);
         expect(existsSync.mock.calls[0][0]).toBe(extension.BRIGHTTEMPFOLDER);

--- a/package.json
+++ b/package.json
@@ -287,6 +287,10 @@
           "light": "./resources/light/download.svg",
           "dark": "./resources/dark/download.svg"
         }
+      },
+      {
+        "command": "zowe.getJobJcl",
+        "title": "Get JCL"
       }
     ],
     "menus": {
@@ -575,6 +579,10 @@
           "when": "viewItem == job",
           "command": "zowe.downloadSpool",
           "group": "inline"
+        },
+        {
+          "when": "viewItem == job",
+          "command": "zowe.getJobJcl"
         }
       ],
       "commandPalette": [

--- a/package.json
+++ b/package.json
@@ -291,6 +291,10 @@
       {
         "command": "zowe.getJobJcl",
         "title": "Get JCL"
+      },
+      {
+        "command": "zowe.setJobSpool",
+        "title": "Set Spool"
       }
     ],
     "menus": {


### PR DESCRIPTION
Resolves #81 by adding a menu item to jobs allowing the user to get the JCL.

Enhances the ability to submit JCL by allowing the content of any editor to be submitted by providing a list of available profiles to use to submit the Job if it can't be determined programatically.

Exploits the functionality made available in the [April 2019 release](https://code.visualstudio.com/updates/v1_34#_command-links-in-notifications) to provide a link in the information message which will open the spool for the newly submitted job.