### PR TITLE
Markdown linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,73 +1,125 @@
 # Change Log
+
 All notable changes to the "vscode-extension-for-zowe" extension will be documented in this file.
 
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
-
 ## 0.18.0
-  - Added the ability to submit JCL from physical sequential data sets
+
+- Added the ability to submit JCL from physical sequential data sets
+
 ## 0.17.0
- - Add Favorites to USS explorer. Thanks to Rodney-Wilson and Lauren-Li
- - Add ability to obtain the raw JCL from a job on spool and resubmit. Thanks @crshnburn
+
+- Add Favorites to USS explorer. Thanks to Rodney-Wilson and Lauren-Li
+- Add ability to obtain the raw JCL from a job on spool and resubmit. Thanks @crshnburn
+
 ## 0.16.3
- - Fix behavior when the user cancels "quick pick" dialogs, including selecting profiles and deleting data sets.
+
+- Fix behavior when the user cancels "quick pick" dialogs, including selecting profiles and deleting data sets.
+
 ## 0.16.2
- - Add the stderr of the getDefaultProfile or getAllProfiles process to display in the error message to the user
+
+- Add the stderr of the getDefaultProfile or getAllProfiles process to display in the error message to the user
+
 ## 0.16.1
- - Attempt to fix an issue where saving data sets ceases to work without any error message
+
+- Attempt to fix an issue where saving data sets ceases to work without any error message
+
 ## 0.16.0
- - Add the ability to display data set attributes by right clicking on a data set
- - Add the ability to save all spool content by clicking a download icon next to the job. Thanks @crshnburn
+
+- Add the ability to display data set attributes by right clicking on a data set
+- Add the ability to save all spool content by clicking a download icon next to the job. Thanks @crshnburn
+
 ## 0.15.1
- - Add a delete session menu item for sessions in the jobs view. Thanks @crshnburn
- - Prevent the delete menu item for USS files and directories appearing on the context menu for sessions. Thanks @crshnburn
- - Fixed an issue where adding a profile to the USS explorer incorrectly referenced data sets
+
+- Add a delete session menu item for sessions in the jobs view. Thanks @crshnburn
+- Prevent the delete menu item for USS files and directories appearing on the context menu for sessions. Thanks @crshnburn
+- Fixed an issue where adding a profile to the USS explorer incorrectly referenced data sets
+
 ## 0.15.0
- - The extension is now compatible with installations which use a secure credential management plugin
-   for profiles in Zowe CLI
+
+- The extension is now compatible with installations which use a secure credential management plugin for profiles in Zowe CLI
+
 ## 0.14.0
- - All zowe views now part of single Zowe view container. Thanks Colin Stone
+
+- All zowe views now part of single Zowe view container. Thanks Colin Stone
+
 ## 0.13.0
- - Added the ability to list and view spool of z/OS Jobs. Thanks @crshnburn
+
+- Added the ability to list and view spool of z/OS Jobs. Thanks @crshnburn
+
 ## 0.12.0
- - Added GIFs to README for USS use cases. Thanks Colin Stone
- - Added the ability to toggle binary mode or text mode on USS files. Thanks @crshnburn
+
+- Added GIFs to README for USS use cases. Thanks Colin Stone
+- Added the ability to toggle binary mode or text mode on USS files. Thanks @crshnburn
+
 ## 0.11.0
- - Create and delete functionality for USS Files and directories added as menu items.
+
+- Create and delete functionality for USS Files and directories added as menu items.
+
 ## 0.10.4
- - Add additional log messages
+
+- Add additional log messages
+
 ## 0.10.3
- - Use path.sep rather than "/".
+
+- Use path.sep rather than "/".
+
 ## 0.10.2
- - VSCode-USS-extension-for-zowe fixed general USS file name error. Thanks Colin Stone
+
+- VSCode-USS-extension-for-zowe fixed general USS file name error. Thanks Colin Stone
+
 ## 0.10.1
- - VSCode-USS-extension-for-zowe merged in. Thanks Colin Stone
+
+- VSCode-USS-extension-for-zowe merged in. Thanks Colin Stone
+
 ## 0.9.1
- - Fix documentation links in Readme. Thanks Brandon Jenkins
+
+- Fix documentation links in Readme. Thanks Brandon Jenkins
+
 ## 0.9.0
- - Display an informational message when no data set patterns are found. Thanks @crshnburn
+
+- Display an informational message when no data set patterns are found. Thanks @crshnburn
+
 ## 0.8.4
- - Fixed an issue where the submit JCL function was looking for user profiles in the wrong directory
+
+- Fixed an issue where the submit JCL function was looking for user profiles in the wrong directory
+
 ## 0.8.3
