### PR TITLE
Fixed case of no default profile present, yet

### DIFF
--- a/__tests__/ProfileLoader.test.ts
+++ b/__tests__/ProfileLoader.test.ts
@@ -19,9 +19,9 @@ import { Logger } from "@brightside/imperative";
 import { loadNamedProfile, loadAllProfiles, loadDefaultProfile } from "../src/ProfileLoader";
 
 const showInformationMessage = jest.fn();
-Object.defineProperty(vscode.window, "showInformationMessage", {value: showInformationMessage});
+Object.defineProperty(vscode.window, "showInformationMessage", { value: showInformationMessage });
 
-describe("ProfileLoader", ()=>{
+describe("ProfileLoader", () => {
     // Mocking log.debug
     const log = new Logger(undefined);
     Object.defineProperty(log, "debug", {
@@ -30,28 +30,28 @@ describe("ProfileLoader", ()=>{
     const mockDebug = jest.spyOn(log, "debug");
 
     // Happy path profiles
-    const profileOne = {name: "profile1", profile: {}, type: "zosmf"};
-    const profileTwo = {name: "profile2", profile: {}, type: "zosmf"};
+    const profileOne = { name: "profile1", profile: {}, type: "zosmf" };
+    const profileTwo = { name: "profile2", profile: {}, type: "zosmf" };
 
-    (child_process.spawnSync as any) = jest.fn((program: string, args: string[], options: any)=>{
+    (child_process.spawnSync as any) = jest.fn((program: string, args: string[], options: any) => {
 
-        const createFakeChildProcess =(status: number, stdout: string, stderr: string) =>{
+        const createFakeChildProcess = (status: number, stdout: string, stderr: string) => {
             return {
                 status,
                 stdout: {
-                    toString : jest.fn(()=> {
+                    toString: jest.fn(() => {
                         return stdout;
                     })
                 },
                 stderr: {
-                    toString : jest.fn(()=>{
+                    toString: jest.fn(() => {
                         return stderr;
                     })
                 },
             };
         };
 
-        if (args[0].indexOf("getAllProfiles") >=0){
+        if (args[0].indexOf("getAllProfiles") >= 0) {
             return createFakeChildProcess(0, JSON.stringify([profileOne, profileTwo]), "");
         } else {
             // load default profile
@@ -59,38 +59,37 @@ describe("ProfileLoader", ()=>{
         }
     });
 
-    it("should return a named profile", ()=>{
+    it("should return a named profile", () => {
 
-       const loadedProfile = loadNamedProfile("profile1");
-       expect(loadedProfile).toEqual(profileOne);
+        const loadedProfile = loadNamedProfile("profile1");
+        expect(loadedProfile).toEqual(profileOne);
     });
 
-    it ("should return all profiles ", ()=>{
+    it("should return all profiles ", () => {
         const loadedProfiles = loadAllProfiles();
         expect(loadedProfiles).toEqual([profileOne, profileTwo]);
     });
 
-    it("should return a default profile", ()=>{
+    it("should return a default profile", () => {
 
         const loadedProfile = loadDefaultProfile(log);
         expect(loadedProfile).toEqual(profileOne);
     });
 
-    it("should display an information message and log a debug message if no default profile is found", ()=> {
+    it("should display an information message and log a debug message if no default profile is found", () => {
         showInformationMessage.mockReset();
         mockDebug.mockReset();
         // Create bad profile
-        (child_process.spawnSync as any) = jest.fn((program: string, args: string[], options: any)=>{
+        (child_process.spawnSync as any) = jest.fn((program: string, args: string[], options: any) => {
             return {
                 status: 0,
                 stdout: "",
                 stderr: "Error text"
             };
         });
-        // Expect loadDefaultProfile to throw an error
-        expect(()=> {
-            loadDefaultProfile(log);
-        }).toThrow();
+        // Expect loadDefaultProfile to return undefined
+        const loadedProfile = loadDefaultProfile(log);
+        expect(loadedProfile).toBeUndefined();
         // Test that the information and debug messages were called
         expect(showInformationMessage.mock.calls.length).toBe(1);
         expect(mockDebug.mock.calls.length).toBe(1);

--- a/src/DatasetTree.ts
+++ b/src/DatasetTree.ts
@@ -91,20 +91,22 @@ export class DatasetTree implements vscode.TreeDataProvider<ZoweNode> {
      */
     public async addSession(log: Logger, sessionName?: string) {
         // Loads profile associated with passed sessionName, default if none passed
-        const zosmfProfile: IProfileLoaded = sessionName? loadNamedProfile(sessionName): loadDefaultProfile(log);
-        // If session is already added, do nothing
-        if (this.mSessionNodes.find((tempNode) => tempNode.mLabel === zosmfProfile.name)) {
-            return;
+        const zosmfProfile: IProfileLoaded = sessionName ? loadNamedProfile(sessionName) : loadDefaultProfile(log);
+        if (zosmfProfile) {
+            // If session is already added, do nothing
+            if (this.mSessionNodes.find((tempNode) => tempNode.mLabel === zosmfProfile.name)) {
+                return;
+            }
+
+            // Uses loaded profile to create a zosmf session with brightside
+            const session = zowe.ZosmfSession.createBasicZosmfSession(zosmfProfile.profile);
+
+            // Creates ZoweNode to track new session and pushes it to mSessionNodes
+            const node = new ZoweNode(zosmfProfile.name, vscode.TreeItemCollapsibleState.Collapsed, null, session);
+            node.contextValue = "session";
+            this.mSessionNodes.push(node);
+            this.refresh();
         }
-
-        // Uses loaded profile to create a zosmf session with brightside
-        const session = zowe.ZosmfSession.createBasicZosmfSession(zosmfProfile.profile);
-
-        // Creates ZoweNode to track new session and pushes it to mSessionNodes
-        const node = new ZoweNode(zosmfProfile.name, vscode.TreeItemCollapsibleState.Collapsed, null, session);
-        node.contextValue = "session";
-        this.mSessionNodes.push(node);
-        this.refresh();
     }
 
     /**
@@ -137,16 +139,16 @@ export class DatasetTree implements vscode.TreeDataProvider<ZoweNode> {
                 this.mFavoriteSession, node.getSession());
             temp.contextValue = "sessionf";
             // add a command to execute the search
-            temp.command = {command: "zowe.pattern", title: "", arguments: [temp]};
+            temp.command = { command: "zowe.pattern", title: "", arguments: [temp] };
             const light = path.join(__dirname, "..", "..", "resources", "light", "pattern.svg");
             const dark = path.join(__dirname, "..", "..", "resources", "dark", "pattern.svg");
-            temp.iconPath = {light, dark};
+            temp.iconPath = { light, dark };
         } else {    // pds | ds
             temp = new ZoweNode("[" + node.getSessionNode().mLabel + "]: " + node.mLabel, node.collapsibleState,
                 this.mFavoriteSession, node.getSession());
             temp.contextValue += "f";
             if (temp.contextValue === "dsf") {
-                temp.command = {command: "zowe.ZoweNode.openPS", title: "", arguments: [temp]};
+                temp.command = { command: "zowe.ZoweNode.openPS", title: "", arguments: [temp] };
             }
         }
 

--- a/src/ProfileLoader.ts
+++ b/src/ProfileLoader.ts
@@ -30,10 +30,10 @@ export function loadAllProfiles(): IProfileLoaded[] {
     }
     if (getProfileProcess.stdout.toString().length === 0) {
         throw new Error(localize("loadAllProfiles.error.loadAll1",
-        "Error attempting to load all zosmf profiles.") +
-        localize("loadAllProfiles.error.loadAll2",
-        "Please ensure that you have created at least one profile with Zowe CLI before attempting to use this extension. Error text:")
-        + getProfileProcess.stderr.toString());
+            "Error attempting to load all zosmf profiles.") +
+            localize("loadAllProfiles.error.loadAll2",
+                "Please ensure that you have created at least one profile with Zowe CLI before attempting to use this extension. Error text:")
+            + getProfileProcess.stderr.toString());
     }
 
     return JSON.parse(getProfileProcess.stdout.toString());
@@ -70,13 +70,13 @@ export function loadDefaultProfile(log: Logger): IProfileLoaded {
             + localize("loadDefaultProfile.error.profile2", " A default zosmf profile created with Zowe CLI is required to use the Zowe extension.")
             + localize("loadDefaultProfile.error.profile3", " Please [create at least one profile with Zowe CLI]")
             + localize("loadDefaultProfile.error.profile4",
-                       "(https://zowe.github.io/docs-site/latest/user-guide/cli-configuringcli.html#creating-zowe-cli-profiles).");
+                "(https://zowe.github.io/docs-site/latest/user-guide/cli-configuringcli.html#creating-zowe-cli-profiles).");
         // Display info message to user
         vscode.window.showInformationMessage(defaultProfileMessage);
         // Include stack trace in debug log
         log.debug(defaultProfileMessage + localize("loadDefaultProfile.debug.errorText", "Error text:") + getProfileProcess.stderr.toString());
         // Keep from continuing
-        throw new Error();
+        return undefined;
     }
     return JSON.parse(getProfileProcess.stdout.toString());
 }


### PR DESCRIPTION
When no profile is defined at all it should not throw an error, but instead the addSession() method should do nothing.

Signed-off-by: Peter Haumer <phaumer@us.ibm.com>