### PR TITLE
 Handle undefined response from QuickPicks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## 0.16.3
+ - Fix behavior when the user cancels "quick pick" dialogs, including selecting profiles and deleting data sets.
 ## 0.16.2
  - Add the stderr of the getDefaultProfile or getAllProfiles process to display in the error message to the user
 ## 0.16.1

--- a/__tests__/extension.test.ts
+++ b/__tests__/extension.test.ts
@@ -647,7 +647,7 @@ describe("Extension Unit Tests", async () => {
         showQuickPick.mockReset();
         showErrorMessage.mockReset();
 
-        showQuickPick.mockReturnValueOnce("Data Set Fake");
+        showQuickPick.mockReturnValueOnce(undefined);
         try {
             await extension.createFile(sessNode, testTree);
             // tslint:disable-next-line:no-empty
@@ -655,19 +655,20 @@ describe("Extension Unit Tests", async () => {
         }
 
         expect(showQuickPick.mock.calls.length).toBe(1);
-        expect(showErrorMessage.mock.calls.length).toBe(1);
-        expect(showErrorMessage.mock.calls[0][0]).toBe("Invalid data set type.");
+        expect(showErrorMessage.mock.calls.length).toBe(0);
     });
 
     it("Testing that deleteDataset is executed successfully", async () => {
         existsSync.mockReset();
         unlinkSync.mockReset();
+        showQuickPick.mockReset();
 
         let node = new ZoweNode("node", vscode.TreeItemCollapsibleState.None, sessNode, null);
         const parent = new ZoweNode("parent", vscode.TreeItemCollapsibleState.Collapsed, sessNode, null);
         let child = new ZoweNode("child", vscode.TreeItemCollapsibleState.None, parent, null);
 
         existsSync.mockReturnValueOnce(true);
+        showQuickPick.mockResolvedValueOnce("Yes");
         await extension.deleteDataset(node, testTree);
         expect(delDataset.mock.calls.length).toBe(1);
         expect(delDataset.mock.calls[0][0]).toBe(session);
@@ -682,6 +683,7 @@ describe("Extension Unit Tests", async () => {
         unlinkSync.mockReset();
         delDataset.mockReset();
         existsSync.mockReturnValueOnce(false);
+        showQuickPick.mockResolvedValueOnce("Yes");
         await extension.deleteDataset(child, testTree);
 
         expect(unlinkSync.mock.calls.length).toBe(0);
@@ -689,6 +691,7 @@ describe("Extension Unit Tests", async () => {
 
         delDataset.mockReset();
         delDataset.mockRejectedValueOnce(Error("not found"));
+        showQuickPick.mockResolvedValueOnce("Yes");
 
         await extension.deleteDataset(node, testTree);
 
@@ -698,13 +701,13 @@ describe("Extension Unit Tests", async () => {
         delDataset.mockReset();
         showErrorMessage.mockReset();
         delDataset.mockRejectedValueOnce(Error(""));
+        showQuickPick.mockResolvedValueOnce("Yes");
 
         await extension.deleteDataset(child, testTree);
 
         expect(showErrorMessage.mock.calls.length).toBe(1);
         expect(showErrorMessage.mock.calls[0][0]).toEqual(Error(""));
 
-        showQuickPick.mockReset();
         showQuickPick.mockResolvedValueOnce("No");
 
         await extension.deleteDataset(child, testTree);

--- a/__tests__/uss/ussNodeActions.test.ts
+++ b/__tests__/uss/ussNodeActions.test.ts
@@ -91,13 +91,18 @@ describe("ussNodeActions", async () => {
         });
     })
     describe("deleteUSSNode", () => {
-        it("deleteUSSNode is executed successfully", async () => {
+        it("should delete node if user verified", async () => {
             showQuickPick.mockResolvedValueOnce("Yes");
             await deleteUSSNode(ussNode, testUSSTree, "");
             expect(testUSSTree.refresh).toHaveBeenCalled();
         });
         it("should not delete node if user did not verify", async () => {
             showQuickPick.mockResolvedValueOnce("No");
+            await deleteUSSNode(ussNode, testUSSTree, "");
+            expect(testUSSTree.refresh).not.toHaveBeenCalled();
+        });
+        it("should not delete node if user cancelled", async () => {
+            showQuickPick.mockResolvedValueOnce(undefined);
             await deleteUSSNode(ussNode, testUSSTree, "");
             expect(testUSSTree.refresh).not.toHaveBeenCalled();
         });

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-extension-for-zowe",
   "displayName": "Zowe",
   "description": "VS Code extension, powered by Zowe CLI, that streamlines interaction with mainframe data sets, USS files, and jobs",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "publisher": "Zowe",
   "repository": {
     "url": "https://github.com/zowe/vscode-extension-for-zowe"

--- a/src/ZoweNode.ts
+++ b/src/ZoweNode.ts
@@ -142,7 +142,7 @@ export class ZoweNode extends vscode.TreeItem {
     }
 
     /**
-     * Returs the session node for this node
+     * Returns the session node for this node
      *
      * @returns {ZoweNode}
      */

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -334,7 +334,12 @@ export async function addSession(datasetProvider: DatasetTree) {
             canPickMany: false
         };
         const chosenProfile = await vscode.window.showQuickPick(profileNamesList, quickPickOptions);
-        await datasetProvider.addSession(chosenProfile);
+        if (chosenProfile) {
+            log.debug("User selected profile '%s'", chosenProfile);
+            await datasetProvider.addSession(chosenProfile);
+        } else {
+            log.debug("User cancelled profile selection");
+        }
     } else {
         vscode.window.showInformationMessage("No more profiles to add");
     }
@@ -380,7 +385,12 @@ export async function addUSSSession(ussFileProvider: USSTree) {
             canPickMany: false
         };
         const chosenProfile = await vscode.window.showQuickPick(profileNamesList, quickPickOptions);
-        await ussFileProvider.addSession(chosenProfile);
+        if (chosenProfile) {
+            log.debug("User selected profile '%s'", chosenProfile);
+            await ussFileProvider.addSession(chosenProfile);
+        } else {
+            log.debug("User cancelled profile selection");
+        }
     } else {
         vscode.window.showInformationMessage("No more profiles to add");  // TODO MISSED TESTING
     }
@@ -408,12 +418,13 @@ export async function createFile(node: ZoweNode, datasetProvider: DatasetTree) {
         "Data Set Partitioned",
         "Data Set Sequential"
     ];
-    log.debug("Creating new data set");
     // get data set type
     const type = await vscode.window.showQuickPick(types, quickPickOptions);
-    if (types.indexOf(type) < 0) {
-        vscode.window.showErrorMessage("Invalid data set type.");
+    if (type == null) {
+        log.debug("No valid data type selected");
         return;
+    } else {
+        log.debug("Creating new data set");
     }
 
     let typeEnum;
@@ -601,7 +612,7 @@ export async function deleteDataset(node: ZoweNode, datasetProvider: DatasetTree
         canPickMany: false
     };
     // confirm that the user really wants to delete
-    if (await vscode.window.showQuickPick(["Yes", "No"], quickPickOptions) === "No") {
+    if (await vscode.window.showQuickPick(["Yes", "No"], quickPickOptions) !== "Yes") {
         log.debug("User picked no. Cancelling delete of data set");
         return;
     }
@@ -1256,7 +1267,12 @@ export async function addJobsSession(datasetProvider: ZosJobsProvider) {
             canPickMany: false
         };
         const chosenProfile = await vscode.window.showQuickPick(profileNamesList, quickPickOptions);
-        await datasetProvider.addSession(chosenProfile);
+        if (chosenProfile) {
+            log.debug("User selected profile '%s'", chosenProfile);
+            await datasetProvider.addSession(chosenProfile);
+        } else {
+            log.debug("User cancelled profile selection");
+        }
     } else {
         vscode.window.showInformationMessage("No more profiles to add");
     }

--- a/src/uss/ussNodeActions.ts
+++ b/src/uss/ussNodeActions.ts
@@ -44,7 +44,7 @@ export async function deleteUSSNode(node: ZoweUSSNode, ussFileProvider: USSTree,
         ignoreFocusOut: true,
         canPickMany: false
     };
-    if (await vscode.window.showQuickPick(["Yes", "No"], quickPickOptions) === "No") {
+    if (await vscode.window.showQuickPick(["Yes", "No"], quickPickOptions) !== "Yes") {
         return;
     }
     try {

--- a/src/zosjobs.ts
+++ b/src/zosjobs.ts
@@ -48,7 +48,7 @@ export class ZosJobsProvider implements vscode.TreeDataProvider<Job> {
         const zosmfProfile: IProfileLoaded = sessionName? loadNamedProfile(sessionName): loadDefaultProfile();
 
         // If session is already added, do nothing
-        if (this.mSessionNodes.filter((tempNode) => tempNode.mLabel === zosmfProfile.profile.name).length) {
+        if (this.mSessionNodes.find((tempNode) => tempNode.mLabel === zosmfProfile.name)) {
             return;
         }
 


### PR DESCRIPTION
Fixes #82 by specifically handling the `undefined` response from QuickPick input prompts in VS Code, rather than incorrectly assuming the first response in the list of options was selected