- - Fixed an issue where labels did not correctly display the name of the Zowe CLI profile
+
+- Fixed an issue where labels did not correctly display the name of the Zowe CLI profile
+
 ## 0.8.2
-- Fixed for compatibility with the current version of the Zowe CLI. If you are having issues retrieving user name or password using this extension,
-please update your zowe CLI to the latest available version, recreate your profiles, and update this extension. That should solve any issues you are having.
+
+- Fixed for compatibility with the current version of the Zowe CLI. If you are having issues retrieving user name or password using this extension, please update your zowe CLI to the latest available version, recreate your profiles, and update this extension. That should solve any issues you are having.
 
 ## 0.8.0
+
 - Introduced capability to submit jobs from the editor. Thanks @crshnburn
+
 ## 0.7.0
+
 - Updated for compatibility with Zowe CLI >=2.0.0. You must now have plain text profiles and Zowe CLI 2.0.0 or greater to use this extension. If you have previously created profiles, please update or recreate them with Zowe CLI.
 - Log files now go to `~/.vscode/extensions/zowe.vscode-extension-for-zowe-x.x.x/logs`
 
 ## 0.6.5
+
 - Fixed issue with platform-specific folder separator, added progress bar when saving
+
 ## 0.6.4
+
 - Make favorites persistent after upgrading the extension
+
 ## 0.6.3
+
 - Updates to README
+
 ## 0.6.2
+
 - Updates to README
+
 ## 0.6.1
+
 - Updates to README
+
 ## 0.5.0
