### PR TITLE
Add node.js req, other minor edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Ensure that you meet the following prerequisites before using the extension:
 * Configure IBM z/OSMF REST services, including TSO/E address space services, z/OS data set and file REST interface, and z/OS jobs REST interface. For more information, see [z/OS Requirements](https://docs.zowe.org/stable/user-guide/systemrequirements-zosmf.html#z-os-requirements).
 * [Install Zowe CLI](https://docs.zowe.org/stable/user-guide/cli-installcli.html).
 * Create at least one Zowe CLI `zosmf` profile.
-* Install Node.js v8.0 or higher. Issue the command `node -v` to check if Node.js is already installed. 
+* Install Node.js v8.0 or higher. Issue the command `node -v` to check if Node.js is already installed.
 
 **Notes:**
 

--- a/README.md
+++ b/README.md
@@ -14,17 +14,19 @@ Zowe&trade; Explorer extension modernizes the way developers and system administ
 
 ## Contents
 
-* [Prerequisites](#prerequisites)
+* [Software Requirements](#software-requirements)
 * [Create a Zowe CLI z/OSMF profile](#create-a-zowe-cli-z/osmf-profile)
 * [Usage tips](#usage-tips)
 * [Sample use cases](#sample-use-cases)
 
-## Prerequisites
+## Software Requirements
 
 Ensure that you meet the following prerequisites before using the extension:
 
-* Configured TSO/E address space services, z/OS data set and file REST interface, and z/OS jobs REST interface. For more information, see [z/OS Requirements](https://docs.zowe.org/stable/user-guide/systemrequirements-zosmf.html#z-os-requirements).
-* Zowe CLI `zosmf` profile.
+* Configure IBM z/OSMF REST services, including TSO/E address space services, z/OS data set and file REST interface, and z/OS jobs REST interface. For more information, see [z/OS Requirements](https://docs.zowe.org/stable/user-guide/systemrequirements-zosmf.html#z-os-requirements).
+* [Install Zowe CLI](https://docs.zowe.org/stable/user-guide/cli-installcli.html).
+* Create at least one Zowe CLI `zosmf` profile.
+* Install Node.js v8.0 or higher. Issue the command `node -v` to check if Node.js is already installed. 
 
 **Notes:**
 


### PR DESCRIPTION
@zFernand0 pointed out that there are some cases where a user can have Zowe CLI installed, but not have Node.js installed. For this reason, it's worth mentioning Node.js as a separate requirement in the readme. 

Also changed the word "Prerequisites" to "Software Requirements" (we've been using the latter in other docs), and separated out the "install cli" and "create a profile" reqs. 

Signed-off-by: BrandonJenkins14 <36675406+BrandonJenkins14@users.noreply.github.com>