### PR TITLE
Correctly determine if file is binary for saving

### DIFF
--- a/__tests__/extension.test.ts
+++ b/__tests__/extension.test.ts
@@ -1607,7 +1607,7 @@ describe("Extension Unit Tests", () => {
 
     it("Testing that saveUSSFile is executed successfully", async () => {
         const testDoc: vscode.TextDocument = {
-            fileName: path.join(extension.USS_DIR, "testFile"),
+            fileName: path.join(extension.USS_DIR, ussNode.mLabel, "testFile"),
             uri: null,
             isUntitled: null,
             languageId: null,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1319,8 +1319,8 @@ export async function saveUSSFile(doc: vscode.TextDocument, ussFileProvider: USS
     let binary;
     const sesNode = (await ussFileProvider.mSessionNodes.find((child) => child.mLabel === sesName.trim()));
     if (sesNode) {
-        documentSession = sesNode.getSession();  // TODO MISSED TESTING
-        binary = Object.keys(sesNode.binaryFiles).includes(remote);
+        documentSession = sesNode.getSession();
+        binary = Object.keys(sesNode.binaryFiles).find((child) => child === remote) !== undefined;
     }
 
     try {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1316,9 +1316,11 @@ export async function saveUSSFile(doc: vscode.TextDocument, ussFileProvider: USS
 
     // get session from session name
     let documentSession;
+    let binary;
     const sesNode = (await ussFileProvider.mSessionNodes.find((child) => child.mLabel === sesName.trim()));
     if (sesNode) {
         documentSession = sesNode.getSession();  // TODO MISSED TESTING
+        binary = Object.keys(sesNode.binaryFiles).includes(remote);
     }
 
     try {
@@ -1326,7 +1328,7 @@ export async function saveUSSFile(doc: vscode.TextDocument, ussFileProvider: USS
             location: vscode.ProgressLocation.Notification,
             title: "Saving file..."
         }, () => {
-            return zowe.Upload.fileToUSSFile(documentSession, doc.fileName, remote, sesNode.binary);  // TODO MISSED TESTING
+            return zowe.Upload.fileToUSSFile(documentSession, doc.fileName, remote, binary);  // TODO MISSED TESTING
         });
         if (response.success) {
             vscode.window.showInformationMessage(response.commandResponse);


### PR DESCRIPTION
Resolves #123

The saveUss function will now correctly determine if a file is binary for saving.