### PR TITLE
Preference to Specify Temp Folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ After you install the Zowe extension, meet the following prerequisites:
 
 * [Install Zowe CLI](https://zowe.github.io/docs-site/latest/user-guide/cli-installcli.html#methods-to-install-zowe-cli) on your PC.
   
-    **Important!** To use the VSC Extension for Zowe, you must install Zowe CLI version `2.0.0` or later.
+> **Important!**: To use the VSC Extension for Zowe, you must install Zowe CLI version `2.0.0` or later.
 * [Create at least one Zowe CLI 'zosmf' profile](https://zowe.github.io/docs-site/latest/user-guide/cli-configuringcli.html#creating-zowe-cli-profiles).
 
 ## Configuration and usage tips
@@ -28,10 +28,17 @@ After you install the Zowe extension, meet the following prerequisites:
 You can alter the behavior of the extension in the following ways:
 
 * **Data set Safe Save:** The Visual Studio Code **Save** functionality will overwrite data set contents on the mainframe. To prevent conflicts, use the Zowe extension **Safe Save** functionality to compare changes made with initial mainframe contents before saving. For more information, see [Use Safe Save to prevent merge conflicts](#use-safe-save-to-prevent-merge-conflicts).
-* **Data set creation settings:** You can change the default creation settings for various data set types. Navigate to the Settings for this extension for more info.
 * **Data set persistence settings:** You can toggle the persistence of any data sets that are present under your **Favorites** tab.
   
 **Tip:** By default, Visual Studio Code does not highlight data set syntax. To enhance the experience of using the extension, download an extension that highlights syntax, such as COBOL.
+
+### Advanced Configuration
+> **WARNING**: Specifying these preferences incorrectly, may cause the extension to fail. 
+
+Extension preferences can also be modified in the `Settings` for this extension. They can be customized in the following ways:
+
+* **Data set creation settings:** You can change the default creation settings for various data set types.
+* **Temp Folder Location:** You can change the default folder location for where temporary files are stored. 
 
 ## Sample use cases
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ After you install the Zowe extension, meet the following prerequisites:
 * [Install Zowe CLI](https://zowe.github.io/docs-site/latest/user-guide/cli-installcli.html#methods-to-install-zowe-cli) on your PC.
   
 > **Important!**: To use the VSC Extension for Zowe, you must install Zowe CLI version `2.0.0` or later.
+
 * [Create at least one Zowe CLI 'zosmf' profile](https://zowe.github.io/docs-site/latest/user-guide/cli-configuringcli.html#creating-zowe-cli-profiles).
 
 ## Configuration and usage tips
@@ -33,12 +34,13 @@ You can alter the behavior of the extension in the following ways:
 **Tip:** By default, Visual Studio Code does not highlight data set syntax. To enhance the experience of using the extension, download an extension that highlights syntax, such as COBOL.
 
 ### Advanced Configuration
-> **WARNING**: Specifying these preferences incorrectly, may cause the extension to fail. 
+
+> **WARNING**: Specifying these preferences incorrectly, may cause the extension to fail.
 
 Extension preferences can also be modified in the `Settings` for this extension. They can be customized in the following ways:
 
 * **Data set creation settings:** You can change the default creation settings for various data set types.
-* **Temp Folder Location:** You can change the default folder location for where temporary files are stored. 
+* **Temp Folder Location:** You can change the default folder location for where temporary files are stored.
 
 ## Sample use cases
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,13 @@ You can alter the behavior of the extension in the following ways:
 Extension preferences can also be modified in the `Settings` for this extension. They can be customized in the following ways:
 
 * **Data set creation settings:** You can change the default creation settings for various data set types.
-* **Temp Folder Location:** You can change the default folder location for where temporary files are stored.
+* **Temp Folder Location:** You can change the default folder location, for where temporary files are stored. In order to set in `Settings`, use the example below.
+
+```json
+"Zowe-Temp-Folder-Location": {
+    "folderPath": "/path/to/directory"
+  }
+```
 
 ## Sample use cases
 

--- a/__mocks__/fs-extra.ts
+++ b/__mocks__/fs-extra.ts
@@ -1,0 +1,12 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+export function moveSync(srcPath: string, destPath: string): void {}

--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -377,7 +377,7 @@ export namespace workspace {
 		 */
         readonly index: number;
     }
-
+    
 }
 
 export interface InputBoxOptions {

--- a/__tests__/integrationTests/extension.test.ts
+++ b/__tests__/integrationTests/extension.test.ts
@@ -51,7 +51,7 @@ describe("Extension Integration Tests", () => {
     beforeEach(async function() {
         this.timeout(TIMEOUT);
         sandbox = sinon.createSandbox();
-        await extension.deactivate();
+        await extension.cleanTempDir();
     });
 
     afterEach(async function() {
@@ -400,6 +400,56 @@ describe("Extension Integration Tests", () => {
         }).timeout(TIMEOUT);
 
         // TODO add tests for saving data set from favorites
+    });
+
+    describe("Updating Temp Folder", () => {
+        // define paths
+        const testingPath = path.join(__dirname, "..", "..", "..", "test");
+        const providedPathOne = path.join(__dirname, "..", "..", "..", "test-folder-one");
+        const providedPathTwo = path.join(__dirname, "..", "..", "..", "test-folder-two");
+
+        // remove directories in case of previously failed tests
+        extension.cleanDir(testingPath);
+        extension.cleanDir(providedPathOne);
+        extension.cleanDir(providedPathTwo);
+
+        it("should assign the temp folder based on preference", async () => {
+            // create target folder
+            fs.mkdirSync(testingPath);
+            await vscode.workspace.getConfiguration().update("Zowe-Temp-Folder-Location",
+                { folderPath: `${testingPath}` }, vscode.ConfigurationTarget.Global);
+
+            expect(extension.BRIGHTTEMPFOLDER).to.equal(`${testingPath}/temp`);
+
+            // Remove directory for subsequent tests
+            extension.cleanDir(testingPath);
+        }).timeout(TIMEOUT);
+
+        it("should update temp folder on preference change", async () => {
+            fs.mkdirSync(providedPathOne);
+            fs.mkdirSync(providedPathTwo);
+
+            // set first preference
+            await vscode.workspace.getConfiguration().update("Zowe-Temp-Folder-Location",
+                { folderPath: `${providedPathOne}` }, vscode.ConfigurationTarget.Global);
+
+            // change preference and test for update
+            await vscode.workspace.getConfiguration().update("Zowe-Temp-Folder-Location",
+            { folderPath: `${providedPathTwo}` }, vscode.ConfigurationTarget.Global);
+
+            expect(extension.BRIGHTTEMPFOLDER).to.equal(`${providedPathTwo}/temp`);
+
+            // Remove directory for subsequent tests
+            extension.cleanDir(providedPathOne);
+            extension.cleanDir(providedPathTwo);
+        }).timeout(TIMEOUT);
+
+        it("should assign default temp folder, if preference is empty", async () => {
+            const expectedDefaultTemp = path.join(__dirname, "..", "..", "..", "resources", "temp");
+            await vscode.workspace.getConfiguration().update("Zowe-Temp-Folder-Location",
+                { folderPath: "" }, vscode.ConfigurationTarget.Global);
+            expect(extension.BRIGHTTEMPFOLDER).to.equal(expectedDefaultTemp);
+        }).timeout(TIMEOUT);
     });
 
     describe("Initializing Favorites", () => {

--- a/__tests__/integrationTests/extension.test.ts
+++ b/__tests__/integrationTests/extension.test.ts
@@ -31,10 +31,6 @@ declare var it: Mocha.ITestDefinition;
 // declare var describe: any;
 
 describe("Extension Integration Tests", () => {
-// tslint:disable-next-line: variable-name
-    const ds_folder = extension.DS_DIR;
-// tslint:disable-next-line: variable-name
-    const brightside_folder = extension.BRIGHTTEMPFOLDER;
     const expect = chai.expect;
     chai.use(chaiAsPromised);
 
@@ -172,18 +168,18 @@ describe("Extension Integration Tests", () => {
     describe("Deactivate", () => {
         it("should clean up the local files when deactivate is invoked", async () => {
             try {
-                fs.mkdirSync(brightside_folder);
-                fs.mkdirSync(ds_folder);
+                fs.mkdirSync(extension.BRIGHTTEMPFOLDER);
+                fs.mkdirSync(extension.DS_DIR);
             } catch (err) {
                 // if operation failed, wait a second and try again
                 await new Promise((resolve) => setTimeout(resolve, 1000));
-                fs.mkdirSync(ds_folder);
+                fs.mkdirSync(extension.DS_DIR);
             }
-            fs.closeSync(fs.openSync(path.join(ds_folder, "file1"), "w"));
-            fs.closeSync(fs.openSync(path.join(ds_folder, "file2"), "w"));
+            fs.closeSync(fs.openSync(path.join(extension.DS_DIR, "file1"), "w"));
+            fs.closeSync(fs.openSync(path.join(extension.DS_DIR, "file2"), "w"));
             await extension.deactivate();
-            expect(fs.existsSync(path.join(ds_folder, "file1"))).to.equal(false);
-            expect(fs.existsSync(path.join(ds_folder, "file2"))).to.equal(false);
+            expect(fs.existsSync(path.join(extension.DS_DIR, "file1"))).to.equal(false);
+            expect(fs.existsSync(path.join(extension.DS_DIR, "file2"))).to.equal(false);
         }).timeout(TIMEOUT);
     });
 
@@ -506,9 +502,6 @@ async function getAllNodes(nodes: ZoweNode[]) {
 }
 
 describe("Extension Integration Tests - USS", () => {
-    const brightsidefolder = extension.BRIGHTTEMPFOLDER;
-    const ussFolder = extension.USS_DIR;
-
     const expect = chai.expect;
     chai.use(chaiAsPromised);
 
@@ -586,18 +579,18 @@ describe("Extension Integration Tests - USS", () => {
     describe("Deactivate", () => {
         it("should clean up the local files when deactivate is invoked", async () => {
             try {
-                fs.mkdirSync(brightsidefolder);
-                fs.mkdirSync(ussFolder);
+                fs.mkdirSync(extension.BRIGHTTEMPFOLDER);
+                fs.mkdirSync(extension.USS_DIR);
             } catch (err) {
                 // if operation failed, wait a second and try again
                 await new Promise((resolve) => setTimeout(resolve, 1000));
-                fs.mkdirSync(ussFolder);
+                fs.mkdirSync(extension.USS_DIR);
             }
-            fs.closeSync(fs.openSync(path.join(ussFolder, "file1"), "w"));
-            fs.closeSync(fs.openSync(path.join(ussFolder, "file2"), "w"));
+            fs.closeSync(fs.openSync(path.join(extension.USS_DIR, "file1"), "w"));
+            fs.closeSync(fs.openSync(path.join(extension.USS_DIR, "file2"), "w"));
             await extension.deactivate();
-            expect(fs.existsSync(path.join(ussFolder, "file1"))).to.equal(false);
-            expect(fs.existsSync(path.join(ussFolder, "file2"))).to.equal(false);
+            expect(fs.existsSync(path.join(extension.USS_DIR, "file1"))).to.equal(false);
+            expect(fs.existsSync(path.join(extension.USS_DIR, "file2"))).to.equal(false);
         }).timeout(TIMEOUT);
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6427,6 +6427,14 @@
       "integrity": "sha512-Q5Vn3yjTDyCMV50TB6VRIbQNxSE4OmZR86VSbGaNpfUolm0iePBB4KdEEHmxoY5sT2+2DIvXW0rvMDP2nHZ4Mg==",
       "dev": true
     },
+    "@types/fs-extra": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-7.0.0.tgz",
+      "integrity": "sha512-ndoMMbGyuToTy4qB6Lex/inR98nPiNHacsgMPvy+zqMLgSxbt8VtWpDArpGp69h1fEDQHn1KB+9DWD++wgbwYA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -6467,8 +6475,7 @@
     "@types/node": {
       "version": "7.10.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.6.tgz",
-      "integrity": "sha512-d0BOAicT0tEdbdVQlLGOVul1kvg6YvbaADRCThGCz5NJ0e9r00SofcR1x69hmlCyrHuB6jd4cKzL9bMLjPnpAA==",
-      "dev": true
+      "integrity": "sha512-d0BOAicT0tEdbdVQlLGOVul1kvg6YvbaADRCThGCz5NJ0e9r00SofcR1x69hmlCyrHuB6jd4cKzL9bMLjPnpAA=="
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -8289,6 +8296,16 @@
       "dev": true,
       "requires": {
         "map-cache": "^0.2.2"
+      }
+    },
+    "fs-extra": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.0.1.tgz",
+      "integrity": "sha512-W+XLrggcDzlle47X/XnS7FXrXu9sDo+Ze9zpndeBxdgv88FHLm1HtmkhEwavruS6koanBjp098rUpHs65EmG7A==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs.realpath": {
@@ -13026,6 +13043,14 @@
         }
       }
     },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -15326,6 +15351,11 @@
           }
         }
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unset-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -750,6 +750,13 @@
           "description": "Toggle if favorite files persist locally",
           "scope": "window"
         },
+        "Zowe-Temp-Folder-Location": {
+          "default": {
+            "folderPath": ""
+          },
+          "description": "Path to temporary folder location",
+          "scope": "window"
+        },
         "Zowe-USS-Persistent-Favorites": {
           "default": {
             "persistence": true,
@@ -802,6 +809,8 @@
   "dependencies": {
     "@brightside/core": "2.28.2",
     "@brightside/imperative": "2.4.6",
+    "@types/fs-extra": "^7.0.0",
+    "fs-extra": "^8.0.1",
     "jsdoc": "^3.5.5",
     "tslint": "^5.17.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,8 @@
 
 import * as zowe from "@brightside/core";
 import * as fs from "fs";
+import { moveSync } from "fs-extra";
+import * as os from "os";
 import * as path from "path";
 import * as vscode from "vscode";
 import { ZoweNode } from "./ZoweNode";
@@ -26,9 +28,9 @@ import { IJobFile } from "@brightside/core";
 import { loadNamedProfile, loadAllProfiles } from "./ProfileLoader";
 
 // Globals
-export const BRIGHTTEMPFOLDER = path.join(__dirname, "..", "..", "resources", "temp");
-export const USS_DIR = path.join(BRIGHTTEMPFOLDER, "_U_");
-export const DS_DIR = path.join(BRIGHTTEMPFOLDER, "_D_");
+export let BRIGHTTEMPFOLDER;
+export let USS_DIR;
+export let DS_DIR;
 
 let log: Logger;
 /**
@@ -38,14 +40,26 @@ let log: Logger;
  * @param {vscode.ExtensionContext} context - Context of vscode at the time that the function is called
  */
 export async function activate(context: vscode.ExtensionContext) {
-    // Call deactivate before continuing
+    // Get temp folder location from settings
+    let preferencesTempPath: string =
+        vscode.workspace.getConfiguration()
+        /* tslint:disable:no-string-literal */
+        .get("Zowe-Temp-Folder-Location")["folderPath"];
+
+    defineGlobals(preferencesTempPath);
+
+    // Call cleanTempDir before continuing
     // this is to handle if the application crashed on a previous execution and
     // VSC didn't get a chance to call our deactivate to cleanup.
-    await deactivate();
+    await cleanTempDir();
 
-    fs.mkdirSync(BRIGHTTEMPFOLDER);
-    fs.mkdirSync(USS_DIR);
-    fs.mkdirSync(DS_DIR);
+    try {
+        fs.mkdirSync(BRIGHTTEMPFOLDER);
+        fs.mkdirSync(USS_DIR);
+        fs.mkdirSync(DS_DIR);
+    } catch (err) {
+        vscode.window.showErrorMessage(err.message);
+    }
 
     let datasetProvider: DatasetTree;
     let ussFileProvider: USSTree;
@@ -123,6 +137,20 @@ export async function activate(context: vscode.ExtensionContext) {
                 setting.favorites = [];
                 await vscode.workspace.getConfiguration().update("Zowe-Persistent-Favorites", setting, vscode.ConfigurationTarget.Global); // MISSED
             }
+        }
+    });
+
+    vscode.workspace.onDidChangeConfiguration((e) => {
+        if (e.affectsConfiguration("Zowe-Temp-Folder-Location")) {
+            const updatedPreferencesTempPath: string =
+                vscode.workspace.getConfiguration()
+                /* tslint:disable:no-string-literal */
+                .get("Zowe-Temp-Folder-Location")["folderPath"];
+
+            moveTempFolder(preferencesTempPath, updatedPreferencesTempPath);
+
+            // Update current temp folder preference
+            preferencesTempPath = updatedPreferencesTempPath;
         }
     });
 
@@ -209,6 +237,56 @@ export async function activate(context: vscode.ExtensionContext) {
         });
         jobsProvider.setJob(jobView, job);
     });
+}
+
+/**
+ * Defines all global variables
+ * @param tempPath File path for temporary folder defined in preferences
+ */
+export function defineGlobals(tempPath: string | undefined) {
+    tempPath !== "" && tempPath !== undefined ?
+        BRIGHTTEMPFOLDER = path.join(tempPath, "temp") :
+        BRIGHTTEMPFOLDER = path.join(__dirname, "..", "..", "resources", "temp");
+
+    USS_DIR = path.join(BRIGHTTEMPFOLDER, "_U_");
+    DS_DIR = path.join(BRIGHTTEMPFOLDER, "_D_");
+}
+
+/**
+ * Moves temp folder to user defined location in preferences
+ * @param previousTempPath temp path settings value before updated by user
+ * @param currentTempPath temp path settings value after updated by user
+ */
+export function moveTempFolder(previousTempPath: string, currentTempPath: string) {
+    // Re-define globals with updated path
+    defineGlobals(currentTempPath);
+
+    if (previousTempPath === "") {
+        previousTempPath = path.join(__dirname, "..", "..", "resources");
+    }
+
+    // Make certain that "temp" folder is cleared
+    cleanTempDir();
+
+    try {
+        fs.mkdirSync(BRIGHTTEMPFOLDER);
+        fs.mkdirSync(USS_DIR);
+        fs.mkdirSync(DS_DIR);
+    } catch (err) {
+        log.error("Error encountered when creating temporary folder! " + JSON.stringify(err));
+        vscode.window.showErrorMessage(err.message);
+    }
+
+    try {
+        // If source and destination path are same, exit
+        if(`${previousTempPath}/temp` === BRIGHTTEMPFOLDER) {
+            return;
+        }
+        moveSync(`${previousTempPath}/temp`, BRIGHTTEMPFOLDER, { overwrite: true });
+    } catch (err) {
+        log.error("Error moving temporary folder! " + JSON.stringify(err));
+        vscode.window.showErrorMessage(err.message);
+    }
 }
 
 /**
@@ -640,8 +718,12 @@ export async function showDSAttributes(parent: ZoweNode, datasetProvider: Datase
 
 }
 
-
-function cleanDir(directory) {
+/**
+ * Recursively deletes directory
+ *
+ * @param directory path to directory to be deleted
+ */
+export function cleanDir(directory) {
     if (!fs.existsSync(directory)) {
         return;
     }
@@ -658,11 +740,11 @@ function cleanDir(directory) {
 }
 
 /**
- * Cleans up the default local storage directory
+ * Cleans up local temp directory
  *
  * @export
  */
-export async function deactivate() {
+export async function cleanTempDir() {
     // logger hasn't necessarily been initialized yet, don't use the `log` in this function
     if (!fs.existsSync(BRIGHTTEMPFOLDER)) {
         return;
@@ -673,6 +755,16 @@ export async function deactivate() {
         vscode.window.showErrorMessage("Unable to delete temporary folder. " + err);  // TODO MISSED TESTING
     }
 }
+
+/**
+ * Called by VSCode on shutdown
+ *
+ * @export
+ */
+export async function deactivate() {
+    await cleanTempDir();
+}
+
 
 /**
  * Deletes a dataset


### PR DESCRIPTION
Issue Number: #97

Adds preference to specify temp directory. In order change the temp folder location, add below to preferences.

```
  "Zowe-Temp-Folder-Location": {
    "folderPath": "/path/to/directory"
  }
```

If no folder is specified, it will default to resource folder used now.