### PR TITLE
Added spawn mechanism back to create .zowe if missing

### DIFF
--- a/__tests__/__unit__/extension.unit.test.ts
+++ b/__tests__/__unit__/extension.unit.test.ts
@@ -21,6 +21,7 @@ import * as brightside from "@brightside/core";
 import * as os from "os";
 import * as fs from "fs";
 import * as fsextra from "fs-extra";
+import * as child_process from "child_process";
 import * as profileLoader from "../../src/Profiles";
 import * as ussNodeActions from "../../src/uss/ussNodeActions";
 import { Job } from "../../src/ZoweJobNode";
@@ -150,6 +151,7 @@ describe("Extension Unit Tests", () => {
     const mockReveal = jest.fn();
     const createWebviewPanel = jest.fn();
     const createTreeView = jest.fn();
+    const spawnSync = jest.fn();
     const pathMock = jest.fn();
     const registerCommand = jest.fn();
     const onDidSaveTextDocument = jest.fn();
@@ -385,6 +387,7 @@ describe("Extension Unit Tests", () => {
     Object.defineProperty(fs, "rmdirSync", {value: rmdirSync});
     Object.defineProperty(fs, "readFileSync", {value: readFileSync});
     Object.defineProperty(fsextra, "moveSync", {value: moveSync});
+    Object.defineProperty(child_process, "spawnSync", {value: spawnSync});
     Object.defineProperty(vscode.window, "showErrorMessage", {value: showErrorMessage});
     Object.defineProperty(vscode.window, "showWarningMessage", {value: showWarningMessage});
     Object.defineProperty(vscode.window, "showInputBox", {value: showInputBox});
@@ -577,6 +580,7 @@ describe("Extension Unit Tests", () => {
         } as vscode.ExtensionContext));
         const mock = new extensionMock();
         readFileSync.mockReturnValueOnce('{ "overrides": { "CredentialManager": "Managed by ANO" }}');
+        spawnSync.mockReturnValue({status: 0});
 
         await extension.activate(mock);
 

--- a/i18n/sample/src/extension.i18n.json
+++ b/i18n/sample/src/extension.i18n.json
@@ -9,6 +9,7 @@
     "activate.didSaveText.file": "File ",
     "activate.didSaveText.notDataSet": " is not a data set or USS file ",
     "profile.init.read.imperative": "Unable to read imperative file. ",
+    "loadAllProfiles.error.spawnProcess": "Failed to spawn process to retrieve inititalize Zowe CLI!\n",
     "initialize.module.load": "Credentials not managed, unable to load security file: ",
     "moveTempFolder.error": "Error encountered when creating temporary folder! ",
     "downloadSpool.select": "Select",

--- a/src/ImperativeInit.ts
+++ b/src/ImperativeInit.ts
@@ -1,0 +1,25 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { Imperative } from "@brightside/imperative";
+import * as path from "path";
+
+/**
+ * Run Imperative.init() to create a ~/.zowe directory if not present
+ */
+(async () => {
+    const mainZoweDir = path.join(require.resolve("@brightside/core"), "..", "..", "..", "..");
+    // we have to mock a few things to get the Imperative.init to work properly
+    (process.mainModule as any).filename = require.resolve("@brightside/core");
+    ((process.mainModule as any).paths as any).unshift(mainZoweDir);
+    // we need to call Imperative.init so that any installed credential manager plugins are loaded
+    await Imperative.init({ configurationModule: require.resolve("@brightside/core/lib/imperative.js") });
+})();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@
 */
 
 import * as zowe from "@brightside/core";
+import { spawnSync } from "child_process";
 import * as fs from "fs";
 import * as os from "os";
 import { moveSync } from "fs-extra";
@@ -18,12 +19,12 @@ import * as vscode from "vscode";
 import { IZoweTreeNode, IZoweJobTreeNode, IZoweUSSTreeNode, IZoweDatasetTreeNode } from "./api/IZoweTreeNode";
 import { ZoweDatasetNode } from "./ZoweDatasetNode";
 import { IZoweTree } from "./api/IZoweTree";
-import { Logger, TextUtils, IProfileLoaded, ImperativeConfig, Session, CredentialManagerFactory, ImperativeError, DefaultCredentialManager } from "@brightside/imperative";
+import { Logger, TextUtils, IProfileLoaded, ImperativeConfig, Session, CredentialManagerFactory,
+         ImperativeError, DefaultCredentialManager, Imperative, IImperativeConfig } from "@brightside/imperative";
 import { DatasetTree, createDatasetTree } from "./DatasetTree";
 import { ZosJobsProvider, createJobsTree } from "./ZosJobsProvider";
 import { Job } from "./ZoweJobNode";
 import { USSTree, createUSSTree } from "./USSTree";
-import { ZoweUSSNode } from "./ZoweUSSNode";
 import * as ussActions from "./uss/ussNodeActions";
 import * as mvsActions from "./mvs/mvsNodeActions";
 import { MvsCommandHandler } from "./command/MvsCommandHandler";
@@ -141,6 +142,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<ZoweEx
                     throw new ImperativeError({msg: err.toString()});
                 }
             }
+        }
+
+        // TODO: Would like to just run this, but there seems a timing issue.
+        //       Files get created, but errors are thrown that the are not available.
+        // const imperativePath = require.resolve("@brightside/core/lib/imperative.js");
+        // await Imperative.init({ configurationModule: imperativePath});
+        // Instead bring back spawn mechanism
+        const imperativeInitProcess = spawnSync("node", [path.join(__dirname, "ImperativeInit.js")]);
+        if (imperativeInitProcess.status !== 0) {
+            throw new Error(localize("loadAllProfiles.error.spawnProcess", "Failed to spawn process to retrieve inititalize Zowe CLI!\n") +
+                imperativeInitProcess.stderr.toString());
         }
 
         await Profiles.createInstance(log);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -144,18 +144,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<ZoweEx
             }
         }
 
