### PR TITLE
Update documentation URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ The VSC Extension for Zowe is powered by [Zowe CLI](https://zowe.org/home/). The
 
 After you install the Zowe extension, meet the following prerequisites:
 
-* [Install Zowe CLI](https://zowe.github.io/docs-site/latest/user-guide/cli-installcli.html#methods-to-install-zowe-cli) on your PC.
+* [Install Zowe CLI](https://docs.zowe.org/stable/user-guide/cli-installcli.html#methods-to-install-zowe-cli) on your PC.
   
 > **Important!**: To use the VSC Extension for Zowe, you must install Zowe CLI version `2.0.0` or later.
 
-* [Create at least one Zowe CLI 'zosmf' profile](https://zowe.github.io/docs-site/latest/user-guide/cli-configuringcli.html#creating-zowe-cli-profiles).
+* [Create at least one Zowe CLI 'zosmf' profile](https://docs.zowe.org/stable/user-guide/cli-configuringcli.html#creating-zowe-cli-profiles).
 
 ## Configuration and usage tips
 

--- a/i18n/sample/src/ProfileLoader.i18n.json
+++ b/i18n/sample/src/ProfileLoader.i18n.json
@@ -8,6 +8,6 @@
     "loadDefaultProfile.error.profile1": "No default zosmf profile found for Zowe CLI.",
     "loadDefaultProfile.error.profile2": " A default zosmf profile created with Zowe CLI is required to use the Zowe extension.",
     "loadDefaultProfile.error.profile3": " Please [create at least one profile with Zowe CLI]",
-    "loadDefaultProfile.error.profile4": "(https://zowe.github.io/docs-site/latest/user-guide/cli-configuringcli.html#creating-zowe-cli-profiles).",
+    "loadDefaultProfile.error.profile4": "(https://docs.zowe.org/stable/user-guide/cli-configuringcli.html#creating-zowe-cli-profiles).",
     "loadDefaultProfile.debug.errorText": "Error text:"
 }

--- a/src/ProfileLoader.ts
+++ b/src/ProfileLoader.ts
@@ -71,7 +71,7 @@ export function loadDefaultProfile(log: Logger): IProfileLoaded {
             + localize("loadDefaultProfile.error.profile2", " A default zosmf profile created with Zowe CLI is required to use the Zowe extension.")
             + localize("loadDefaultProfile.error.profile3", " Please [create at least one profile with Zowe CLI]")
             + localize("loadDefaultProfile.error.profile4",
-                "(https://zowe.github.io/docs-site/latest/user-guide/cli-configuringcli.html#creating-zowe-cli-profiles).");
+                "(https://docs.zowe.org/stable/user-guide/cli-configuringcli.html#creating-zowe-cli-profiles).");
         // Display info message to user
         vscode.window.showInformationMessage(defaultProfileMessage);
         // Include stack trace in debug log


### PR DESCRIPTION
Signed-off-by: Lauren Li <Lauren.Li@ibm.com>

Related to issues #155 (No default zosmf profile found for ZOWE CLI) and #133 (Massive error message when user has no Zowe profile defined):
- Provides updated documentation links for creating a Zowe CLI profile
- Provides updated install instructions for Zowe CLI on the PC.