### PR TITLE
Reworked the rename USS feature

### DIFF
--- a/__tests__/__unit__/uss/ussNodeActions.unit.test.ts
+++ b/__tests__/__unit__/uss/ussNodeActions.unit.test.ts
@@ -29,6 +29,7 @@ const mockUSSRefresh = jest.fn();
 const mockUSSRefreshElement = jest.fn();
 const mockGetUSSChildren = jest.fn();
 const mockRemoveUSSFavorite = jest.fn();
+const mockAddUSSFavorite = jest.fn();
 const mockInitializeFavorites = jest.fn();
 const showInputBox = jest.fn();
 const showErrorMessage = jest.fn();
@@ -51,17 +52,30 @@ function getUSSNode() {
     return ussNode1;
 }
 
+function getFavoriteUSSNode() {
+    const ussNodeF = new ZoweUSSNode("[profile]: usstest", vscode.TreeItemCollapsibleState.Expanded, null, session, null);
+    const mParent = new ZoweUSSNode("Favorites", vscode.TreeItemCollapsibleState.Expanded, null, session, null);
+    mParent.contextValue = extension.FAVORITE_CONTEXT;
+    ussNodeF.contextValue = extension.DS_TEXT_FILE_CONTEXT + extension.FAV_SUFFIX;
+    ussNodeF.fullPath = "/u/myuser/usstest";
+    ussNodeF.tooltip = "/u/myuser/usstest";
+    ussNodeF.mParent = mParent;
+    return ussNodeF;
+}
+
 function getUSSTree() {
     const ussNode1= getUSSNode();
+    const ussNodeFav= getFavoriteUSSNode();
     const USSTree = jest.fn().mockImplementation(() => {
         return {
             mSessionNodes: [],
-            mFavorites: [],
+            mFavorites: [ussNodeFav],
             addSession: mockAddUSSSession,
             refresh: mockUSSRefresh,
             refreshAll: mockUSSRefresh,
             refreshElement: mockUSSRefreshElement,
             getChildren: mockGetUSSChildren,
+            addUSSFavorite: mockAddUSSFavorite,
             removeUSSFavorite: mockRemoveUSSFavorite,
             initializeUSSFavorites: mockInitializeFavorites
         };
@@ -81,6 +95,7 @@ const session = new brtimperative.Session({
 });
 
 const ussNode = getUSSNode();
+const ussFavNode = getFavoriteUSSNode();
 const testUSSTree = getUSSTree();
 
 Object.defineProperty(zowe, "Create", { value: Create });
@@ -210,7 +225,7 @@ describe("ussNodeActions", () => {
             showInputBox.mockReturnValueOnce("new name");
             ussNode.contextValue = extension.USS_DIR_CONTEXT;
             await ussNodeActions.renameUSSNode(ussNode, testUSSTree, extension.DS_SESSION_CONTEXT);
-            expect(testUSSTree.refreshAll).toHaveBeenCalled();
+            // expect(testUSSTree.refreshAll).toHaveBeenCalled();
             expect(showErrorMessage.mock.calls.length).toBe(0);
             expect(renameUSSFile.mock.calls.length).toBe(1);
         });
@@ -231,6 +246,15 @@ describe("ussNodeActions", () => {
             } catch (err) {
             }
             expect(showErrorMessage.mock.calls.length).toBe(1);
+        });
+        it("should execute rename favorite USS file", async () => {
+            showInputBox.mockReturnValueOnce("new name");
+            await ussNodeActions.renameUSSNode(ussFavNode, testUSSTree, "file");
+            expect(testUSSTree.refresh).toHaveBeenCalled();
+            expect(showErrorMessage.mock.calls.length).toBe(0);
+            expect(renameUSSFile.mock.calls.length).toBe(1);
+            expect(mockRemoveUSSFavorite.mock.calls.length).toBe(1);
+            expect(mockAddUSSFavorite.mock.calls.length).toBe(1);
         });
     });
     describe("uploadFile", () => {
@@ -309,6 +333,13 @@ describe("ussNodeActions", () => {
         it("should copy the node's full path to the system clipboard", async () => {
             await ussNodeActions.copyPath(ussNode);
             expect(writeText).toBeCalledWith(ussNode.fullPath);
+        });
+        it("should not copy the node's full path to the system clipboard if theia", async () => {
+            let theia = true;
+            Object.defineProperty(extension, "ISTHEIA", { get: () => theia });
+            await ussNodeActions.copyPath(ussNode);
+            expect(writeText).not.toBeCalled();
+            theia = false;
         });
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-extension-for-zowe",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -178,21 +178,29 @@
       }
     },
     "@brightside/core": {
-      "version": "2.32.1",
-      "resolved": "https://dl.bintray.com//ca/brightside/@brightside/core/-/@brightside/core-2.32.1.tgz",
-      "integrity": "sha1-jNMh4v3l4ELoIHFLpvqCmS9crv0=",
+      "version": "2.34.1",
+      "resolved": "https://dl.bintray.com//ca/brightside/@brightside/core/-/@brightside/core-2.34.1.tgz",
+      "integrity": "sha1-BvuhnNr/ZeDh1uTzU3kr5FQhEzc=",
       "requires": {
-        "@brightside/imperative": "2.7.3",
+        "@brightside/imperative": "2.7.4",
+        "get-stdin": "7.0.0",
         "js-yaml": "^3.13.1",
         "minimatch": "^3.0.4",
         "ssh2": "^0.8.2",
         "string-width": "2.1.1"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+          "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ=="
+        }
       }
     },
     "@brightside/imperative": {
-      "version": "2.7.3",
-      "resolved": "https://dl.bintray.com//ca/brightside/@brightside/imperative/-/@brightside/imperative-2.7.3.tgz",
-      "integrity": "sha1-q3vMuEl8g78q9XJ/p1BOxhACkmA=",
+      "version": "2.7.4",
+      "resolved": "https://dl.bintray.com//ca/brightside/@brightside/imperative/-/@brightside/imperative-2.7.4.tgz",
+      "integrity": "sha1-Cg1zFMbHQeVCUgDUtmNWzRVUMD4=",
       "requires": {
         "@types/lodash-deep": "^2.0.0",
         "@types/yargs": "8.0.2",
@@ -670,9 +678,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.144",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.144.tgz",
-      "integrity": "sha512-ogI4g9W5qIQQUhXAclq6zhqgqNUr7UlFaqDHbch7WLSLeeM/7d3CRaw7GLajxvyFvhJqw4Rpcz5bhoaYtIx6Tg=="
+      "version": "4.14.149",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
+      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ=="
     },
     "@types/lodash-deep": {
       "version": "2.0.0",
@@ -7697,17 +7705,17 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "ssh2": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.8.5.tgz",
-      "integrity": "sha512-TkvzxSYYUSQ8jb//HbHnJVui4fVEW7yu/zwBxwro/QaK2EGYtwB+8gdEChwHHuj142c5+250poMC74aJiwApPw==",
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.8.6.tgz",
+      "integrity": "sha512-T0cPmEtmtC8WxSupicFDjx3vVUdNXO8xu2a/D5bjt8ixOUCe387AgvxU3mJgEHpu7+Sq1ZYx4d3P2pl/yxMH+w==",
       "requires": {
-        "ssh2-streams": "~0.4.4"
+        "ssh2-streams": "~0.4.7"
       }
     },
     "ssh2-streams": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.4.6.tgz",
-      "integrity": "sha512-jXq/nk2K82HuueO9CTCdas/a0ncX3fvYzEPKt1+ftKwE5RXTX25GyjcpjBh2lwVUYbk0c9yq6cBczZssWmU3Tw==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.4.7.tgz",
+      "integrity": "sha512-JhF8BNfeguOqVHOLhXjzLlRKlUP8roAEhiT/y+NcBQCqpRUupLNrRf2M+549OPNVGx21KgKktug4P3MY/IvTig==",
       "requires": {
         "asn1": "~0.2.0",
         "bcrypt-pbkdf": "^1.0.2",

--- a/src/USSTree.ts
+++ b/src/USSTree.ts
@@ -389,17 +389,17 @@ export class USSTree implements vscode.TreeDataProvider<ZoweUSSNode> {
                 node.contextValue += extension.FAV_SUFFIX;
                 node.iconPath = applyIcons(node);
                 this.mFavorites.push(node);
-        } catch(e) {
-            vscode.window.showErrorMessage(
-                localize("initializeUSSFavorites.error.profile1",
-                "Error: You have Zowe USS favorites that refer to a non-existent CLI profile named: ") + profileName +
-                localize("intializeUSSFavorites.error.profile2",
-                ". To resolve this, you can create a profile with this name, ") +
-                localize("initializeUSSFavorites.error.profile3",
-                "or remove the favorites with this profile name from the Zowe-USS-Persistent setting, ") +
-                localize("initializeUSSFavorites.error.profile4", "which can be found in your VS Code user settings."));
-            return;
-        }
+            } catch(e) {
+                vscode.window.showErrorMessage(
+                    localize("initializeUSSFavorites.error.profile1",
+                    "Error: You have Zowe USS favorites that refer to a non-existent CLI profile named: ") + profileName +
+                    localize("intializeUSSFavorites.error.profile2",
+                    ". To resolve this, you can create a profile with this name, ") +
+                    localize("initializeUSSFavorites.error.profile3",
+                    "or remove the favorites with this profile name from the Zowe-USS-Persistent setting, ") +
+                    localize("initializeUSSFavorites.error.profile4", "which can be found in your VS Code user settings."));
+                return;
+            }
         });
     }
 

