### PR TITLE
Default profile error

### DIFF
--- a/__tests__/DatasetTree.test.ts
+++ b/__tests__/DatasetTree.test.ts
@@ -18,7 +18,7 @@ jest.mock("../src/ProfileLoader");
 import * as vscode from "vscode";
 import { DatasetTree } from "../src/DatasetTree";
 import { ZoweNode } from "../src/ZoweNode";
-import { Session } from "@brightside/imperative";
+import { Session, Logger } from "@brightside/imperative";
 
 import * as profileLoader from "../src/ProfileLoader";
 
@@ -204,9 +204,11 @@ describe("DatasetTree Unit Tests", () => {
      * Test the addSession command
      *************************************************************************************************************/
     it("Test the addSession command ", async () => {
-        testTree.addSession();
+        const log = new Logger(undefined);
 
-        testTree.addSession("fake");
+        testTree.addSession(log);
+
+        testTree.addSession(log, "fake");
     });
 
     /*************************************************************************************************************

--- a/__tests__/ProfileLoader.test.ts
+++ b/__tests__/ProfileLoader.test.ts
@@ -79,7 +79,7 @@ describe("ProfileLoader", ()=>{
     it("should display an information message and log a debug message if no default profile is found", ()=> {
         showInformationMessage.mockReset();
         mockDebug.mockReset();
-
+        // Create bad profile
         (child_process.spawnSync as any) = jest.fn((program: string, args: string[], options: any)=>{
             return {
                 status: 0,

--- a/__tests__/ProfileLoader.test.ts
+++ b/__tests__/ProfileLoader.test.ts
@@ -9,13 +9,23 @@
 *                                                                                 *
 */
 
+jest.mock("vscode");
 jest.mock("child_process");
+jest.mock("@brightside/imperative");
+import * as vscode from "vscode";
 import * as child_process from "child_process";
+import { Logger } from "@brightside/imperative";
 
 import { loadNamedProfile, loadAllProfiles, loadDefaultProfile } from "../src/ProfileLoader";
 
+const showInformationMessage = jest.fn();
+const debug = jest.fn();
+Object.defineProperty(vscode.window, "showInformationMessage", {value: showInformationMessage});
+Object.defineProperty(Logger, "debug", {value: debug});
+
 
 describe("ProfileLoader", ()=>{
+    const log = new Logger(undefined);
 
     const profileOne = {name: "profile1", profile: {}, type: "zosmf"};
     const profileTwo = {name: "profile2", profile: {}, type: "zosmf"};
@@ -59,7 +69,20 @@ describe("ProfileLoader", ()=>{
 
     it("should return a default profile", ()=>{
 
-        const loadedProfile = loadDefaultProfile();
+        const loadedProfile = loadDefaultProfile(log);
         expect(loadedProfile).toEqual(profileOne);
-     });
+    });
+
+    it("should display an information message and log a debug message if no default profile is found", ()=> {
+        (child_process.spawnSync as any) = jest.fn((program: string, args: string[], options: any)=>{
+            return {
+                status: 0,
+                stdout: "",
+                stderr: "Error text"
+            };
+        });
+        loadDefaultProfile(log);
+        expect(showInformationMessage.mock.calls.length).toBe(1);
+        // expect(log.debug.mock.calls.length).toBe(1);
+    });
 });

--- a/__tests__/USSTree.test.ts
+++ b/__tests__/USSTree.test.ts
@@ -15,7 +15,7 @@ jest.mock("@brightside/imperative");
 jest.mock("@brightside/core/lib/zosfiles/src/api/methods/list/doc/IListOptions");
 jest.mock("Session");
 jest.mock("../src/ProfileLoader");
-import { Session } from "@brightside/imperative";
+import { Session, Logger } from "@brightside/imperative";
 import * as vscode from "vscode";
 import { USSTree } from "../src/USSTree";
 import { ZoweUSSNode } from "../src/ZoweUSSNode";
@@ -210,9 +210,11 @@ describe("Unit Tests (Jest)", () => {
      * Test the addSession command
      *************************************************************************************************************/
     it("Test the addSession command ", async () => {
-        testTree.addSession();
+        const log = new Logger(undefined);
 
-        testTree.addSession("fake");
+        testTree.addSession(log);
+
+        testTree.addSession(log, "fake");
     });
 
     /*************************************************************************************************************

--- a/__tests__/integrationTests/DatasetTree.test.ts
+++ b/__tests__/integrationTests/DatasetTree.test.ts
@@ -11,6 +11,7 @@
 
 // tslint:disable:no-magic-numbers
 import * as zowe from "@brightside/core";
+import { Logger } from "@brightside/imperative";
 // tslint:disable-next-line:no-implicit-dependencies
 import * as expect from "expect";
 import * as vscode from "vscode";
@@ -159,7 +160,8 @@ describe("DatasetTree Integration Tests", async () => {
      *************************************************************************************************************/
     it("Tests the addSession() function by adding a default, deleting, then adding a passed session", async () => {
         const len = testTree.mSessionNodes.length;
-        await testTree.addSession();
+        const log = new Logger(undefined);
+        await testTree.addSession(log);
         expect(testTree.mSessionNodes.length).toEqual(len + 1);
         testTree.deleteSession(testTree.mSessionNodes[len]);
         await testTree.addSession(testConst.profile.name);

--- a/__tests__/integrationTests/USSTree.test.ts
+++ b/__tests__/integrationTests/USSTree.test.ts
@@ -11,6 +11,7 @@
 
 // tslint:disable:no-magic-numbers
 import * as zowe from "@brightside/core";
+import { Logger } from "@brightside/imperative";
 import * as chai from "chai";
 import * as chaiAsPromised from "chai-as-promised";
 // tslint:disable-next-line:no-implicit-dependencies
@@ -162,7 +163,8 @@ describe("USSTree Integration Tests", async () => {
      *************************************************************************************************************/
     it("Tests the addSession() function by adding a default, deleting, then adding a passed session", async () => {
         const len = testTree.mSessionNodes.length;
-        await testTree.addSession();
+        const log = new Logger(undefined);
+        await testTree.addSession(log);
         expect(testTree.mSessionNodes.length).toEqual(len + 1);
         testTree.deleteSession(testTree.mSessionNodes[len]);
         await testTree.addSession(testConst.profile.name);

--- a/__tests__/zosjobs.test.ts
+++ b/__tests__/zosjobs.test.ts
@@ -15,7 +15,7 @@ jest.mock("@brightside/core");
 jest.mock("@brightside/imperative");
 import * as vscode from "vscode";
 import * as brightside from "@brightside/core";
-import { Session } from "@brightside/imperative";
+import { Session, Logger } from "@brightside/imperative";
 
 import * as profileLoader from "../src/ProfileLoader";
 import { Job, ZosJobsProvider } from "../src/zosjobs";
@@ -29,6 +29,7 @@ describe("Zos Jobs Unit Tests", () => {
     });
 
     describe("ZosJobsProvider Unit Test", () => {
+        const log = new Logger(undefined);
         const ZosmfSession = jest.fn();
         const createBasicZosmfSession = jest.fn();
 
@@ -118,7 +119,7 @@ describe("Zos Jobs Unit Tests", () => {
 
         it("should add the session to the tree", async () => {
             createBasicZosmfSession.mockReturnValue(session);
-            await testJobsProvider.addSession("fake");
+            await testJobsProvider.addSession(log, "fake");
             expect(testJobsProvider.mSessionNodes[0]).toBeDefined();
             expect(testJobsProvider.mSessionNodes[0].mLabel).toEqual("fake");
             expect(testJobsProvider.mSessionNodes[0].tooltip).toEqual("fake - owner: fake prefix: *");
@@ -132,7 +133,7 @@ describe("Zos Jobs Unit Tests", () => {
         it("should get the jobs of the session", async () => {
             createBasicZosmfSession.mockReturnValue(session);
             getJobsByOwnerAndPrefix.mockReturnValue([iJob, iJobComplete]);
-            await testJobsProvider.addSession("fake");
+            await testJobsProvider.addSession(log, "fake");
             const jobs = await testJobsProvider.mSessionNodes[0].getChildren();
             expect(jobs.length).toBe(2);
             expect(jobs[0].job.jobid).toEqual(iJob.jobid);

--- a/src/DatasetTree.ts
+++ b/src/DatasetTree.ts
@@ -13,7 +13,7 @@ import * as zowe from "@brightside/core";
 import * as path from "path";
 import * as vscode from "vscode";
 import { ZoweNode } from "./ZoweNode";
-import { IProfileLoaded } from "@brightside/imperative";
+import { IProfileLoaded, Logger } from "@brightside/imperative";
 import { loadNamedProfile, loadDefaultProfile } from "./ProfileLoader";
 
 /**
@@ -87,9 +87,9 @@ export class DatasetTree implements vscode.TreeDataProvider<ZoweNode> {
      *
      * @param {string} [sessionName] - optional; loads default profile if not passed
      */
-    public async addSession(sessionName?: string) {
+    public async addSession(log: Logger, sessionName?: string) {
         // Loads profile associated with passed sessionName, default if none passed
-        const zosmfProfile: IProfileLoaded = sessionName? loadNamedProfile(sessionName): loadDefaultProfile();
+        const zosmfProfile: IProfileLoaded = sessionName? loadNamedProfile(sessionName): loadDefaultProfile(log);
         // If session is already added, do nothing
         if (this.mSessionNodes.find((tempNode) => tempNode.mLabel === zosmfProfile.name)) {
             return;

--- a/src/ProfileLoader.ts
+++ b/src/ProfileLoader.ts
@@ -11,7 +11,8 @@
 
 import { spawnSync } from "child_process";
 import * as path from "path";
-import { IProfileLoaded } from "@brightside/imperative";
+import { IProfileLoaded, Logger } from "@brightside/imperative";
+import * as vscode from "vscode";
 
 /**
  * Load all profiles by spawning a script that uses the users' globally installed
@@ -52,7 +53,7 @@ export function loadNamedProfile(name: string): IProfileLoaded {
 /**
  * Load the default zosmf profile
  */
-export function loadDefaultProfile(): IProfileLoaded {
+export function loadDefaultProfile(log: Logger): IProfileLoaded {
     const getProfileProcess = spawnSync("node", [path.join(__dirname, "getDefaultProfile.js")]);
 
     if (getProfileProcess.status !== 0) {
@@ -60,9 +61,15 @@ export function loadDefaultProfile(): IProfileLoaded {
             getProfileProcess.stderr.toString());
     }
     if (getProfileProcess.stdout.toString().length === 0) {
-        throw new Error("Error attempting to load the default zosmf profile for Zowe CLI. Please " +
-            "ensure that you have created at least one profile with Zowe CLI " +
-            "before attempting to use this extension. Error text:" + getProfileProcess.stderr.toString());
+        const defaultProfileMessage = "No default zosmf profile found for Zowe CLI. A default zosmf " +
+            "profile created with Zowe CLI is required to use the Zowe extension. Please [create at least one profile " +
+            "with Zowe CLI](https://zowe.github.io/docs-site/latest/user-guide/cli-configuringcli.html#creating-zowe-cli-profiles).";
+        // Display info message to user
+        vscode.window.showInformationMessage(defaultProfileMessage);
+        // Include stack trace in debug log
+        log.debug(defaultProfileMessage + "Error text:" + getProfileProcess.stderr.toString());
+        // Keep from continuing
+        throw new Error();
     }
     return JSON.parse(getProfileProcess.stdout.toString());
 }

--- a/src/USSTree.ts
+++ b/src/USSTree.ts
@@ -10,7 +10,7 @@
 */
 
 import * as zowe from "@brightside/core";
-import { CliProfileManager, IProfileLoaded } from "@brightside/imperative";
+import { CliProfileManager, IProfileLoaded, Logger } from "@brightside/imperative";
 import * as os from "os";
 import * as path from "path";
 import * as vscode from "vscode";
@@ -89,9 +89,9 @@ export class USSTree implements vscode.TreeDataProvider<ZoweUSSNode> {
      *
      * @param {string} [sessionName] - optional; loads default profile if not passed
      */
-    public async addSession(sessionName?: string) {
+    public async addSession(log: Logger, sessionName?: string) {
         // Loads profile associated with passed sessionName, default if none passed
-        const zosmfProfile: IProfileLoaded = sessionName? loadNamedProfile(sessionName): loadDefaultProfile();
+        const zosmfProfile: IProfileLoaded = sessionName? loadNamedProfile(sessionName): loadDefaultProfile(log);
 
         // If session is already added, do nothing
         if (this.mSessionNodes.find((tempNode) => tempNode.mLabel === zosmfProfile.name)) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -78,10 +78,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
         // Initialize dataset provider with the created session and the selected pattern
         datasetProvider = new DatasetTree();
-        await datasetProvider.addSession();
+        await datasetProvider.addSession(log);
         // Initialize file provider with the created session and the selected fullPath
         ussFileProvider = new USSTree();
-        await ussFileProvider.addSession();
+        await ussFileProvider.addSession(log);
     } catch (err) {
         log.error("Error encountered while activating and initializing logger! " + JSON.stringify(err));
         vscode.window.showErrorMessage(err.message); // TODO MISSED TESTING
@@ -188,7 +188,7 @@ export async function activate(context: vscode.ExtensionContext) {
     try {
         // Initialize dataset provider with the created session and the selected pattern
         jobsProvider = new ZosJobsProvider();
-        await jobsProvider.addSession();
+        await jobsProvider.addSession(log);
     } catch (err) {
         vscode.window.showErrorMessage(err.message);
     }
@@ -494,7 +494,7 @@ export async function addSession(datasetProvider: DatasetTree) {
         const chosenProfile = await vscode.window.showQuickPick(profileNamesList, quickPickOptions);
         if (chosenProfile) {
             log.debug("User selected profile '%s'", chosenProfile);
-            await datasetProvider.addSession(chosenProfile);
+            await datasetProvider.addSession(log, chosenProfile);
         } else {
             log.debug("User cancelled profile selection");
         }
@@ -545,7 +545,7 @@ export async function addUSSSession(ussFileProvider: USSTree) {
         const chosenProfile = await vscode.window.showQuickPick(profileNamesList, quickPickOptions);
         if (chosenProfile) {
             log.debug("User selected profile '%s'", chosenProfile);
-            await ussFileProvider.addSession(chosenProfile);
+            await ussFileProvider.addSession(log, chosenProfile);
         } else {
             log.debug("User cancelled profile selection");
         }
@@ -877,7 +877,7 @@ export async function enterPattern(node: ZoweNode, datasetProvider: DatasetTree)
         // executing search from saved search in favorites
         pattern = node.mLabel.substring(node.mLabel.indexOf(":") + 2);  // TODO MISSED TESTING
         const session = node.mLabel.substring(node.mLabel.indexOf("[") + 1, node.mLabel.indexOf("]"));
-        await datasetProvider.addSession(session);
+        await datasetProvider.addSession(log, session);
         node = datasetProvider.mSessionNodes.find((tempNode) => tempNode.mLabel === session);
     }
 
@@ -1467,7 +1467,7 @@ export async function addJobsSession(datasetProvider: ZosJobsProvider) {
         const chosenProfile = await vscode.window.showQuickPick(profileNamesList, quickPickOptions);
         if (chosenProfile) {
             log.debug("User selected profile '%s'", chosenProfile);
-            await datasetProvider.addSession(chosenProfile);
+            await datasetProvider.addSession(log, chosenProfile);
         } else {
             log.debug("User cancelled profile selection");
         }

--- a/src/zosjobs.ts
+++ b/src/zosjobs.ts
@@ -11,7 +11,7 @@
 
 import * as vscode from "vscode";
 import * as zowe from "@brightside/core";
-import { Session, IProfileLoaded } from "@brightside/imperative";
+import { Session, IProfileLoaded, Logger } from "@brightside/imperative";
 // tslint:disable-next-line: no-duplicate-imports
 import { IJob, IJobFile } from "@brightside/core";
 import { loadNamedProfile, loadDefaultProfile } from "./ProfileLoader";
@@ -42,9 +42,9 @@ export class ZosJobsProvider implements vscode.TreeDataProvider<Job> {
      *
      * @param {string} [sessionName] - optional; loads default profile if not passed
      */
-    public async addSession(sessionName?: string) {
+    public async addSession(log: Logger, sessionName?: string) {
         // Loads profile associated with passed sessionName, default if none passed
-        const zosmfProfile: IProfileLoaded = sessionName? loadNamedProfile(sessionName): loadDefaultProfile();
+        const zosmfProfile: IProfileLoaded = sessionName? loadNamedProfile(sessionName): loadDefaultProfile(log);
 
         // If session is already added, do nothing
         if (this.mSessionNodes.find((tempNode) => tempNode.mLabel === zosmfProfile.name)) {


### PR DESCRIPTION
Addresses issue #133 (Massive error message when user has no Zowe profile defined)

**Summary:**
Replaces this massive error message:
![image (10)](https://user-images.githubusercontent.com/45975633/60744433-dfed3200-9f43-11e9-8e25-e907a25ff23e.png)

With this much more user-friendly information message:
<img width="452" alt="Screen Shot 2019-07-05 at 4 29 51 PM" src="https://user-images.githubusercontent.com/45975633/60744399-c1873680-9f43-11e9-9fd5-13686e4d8d32.png">

**Details:**
- The blue text links to Zowe's documentation on how to create a Zowe CLI profile: https://zowe.github.io/docs-site/latest/user-guide/cli-configuringcli.html#creating-zowe-cli-profiles
- If the user wishes to do additional debugging, the stack trace is now logged in zowe.log (where the rest of the Zowe VS Code extension's error/debug messages go).
- The main change in this PR is just in ProfileLoader.ts, but quite a few other files had to also be touched because adding logging for `loadDefaultProfile` requires passing the `log` object down multiple functions in different files, and updating their respective tests.