### PR TITLE
Remove duplicate commands

### DIFF
--- a/__tests__/__unit__/__snapshots__/extension.unit.test.ts.snap
+++ b/__tests__/__unit__/__snapshots__/extension.unit.test.ts.snap
@@ -154,11 +154,6 @@ Array [
   },
   Object {
     "command": "zowe.refreshNode",
-    "group": "inline",
-    "when": "view == zowe.explorer && viewItem == member_fav",
-  },
-  Object {
-    "command": "zowe.refreshNode",
     "group": "0_mainframeInteraction",
     "when": "view == zowe.explorer && viewItem == member_fav",
   },
@@ -176,16 +171,6 @@ Array [
     "command": "zowe.renameDataSetMember",
     "group": "6_modification@2",
     "when": "view == zowe.explorer && viewItem == member",
-  },
-  Object {
-    "command": "zowe.renameDataSetMember",
-    "group": "6_modification@2",
-    "when": "view == zowe.explorer && viewItem == member_fav",
-  },
-  Object {
-    "command": "zowe.refreshNode",
-    "group": "inline",
-    "when": "view == zowe.explorer && viewItem == ds",
   },
   Object {
     "command": "zowe.renameDataSetMember",
@@ -226,21 +211,6 @@ Array [
     "command": "zowe.renameDataSet",
     "group": "6_modification@2",
     "when": "view == zowe.explorer && viewItem == ds",
-  },
-  Object {
-    "command": "zowe.copyDataSet",
-    "group": "9_cutcopypaste",
-    "when": "view == zowe.explorer && viewItem == ds",
-  },
-  Object {
-    "command": "zowe.pasteDataSet",
-    "group": "9_cutcopypaste",
-    "when": "view == zowe.explorer && viewItem == ds",
-  },
-  Object {
-    "command": "zowe.refreshNode",
-    "group": "inline",
-    "when": "view == zowe.explorer && viewItem == ds_fav",
   },
   Object {
     "command": "zowe.copyDataSet",

--- a/package.json
+++ b/package.json
@@ -561,11 +561,6 @@
         {
           "when": "view == zowe.explorer && viewItem == member_fav",
           "command": "zowe.refreshNode",
-          "group": "inline"
-        },
-        {
-          "when": "view == zowe.explorer && viewItem == member_fav",
-          "command": "zowe.refreshNode",
           "group": "0_mainframeInteraction"
         },
         {
@@ -582,16 +577,6 @@
           "when": "view == zowe.explorer && viewItem == member",
           "command": "zowe.renameDataSetMember",
           "group": "6_modification@2"
-        },
-        {
-          "when": "view == zowe.explorer && viewItem == member_fav",
-          "command": "zowe.renameDataSetMember",
-          "group": "6_modification@2"
-        },
-        {
-          "when": "view == zowe.explorer && viewItem == ds",
-          "command": "zowe.refreshNode",
-          "group": "inline"
         },
         {
           "when": "view == zowe.explorer && viewItem == member_fav",
@@ -632,21 +617,6 @@
           "when": "view == zowe.explorer && viewItem == ds",
           "command": "zowe.renameDataSet",
           "group": "6_modification@2"
-        },
-        {
-          "when": "view == zowe.explorer && viewItem == ds",
-          "command": "zowe.copyDataSet",
-          "group": "9_cutcopypaste"
-        },
-        {
-          "when": "view == zowe.explorer && viewItem == ds",
-          "command": "zowe.pasteDataSet",
-          "group": "9_cutcopypaste"
-        },
-        {
-          "when": "view == zowe.explorer && viewItem == ds_fav",
-          "command": "zowe.refreshNode",
-          "group": "inline"
         },
         {
           "when": "view == zowe.explorer && viewItem == ds",


### PR DESCRIPTION
This PR addresses issue #369 ("Copy Data Set" and "Paste Data Set" listed twice in Data Set context menu):
- Remove duplicate commands 
- Update unit test snapshot for menu items