### PR TITLE
Separate out test from main extensions

### DIFF
--- a/__tests__/__integration__/extension.integration.test.ts
+++ b/__tests__/__integration__/extension.integration.test.ts
@@ -74,25 +74,6 @@ describe("Extension Integration Tests", () => {
         await vscode.workspace.getConfiguration().update("Zowe-Persistent-Favorites", oldSettings, vscode.ConfigurationTarget.Global);
     });
 
-    describe("TreeView", () => {
-        it("should create the TreeView", async () => {
-            // Initialize dataset provider
-            const datasetProvider = new DatasetTree();
-
-            // Create the TreeView using datasetProvider to create tree structure
-            const testTreeView = vscode.window.createTreeView("zowe.explorer", {treeDataProvider: datasetProvider});
-
-            const allNodes = await getAllNodes(datasetProvider.mSessionNodes);
-            for (const node of allNodes) {
-                // For each node, select that node in TreeView by calling reveal()
-                await testTreeView.reveal(node);
-                // Test that the node is successfully selected
-                expect(node).to.deep.equal(testTreeView.selection[0]);
-            }
-            testTreeView.dispose();
-        }).timeout(TIMEOUT);
-    });
-
     describe("Creating a Session", () => {
         it("should add a session", async () => {
             // Grab profiles
@@ -693,6 +674,27 @@ describe("Extension Integration Tests - USS", () => {
             await extension.saveUSSFile(doc, ussTestTree);
         }).timeout(TIMEOUT);
     });
+});
+
+describe("TreeView", () => {
+    const expect = chai.expect;
+    chai.use(chaiAsPromised);
+
+    it("should create the TreeView", async () => {
+        // Initialize dataset provider
+        const datasetProvider = new DatasetTree();
+        // Create the TreeView using datasetProvider to create tree structure
+        const testTreeView = vscode.window.createTreeView("zowe.explorer", {treeDataProvider: datasetProvider});
+
+        const allNodes = await getAllNodes(datasetProvider.mSessionNodes);
+        for (const node of allNodes) {
+            // For each node, select that node in TreeView by calling reveal()
+            await testTreeView.reveal(node);
+            // Test that the node is successfully selected
+            expect(node).to.deep.equal(testTreeView.selection[0]);
+        }
+        testTreeView.dispose();
+    }).timeout(TIMEOUT);
 });
 
 /*************************************************************************************************************


### PR DESCRIPTION
Signed-off-by: Colin-Stone <30794003+Colin-Stone@users.noreply.github.com>
Issue seems to be that there are conflicts between tree views set up in the before sections and running in it sections. This fix has separated out the problem dataset test but the real solution is about moving the tests out of this monolithic file. 

I am intending to do that anyway as part of the restructuring. The USS equivalent test is passing simply because it isn't working correctly and testing what is needed. It ain't broke so I didn't fix it but will look at it again when I restructure the tests

Fixes #237 