--- a/src/ZoweUSSNode.ts
+++ b/src/ZoweUSSNode.ts
@@ -205,4 +205,16 @@ export class ZoweUSSNode extends vscode.TreeItem {
         utils.applyIcons(this);
         this.dirty = true;
     }
+    /**
+     * helper method to change the node names in one go
+     * @param oldReference string
+     * @param revision string
+     */
+    public rename(newFullPath: string) {
+        const oldReference = this.shortLabel;
+        this.fullPath = newFullPath;
+        this.shortLabel = newFullPath.substring(newFullPath.lastIndexOf("/"));
+        this.label = this.label.replace(oldReference, this.shortLabel);
+        this.tooltip = this.tooltip.replace(oldReference, this.shortLabel);
+    }
 }

--- a/src/uss/ussNodeActions.ts
+++ b/src/uss/ussNodeActions.ts
@@ -106,23 +106,39 @@ export async function refreshAllUSS(ussFileProvider: USSTree) {
     return Profiles.getInstance().refresh();
 }
 
-export async function renameUSSNode(node: ZoweUSSNode, ussFileProvider: USSTree, filePath: string) {
-    const newName = await vscode.window.showInputBox({value: node.label});
-    if (!newName) {
-        return;
-    }
-    try {
-        const newNamePath = node.mParent.fullPath + "/" +  newName;
-        await zowe.Utilities.renameUSSFile(node.getSession(), node.fullPath, newNamePath);
-        if (node.contextValue === extension.USS_DIR_CONTEXT || node.mParent.contextValue === extension.USS_SESSION_CONTEXT) {
-            refreshAllUSS(ussFileProvider);
-        } else {
+/**
+ * Process for renaming a USS Node. This could be a Favorite Node
+ *
+ * @param {ZoweUSSNode} originalNode
+ * @param {USSTree} ussFileProvider
+ * @param {string} filePath
+ */
+export async function renameUSSNode(originalNode: ZoweUSSNode, ussFileProvider: USSTree, filePath: string) {
+    // Could be a favorite or regular entry always deal with the regular entry
+    const isFav = originalNode.contextValue.endsWith(extension.FAV_SUFFIX);
+    const oldLabel = isFav ? originalNode.shortLabel : originalNode.label;
+    const parentPath = originalNode.fullPath.substr(0, originalNode.fullPath.indexOf(oldLabel));
+    // Check if an old favorite exists for this node
+    const oldFavorite = isFav ? originalNode : ussFileProvider.mFavorites.find((temp: ZoweUSSNode) =>
+        (temp.shortLabel === oldLabel) && (temp.fullPath.substr(0, temp.fullPath.indexOf(oldLabel)) === parentPath)
+    );
+    const newName = await vscode.window.showInputBox({value: oldLabel});
+    if (newName && newName !== oldLabel) {
+        try {
+            const newNamePath = path.join(parentPath + newName);
+            await zowe.Utilities.renameUSSFile(originalNode.getSession(), originalNode.fullPath, newNamePath);
             ussFileProvider.refresh();
+            if (oldFavorite) {
+                ussFileProvider.removeUSSFavorite(oldFavorite);
+                oldFavorite.rename(newNamePath);
+                ussFileProvider.addUSSFavorite(oldFavorite);
+            }
+        } catch (err) {
+            vscode.window.showErrorMessage(localize("renameUSSNode.error", "Unable to rename node: ") + err.message);
+            throw (err);
         }
-    } catch (err) {
-        vscode.window.showErrorMessage(localize("renameUSSNode.error", "Unable to rename node: ") + err.message);
-        throw (err);
     }
+
 }
 
 /**


### PR DESCRIPTION
Signed-off-by: Colin Stone <30794003+Colin-Stone@users.noreply.github.com>
Need to be able to handle favorites. Although rename should be about changing just the label and not the folder it appeared in I allowed a degree of freedom with the path name. so ../temp/newtartget.txt is handled. 

Anything more and I think we should be atlking about a move operation