### PR TITLE
Check profile name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "vscode-extension-for-zowe" extension will be documented in this file.
 
+## 0.24.1
+
+- Fixed issue when saving USS files
+
 ## 0.24.0
 
 - Updated Localization Documentation and Added Update Dictionary Script. Thanks to @evannwu20

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-extension-for-zowe",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "publisher": "Zowe",
   "repository": {
     "url": "https://github.com/zowe/vscode-extension-for-zowe"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1485,7 +1485,7 @@ export async function saveUSSFile(doc: vscode.TextDocument, ussFileProvider: USS
     // get session from session name
     let documentSession;
     let binary;
-    const sesNode = (await ussFileProvider.mSessionNodes.find((child) => child.label.trim()=== sesName.trim()));
+    const sesNode = (await ussFileProvider.mSessionNodes.find((child) => child.mProfileName && child.mProfileName.trim()=== sesName.trim()));
     if (sesNode) {
         documentSession = sesNode.getSession();
         binary = Object.keys(sesNode.binaryFiles).find((child) => child === remote) !== undefined;


### PR DESCRIPTION
Signed-off-by: Colin-Stone <30794003+Colin-Stone@users.noreply.github.com>

Issue caused while rationalizing the number of duplicated fields. In USS files the session label has the filter path alongside it. So in this case only the duplicated mLabel and label fields were not the same.

This will be a quick fix for now and I intend to completely review the duplicated fields as another Issue