### PR TITLE
Add Label hack

### DIFF
--- a/src/ZosJobsProvider.ts
+++ b/src/ZosJobsProvider.ts
@@ -24,7 +24,8 @@ import {
     FilterDescriptor,
     getAppName,
     resolveQuickPickHelper,
-    sortTreeItems
+    sortTreeItems,
+    labelHack
 } from "./utils";
 import { IZoweTree } from "./ZoweTree";
 import * as extension from "../src/extension";
@@ -497,12 +498,12 @@ export class ZosJobsProvider implements IZoweTree<Job> {
                 }
                 this.applySearchLabelToNode(node, searchCriteria);
             }
-            this.addHistory(searchCriteria);
-
             node.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
             node.iconPath = applyIcons(node.getSessionNode(), extension.ICON_STATE_OPEN);
+            labelHack(node);
             node.dirty = true;
             this.refreshElement(node);
+            this.addHistory(searchCriteria);
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Colin Stone <30794003+Colin-Stone@users.noreply.github.com>
Added the rather horrible labelHack to the Jobs tree so that the session node will have the label subtley changed and therefore vscode decides to refresh it. Without this VSCode thinks it's the same object that hasn't changed so would only refresh if manually pressing the expand button.