-        // TODO: Would like to just run this, but there seems a timing issue.
-        //       Files get created, but errors are thrown that the are not available.
-        // const imperativePath = require.resolve("@brightside/core/lib/imperative.js");
-        // await Imperative.init({ configurationModule: imperativePath});
-        // Instead bring back spawn mechanism
-        // TODO remove
-        // const imperativeInitProcess = spawnSync("node", [path.join(__dirname, "ImperativeInit.js")]);
-        // if (imperativeInitProcess.status !== 0) {
-        //     throw new Error(localize("loadAllProfiles.error.spawnProcess", "Failed to spawn process to retrieve inititalize Zowe CLI!\n") +
-        //         imperativeInitProcess.stderr.toString());
-        // }
-
         await Profiles.createInstance(log);
         // Initialize dataset provider
         datasetProvider = await createDatasetTree(log);
@@ -388,6 +376,11 @@ export function getSecurityModules(moduleName): NodeRequire | undefined {
     } catch (error) {
         log.warn(localize("profile.init.read.imperative", "Unable to read imperative file. ") + error.message);
         vscode.window.showInformationMessage(error.message);
+        // TODO: Would like to just run this, but there seems a timing issue.
+        //       Files get created, but errors are thrown that the are not available.
+        // const imperativePath = require.resolve("@brightside/core/lib/imperative.js");
+        // await Imperative.init({ configurationModule: imperativePath});
+        // Instead bring back spawn mechanism
         const imperativeInitProcess = spawnSync("node", [path.join(__dirname, "ImperativeInit.js")]);
         if (imperativeInitProcess.status !== 0) {
             throw new Error(localize("loadAllProfiles.error.spawnProcess", "Failed to spawn process to retrieve inititalize Zowe CLI!\n") +

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -149,11 +149,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<ZoweEx
         // const imperativePath = require.resolve("@brightside/core/lib/imperative.js");
         // await Imperative.init({ configurationModule: imperativePath});
         // Instead bring back spawn mechanism
-        const imperativeInitProcess = spawnSync("node", [path.join(__dirname, "ImperativeInit.js")]);
-        if (imperativeInitProcess.status !== 0) {
-            throw new Error(localize("loadAllProfiles.error.spawnProcess", "Failed to spawn process to retrieve inititalize Zowe CLI!\n") +
-                imperativeInitProcess.stderr.toString());
-        }
+        // TODO remove
+        // const imperativeInitProcess = spawnSync("node", [path.join(__dirname, "ImperativeInit.js")]);
+        // if (imperativeInitProcess.status !== 0) {
+        //     throw new Error(localize("loadAllProfiles.error.spawnProcess", "Failed to spawn process to retrieve inititalize Zowe CLI!\n") +
+        //         imperativeInitProcess.stderr.toString());
+        // }
 
         await Profiles.createInstance(log);
         // Initialize dataset provider
@@ -378,7 +379,7 @@ export function defineGlobals(tempPath: string | undefined) {
 export function getSecurityModules(moduleName): NodeRequire | undefined {
     let imperativeIsSsecure: boolean = false;
     try {
-        const fileName = path.join(getZoweDir(), "settings", "imperative.json");
+        const fileName = path.join(getZoweDir(), "settings", "Wimperative.json");
         const settings = JSON.parse(fs.readFileSync(fileName).toString());
         const value1 = settings.overrides.CredentialManager;
         const value2 = settings.overrides["credential-manager"];
@@ -387,6 +388,11 @@ export function getSecurityModules(moduleName): NodeRequire | undefined {
     } catch (error) {
         log.warn(localize("profile.init.read.imperative", "Unable to read imperative file. ") + error.message);
         vscode.window.showInformationMessage(error.message);
+        const imperativeInitProcess = spawnSync("node", [path.join(__dirname, "ImperativeInit.js")]);
+        if (imperativeInitProcess.status !== 0) {
+            throw new Error(localize("loadAllProfiles.error.spawnProcess", "Failed to spawn process to retrieve inititalize Zowe CLI!\n") +
+                imperativeInitProcess.stderr.toString());
+        }
         return undefined;
     }
     if (imperativeIsSsecure) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -379,7 +379,7 @@ export function defineGlobals(tempPath: string | undefined) {
 export function getSecurityModules(moduleName): NodeRequire | undefined {
     let imperativeIsSsecure: boolean = false;
     try {
-        const fileName = path.join(getZoweDir(), "settings", "Wimperative.json");
+        const fileName = path.join(getZoweDir(), "settings", "imperative.json");
         const settings = JSON.parse(fs.readFileSync(fileName).toString());
         const value1 = settings.overrides.CredentialManager;
         const value2 = settings.overrides["credential-manager"];


### PR DESCRIPTION
Signed-off-by: Peter Haumer <4391934+phaumer@users.noreply.github.com>

This is a quick hack for https://github.com/zowe/vscode-extension-for-zowe/issues/514
Would like to learn how to do this properly.  Would imperative have to be extended? I see a challenge that this will not work once we add webpack support, unless we explicitly exclude the file ImperativeInit.js from the webpack bundle. (@lauren-li )