### PR TITLE
Broken test erratic results

### DIFF
--- a/__tests__/__integration__/USSTree.integration.test.ts
+++ b/__tests__/__integration__/USSTree.integration.test.ts
@@ -182,12 +182,16 @@ describe("USSTree Integration Tests", async () => {
      * Tests the deleteSession() function
      *************************************************************************************************************/
     it("Tests the addSession() function by adding a default, deleting, then adding a passed session", async () => {
-        const len = testTree.mSessionNodes.length;
+        let len = testTree.mSessionNodes.length;
         const log = new Logger(undefined);
         await testTree.addSession();
-        expect(testTree.mSessionNodes.length).toEqual(len + 1);
-        testTree.deleteSession(testTree.mSessionNodes[len]);
-        await testTree.addSession(testConst.profile.name);
+        expect(testTree.mSessionNodes.length).toBeGreaterThanOrEqual(len + 1);
+        len = testTree.mSessionNodes.length;
+        const testNode = testTree.mSessionNodes[len - 1];
+        testTree.deleteSession(testNode);
+        len--;
+        expect(testTree.mSessionNodes.length).toEqual(len);
+        await testTree.addSession(testNode.label);
         expect(testTree.mSessionNodes.length).toEqual(len + 1);
     }).timeout(TIMEOUT);
 

--- a/src/USSTree.ts
+++ b/src/USSTree.ts
@@ -122,10 +122,10 @@ export class USSTree implements vscode.TreeDataProvider<ZoweUSSNode> {
     /**
      * Adds a new session to the uss files tree
      *
-     * @param {string} [sessionName] - optional; loads default profile if not passed
+     * @param {string} [sessionName] - optional; loads persisted profiles or default if not passed
      */
     public async addSession(sessionName?: string) {
-        // Loads profile associated with passed sessionName, default if none passed
+        // Loads profile associated with passed sessionName, persisted profiles or default if none passed
         if (sessionName) {
             const zosmfProfile: IProfileLoaded = Profiles.getInstance().loadNamedProfile(sessionName);
             if (zosmfProfile) {


### PR DESCRIPTION
Signed-off-by: Colin Stone <30794003+Colin-Stone@users.noreply.github.com>
Tes relied on settings.json not having persisted entries or maybe one at most. This fix changes the logic in the test to remove a profile that has been added automatically and then adds it back again