+
 - Initial release

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ After you install the Zowe extension, meet the following prerequisites:
 You can alter the behavior of the extension in the following ways:
 
 * **Data set Safe Save:** The Visual Studio Code **Save** functionality will overwrite data set contents on the mainframe. To prevent conflicts, use the Zowe extension **Safe Save** functionality to compare changes made with initial mainframe contents before saving. For more information, see [Use Safe Save to prevent merge conflicts](#use-safe-save-to-prevent-merge-conflicts).
-* **Data set creation settings:** You can change the default creation settings for various data set types. Navigate to the Settings for this extension for more info. 
+* **Data set creation settings:** You can change the default creation settings for various data set types. Navigate to the Settings for this extension for more info.
 * **Data set persistence settings:** You can toggle the persistence of any data sets that are present under your **Favorites** tab.
   
 **Tip:** By default, Visual Studio Code does not highlight data set syntax. To enhance the experience of using the extension, download an extension that highlights syntax, such as COBOL.
@@ -67,10 +67,10 @@ Review the following use cases to understand how to use this extension.
 4. Click the PDS member (or PS) that you want to download.
 
     **Note:** To view the members of a PDS, click the PDS to expand the tree.
-    
-    The PDS member displays in the text editor window of VSC. 
-6. Edit the document.
-7. Navigate back to the PDS member (or PS) in the explorer tree, and click the **Safe Save** button.
+
+    The PDS member displays in the text editor window of VSC.
+5. Edit the document.
+6. Navigate back to the PDS member (or PS) in the explorer tree, and click the **Safe Save** button.
 
 Your PDS member (or PS) is uploaded.  
 
@@ -101,7 +101,7 @@ Your PDS member (or PS) is uploaded.
    The PDS is created.
 6. To create a member, right-click the PDS and select **Create New Member**.
 7. Enter a name for the member.
-   The member is created. 
+   The member is created.
 
 ![Create](https://github.com/mheuzey/temp/blob/master/resources/gifs/new_pds_new_member.gif?raw=true "Create")
 <br /><br />
@@ -113,21 +113,21 @@ Your PDS member (or PS) is uploaded.
 3. Open the profile and PDS containing the member.
 4. Right-click on the PDS member that you want to delete and select **Delete Member**.
 5. Confirm the deletion by clicking **Yes** on the drop-down menu.
-    
+
     **Note:** Alternatively, you can select 'No' to cancel the deletion.
 6. To delete a PDS, right-click the PDS and click **Delete PDS**, then confirm the deletion.
-    
+
     **Note:** You can delete a PDS before you you delete its members.
 
 ![Delete](https://github.com/mheuzey/temp/blob/master/resources/gifs/delete_pds_delete_member.gif?raw=true "Delete")
 <br /><br />
 
-### View and access multiple profiles simultaneously 
+### View and access multiple profiles simultaneously
 
 1. Navigate to your explorer tree.
 2. Open the **DATA SETS** bar.
-2. Click the **Add Profile** button on the right of the **DATA SET** explorer bar.
-3. Select the profile that you want to add to the view as illustrated by the following screen.
+3. Click the **Add Profile** button on the right of the **DATA SET** explorer bar.
+4. Select the profile that you want to add to the view as illustrated by the following screen.
 
 ![Add Profile](https://github.com/mheuzey/temp/blob/master/resources/gifs/addProfile.gif?raw=true "Add Profile")
 <br /><br />
@@ -139,7 +139,6 @@ Your PDS member (or PS) is uploaded.
 3. Click the **Edit** button to the left of the Data Set settings that you want to edit.
 4. Select **Copy to Settings**.
 5. Edit the settings as needed.
-
 
 ### View Unix System Services (USS) files
 
@@ -168,8 +167,8 @@ Your PDS member (or PS) is uploaded.
 1. Click the file that you want to download.
 
     **Note:** To view the files within a directory, click the directory to expand the tree.
-    
-    The file displays in the text editor window of VSC. 
+
+    The file displays in the text editor window of VSC.
 
     **Note:** If you have defined file associations with syntax coloring the suffix of your file will be marked up.
 
@@ -181,7 +180,6 @@ Your file is uploaded.
 ![Edit](./docs/images/editUSS.gif?raw=true "Edit")
 <br /><br />
 
-
 ### Creating and deleting files and directories
 
 #### Create a directory
@@ -190,7 +188,7 @@ Your file is uploaded.
 2. Open the **Unix System Services (USS)** bar.
 3. Select a directory that you want to add the new directory to.
 4. Select the **Create directory** button and specify the directory name.
-   The directory is created. 
+   The directory is created.
 
 #### Create a file
 
@@ -198,7 +196,7 @@ Your file is uploaded.
 2. Open the **Unix System Services (USS)** bar.
 3. Select a directory that you want to add the new file to.
 4. Select the **Create file** button and specify the file name.
-   The file is created. 
+   The file is created.
 
 #### Delete a file
 
@@ -206,25 +204,24 @@ Your file is uploaded.
 2. Open the **Unix System Services (USS)** bar.
 3. Select a file you want to remove.
 4. Select the **Delete** button and press yes in the confirmation dropdown.
-   The file is deleted. 
-   
+   The file is deleted.
+
 #### Delete a directory
 
 1. Navigate to your explorer tree.
 2. Open the **Unix System Services (USS)** bar.
 3. Select a directory you want to remove.
 4. Select the **Delete** button and press yes in the confirmation dropdown.
-   The directory and all child files and directories are deleted. 
+   The directory and all child files and directories are deleted.
 
 ![Create and Delete](./docs/images/CreateDelete.gif?raw=true "Create and Delete")
 <br /><br />
 
-### View and access multiple profiles simultaneously 
+### View and access multiple USS profiles simultaneously
 
 1. Navigate to your explorer tree.
 2. Open the **Unix System Services (USS)** bar.
-2. Click the **Add Profile** button on the right of the **Unix System Services (USS)** explorer bar.
-3. Select the profile that you want to add to the view as illustrated by the following screen.
+3. Click the **Add Profile** button on the right of the **Unix System Services (USS)** explorer bar.
+4. Select the profile that you want to add to the view as illustrated by the following screen.
 
 ![Add Profile](./docs/images/profile2.gif?raw=true "Add Profile")
-<br /><br />

--- a/package.json
+++ b/package.json
@@ -344,7 +344,7 @@
         {
           "when": "view == zowe.uss.explorer && viewItem == directory",
           "command": "zowe.uss.addFavorite",
-         "group": "navigation"
+          "group": "navigation"
         },
         {
           "when": "view == zowe.uss.explorer && viewItem == directoryf",
@@ -749,14 +749,15 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "npm run build",
+    "vscode:prepublish": "npm run build && npm run markdown",
     "build": "npm run license && tsc --pretty",
     "watch": "tsc -watch --pretty",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "test:unit": "jest --coverage",
     "test": "jest --coverage",
     "package": "vsce package",
-    "license": "node ./scripts/license.js"
+    "license": "node ./scripts/license.js",
+    "markdown": "markdownlint CHANGELOG.md README.md"
   },
   "devDependencies": {
     "@types/chai": "^4.1.4",
@@ -774,6 +775,7 @@
     "jest": "^22.4.4",
     "jest-html-reporter": "^2.4.0",
     "jsdom": "11.11.0",
+    "markdownlint-cli": "^0.16.0",
     "sinon": "^6.1.0",
     "ts-jest": "^22.4.6",
     "typescript": "^2.9.2",


### PR DESCRIPTION
Resolves #100

Add markdown linting to the prepublish steps and apply the linting to the CHANGELOG and README markdown files.