### PR TITLE
trim for compares - Review first as other PR has version increment

### DIFF
--- a/src/DatasetTree.ts
+++ b/src/DatasetTree.ts
@@ -105,7 +105,7 @@ export class DatasetTree implements vscode.TreeDataProvider<ZoweNode> {
         const zosmfProfile: IProfileLoaded = sessionName ? loadNamedProfile(sessionName) : loadDefaultProfile(log);
         if (zosmfProfile) {
             // If session is already added, do nothing
-            if (this.mSessionNodes.find((tempNode) => tempNode.label === zosmfProfile.name)) {
+            if (this.mSessionNodes.find((tempNode) => tempNode.label.trim() === zosmfProfile.name)) {
                 return;
             }
 
@@ -128,8 +128,8 @@ export class DatasetTree implements vscode.TreeDataProvider<ZoweNode> {
      */
     public deleteSession(node: ZoweNode) {
         // Removes deleted session from mSessionNodes
-        this.mSessionNodes = this.mSessionNodes.filter((tempNode) => tempNode.label !== node.label);
-        this.refreshElement(node);
+        this.mSessionNodes = this.mSessionNodes.filter((tempNode) => tempNode.label.trim() !== node.label.trim());
+        this.refresh();
     }
 
     /**

--- a/src/USSTree.ts
+++ b/src/USSTree.ts
@@ -106,7 +106,7 @@ export class USSTree implements vscode.TreeDataProvider<ZoweUSSNode> {
         const zosmfProfile: IProfileLoaded = sessionName ? loadNamedProfile(sessionName) : loadDefaultProfile(log);
         if (zosmfProfile) {
             // If session is already added, do nothing
-            if (this.mSessionNodes.find((tempNode) => tempNode.label === zosmfProfile.name)) {
+            if (this.mSessionNodes.find((tempNode) => tempNode.label.trim() === zosmfProfile.name)) {
                 return;
             }
 
@@ -119,6 +119,7 @@ export class USSTree implements vscode.TreeDataProvider<ZoweUSSNode> {
             node.contextValue = "uss_session";
             node.iconPath = utils.applyIcons(node);
             this.mSessionNodes.push(node);
+            this.refresh();
         }
     }
 
@@ -129,8 +130,8 @@ export class USSTree implements vscode.TreeDataProvider<ZoweUSSNode> {
      */
     public deleteSession(node: ZoweUSSNode) {
         // Removes deleted session from mSessionNodes
-        this.mSessionNodes = this.mSessionNodes.filter((tempNode) => tempNode.label !== node.label);
-        this.refreshElement(node);
+        this.mSessionNodes = this.mSessionNodes.filter((tempNode) => tempNode.label.trim() !== node.label.trim());
+        this.refresh();
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Colin-Stone <30794003+Colin-Stone@users.noreply.github.com> Unfortunately the hack to force nodes to refresh is changing the label. This adds a blank or removes it from the label causing the node to repaint. The knock on effect is that every place you are doing a label compare you need a trim(). One place I had missed. 
Another consequence of this bug was that it indicated that when removing a session the node remained. The solution was to perform a higher level refresh.  