### PR TITLE
Add KeytarCredentialManager class modelled after SCS plugin

### DIFF
--- a/__mocks__/@brightside/imperative.ts
+++ b/__mocks__/@brightside/imperative.ts
@@ -93,6 +93,9 @@ export class DefaultCredentialManager {
      public test: "test";
 }
 
+// tslint:disable-next-line:max-classes-per-file
+export class AbstractCredentialManager {
+}
 
 // tslint:disable-next-line:max-classes-per-file
 export class Logger {

--- a/__tests__/__unit__/KeytarCredentialManager.unit.test.ts
+++ b/__tests__/__unit__/KeytarCredentialManager.unit.test.ts
@@ -9,7 +9,7 @@
 *                                                                                 *
 */
 
-import { KeytarCredentialManager } from "../../src/KeytarCredentialManager";
+const KeytarCredentialManager = require("../../src/KeytarCredentialManager");
 
 describe("KeytarCredentialManager Unit Tests", () => {
     // Use a fake insecure credential store
@@ -20,7 +20,7 @@ describe("KeytarCredentialManager Unit Tests", () => {
         "Broadcom-Plugin_user4": "froyo"
     };
 
-    const credentialMgr = new KeytarCredentialManager("Awesome-Service", "");
+    let credentialMgr: any;
 
     // Mock the Keytar module
     KeytarCredentialManager.keytar = {
@@ -36,6 +36,11 @@ describe("KeytarCredentialManager Unit Tests", () => {
             delete credentialStore[`${service}_${account}`];
         })
     };
+
+    beforeAll(async () => {
+        credentialMgr = new KeytarCredentialManager("Awesome-Service", "");
+        await credentialMgr.initialize();
+    });
 
     afterEach(() => {
         jest.resetAllMocks();
@@ -70,11 +75,11 @@ describe("KeytarCredentialManager Unit Tests", () => {
     it("Test saving passwords to credential store", async () => {
         expect(credentialMgr["Zowe-Plugin_user1"]).toBeDefined();
         await credentialMgr.save("user1", "cupcake");
-        expect(KeytarCredentialManager.keytar.setPassword).toHaveBeenLastCalledWith("Awesome-Plugin", "user1", "cupcake");
+        expect(KeytarCredentialManager.keytar.setPassword).toHaveBeenLastCalledWith("Awesome-Service", "user1", "cupcake");
         expect(credentialMgr["Zowe-Plugin_user1"]).toBeUndefined();
 
         const secret = await credentialMgr.load("user1");
-        expect(KeytarCredentialManager.keytar.getPassword).toHaveBeenLastCalledWith("Awesome-Plugin", "user1");
+        expect(KeytarCredentialManager.keytar.getPassword).toHaveBeenLastCalledWith("Awesome-Service", "user1");
         expect(secret).toBe("cupcake");
     });
 });

--- a/__tests__/__unit__/KeytarCredentialManager.unit.test.ts
+++ b/__tests__/__unit__/KeytarCredentialManager.unit.test.ts
@@ -1,0 +1,80 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { KeytarCredentialManager } from "../../src/KeytarCredentialManager";
+
+describe("KeytarCredentialManager Unit Tests", () => {
+    // Use a fake insecure credential store
+    const credentialStore: {[key: string]: string} = {
+        "Zowe-Plugin_user1": "cupcake",
+        "@brightside/core_user2": "donut",
+        "@zowe/cli_user3": "eclair",
+        "Broadcom-Plugin_user4": "froyo"
+    };
+
+    const credentialMgr = new KeytarCredentialManager("Awesome-Service", "");
+
+    // Mock the Keytar module
+    KeytarCredentialManager.keytar = {
+        getPassword: jest.fn((service: string, account: string): string => {
+            return credentialStore[`${service}_${account}`];
+        }),
+
+        setPassword: jest.fn((service: string, account: string, password: string) => {
+            credentialStore[`${service}_${account}`] = password;
+        }),
+
+        deletePassword: jest.fn((service: string, account: string) => {
+            delete credentialStore[`${service}_${account}`];
+        })
+    };
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it("Test loading passwords from credential store", async () => {
+        let secret = await credentialMgr.load("user1");
+        expect(KeytarCredentialManager.keytar.getPassword).toHaveBeenLastCalledWith("Zowe-Plugin", "user1");
+        expect(secret).toBe("cupcake");
+
+        secret = await credentialMgr.load("user2");
+        expect(KeytarCredentialManager.keytar.getPassword).toHaveBeenLastCalledWith("@brightside/core", "user2");
+        expect(secret).toBe("donut");
+
+        secret = await credentialMgr.load("user3");
+        expect(KeytarCredentialManager.keytar.getPassword).toHaveBeenLastCalledWith("@zowe/cli", "user3");
+        expect(secret).toBe("eclair");
+
+        secret = await credentialMgr.load("user4");
+        expect(KeytarCredentialManager.keytar.getPassword).toHaveBeenLastCalledWith("Broadcom-Plugin", "user4");
+        expect(secret).toBe("froyo");
+    });
+
+    it("Test deleting passwords from credential store", async () => {
+        await credentialMgr.delete("user3");
+        expect(KeytarCredentialManager.keytar.deletePassword).toHaveBeenLastCalledWith("Broadcom-Plugin", "user3");
+
+        const secret = await credentialMgr.load("user3");
+        expect(secret).toBeUndefined();
+    });
+
+    it("Test saving passwords to credential store", async () => {
+        expect(credentialMgr["Zowe-Plugin_user1"]).toBeDefined();
+        await credentialMgr.save("user1", "cupcake");
+        expect(KeytarCredentialManager.keytar.setPassword).toHaveBeenLastCalledWith("Awesome-Plugin", "user1", "cupcake");
+        expect(credentialMgr["Zowe-Plugin_user1"]).toBeUndefined();
+
+        const secret = await credentialMgr.load("user1");
+        expect(KeytarCredentialManager.keytar.getPassword).toHaveBeenLastCalledWith("Awesome-Plugin", "user1");
+        expect(secret).toBe("cupcake");
+    });
+});

--- a/__tests__/__unit__/KeytarCredentialManager.unit.test.ts
+++ b/__tests__/__unit__/KeytarCredentialManager.unit.test.ts
@@ -19,9 +19,9 @@ describe("KeytarCredentialManager Unit Tests", () => {
     // Use a fake insecure credential store
     const credentialStore: {[key: string]: string} = {
         "Zowe-Plugin_user1": b64Encode("cupcake"),
-        "@brightside/core_user2": b64Encode("donut"),
+        "@brightside/core_user2_password": b64Encode("donut"),
         "@zowe/cli_user3": b64Encode("eclair"),
-        "Broadcom-Plugin_user4": b64Encode("froyo")
+        "Broadcom-Plugin_user4_user": b64Encode("froyo")
     };
 
     const credentialMgr = new KeytarCredentialManager("Awesome-Service", "");
@@ -50,16 +50,16 @@ describe("KeytarCredentialManager Unit Tests", () => {
         expect(KeytarCredentialManager.keytar.getPassword).toHaveBeenLastCalledWith("Zowe-Plugin", "user1");
         expect(secret).toBe("cupcake");
 
-        secret = await credentialMgr.load("user2");
-        expect(KeytarCredentialManager.keytar.getPassword).toHaveBeenLastCalledWith("@brightside/core", "user2");
+        secret = await credentialMgr.load("user2_pass");
+        expect(KeytarCredentialManager.keytar.getPassword).toHaveBeenLastCalledWith("@brightside/core", "user2_password");
         expect(secret).toBe("donut");
 
         secret = await credentialMgr.load("user3");
         expect(KeytarCredentialManager.keytar.getPassword).toHaveBeenLastCalledWith("@zowe/cli", "user3");
         expect(secret).toBe("eclair");
 
-        secret = await credentialMgr.load("user4");
-        expect(KeytarCredentialManager.keytar.getPassword).toHaveBeenLastCalledWith("Broadcom-Plugin", "user4");
+        secret = await credentialMgr.load("user4_username");
+        expect(KeytarCredentialManager.keytar.getPassword).toHaveBeenLastCalledWith("Broadcom-Plugin", "user4_user");
         expect(secret).toBe("froyo");
     });
 
@@ -77,6 +77,15 @@ describe("KeytarCredentialManager Unit Tests", () => {
         expect(error).toBeDefined();
         expect(error.additionalDetails).toContain("Service = Awesome-Service");
         expect(error.additionalDetails).toContain("Account = user3");
+
+        try {
+            await credentialMgr.delete("user5");
+        } catch (err) {
+            error = err;
+        }
+        expect(error).toBeDefined();
+        expect(error.additionalDetails).toContain("Service = Awesome-Service");
+        expect(error.additionalDetails).toContain("Account = user5");
     });
 
     it("Test saving passwords to credential store", async () => {

--- a/i18n/sample/src/extension.i18n.json
+++ b/i18n/sample/src/extension.i18n.json
@@ -1,5 +1,6 @@
 {
     "initialize.log.debug": "Initialized logger from VSCode extension",
+    "displayName": "Zowe Explorer",
     "initialize.log.error": "Error encountered while activating and initializing logger! ",
     "onDidSaveTextDocument1": "File was saved -- determining whether the file is a USS file or Data set.\n Comparing (case insensitive) ",
     "onDidSaveTextDocument2": " against directory ",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-extension-for-zowe",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,17 +14,17 @@
       }
     },
     "@babel/core": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.3.tgz",
-      "integrity": "sha512-4XFkf8AwyrEG7Ziu3L2L0Cv+WyY47Tcsp70JFmpftbAA1K7YL/sgE9jh9HyNj08Y/U50ItUchpN0w6HxAoX1rA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.4.tgz",
+      "integrity": "sha512-0LiLrB2PwrVI+a2/IEskBopDYSd8BCb3rOvH7D5tzoWd696TBEduBvuLVm4Nx6rltrLZqvI3MCalB2K2aVzQjA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.8.3",
-        "@babel/helpers": "^7.8.3",
-        "@babel/parser": "^7.8.3",
+        "@babel/generator": "^7.8.4",
+        "@babel/helpers": "^7.8.4",
+        "@babel/parser": "^7.8.4",
         "@babel/template": "^7.8.3",
-        "@babel/traverse": "^7.8.3",
+        "@babel/traverse": "^7.8.4",
         "@babel/types": "^7.8.3",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
@@ -54,9 +54,9 @@
       }
     },
     "@babel/generator": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.3.tgz",
-      "integrity": "sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
+      "integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.8.3",
@@ -109,13 +109,13 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.3.tgz",
-      "integrity": "sha512-LmU3q9Pah/XyZU89QvBgGt+BCsTPoQa+73RxAQh8fb8qkDyIfeQnmgs+hvzhTCKTzqOyk7JTkS3MS1S8Mq5yrQ==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.4.tgz",
+      "integrity": "sha512-VPbe7wcQ4chu4TDQjimHv/5tj73qz88o12EPkO2ValS2QiQS/1F2SsjyIGNnAD0vF/nZS6Cf9i+vW6HIlnaR8w==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.8.3",
-        "@babel/traverse": "^7.8.3",
+        "@babel/traverse": "^7.8.4",
         "@babel/types": "^7.8.3"
       }
     },
@@ -131,9 +131,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.3.tgz",
-      "integrity": "sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
+      "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
       "dev": true
     },
     "@babel/plugin-syntax-object-rest-spread": {
@@ -157,16 +157,16 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.3.tgz",
-      "integrity": "sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
+      "integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.8.3",
+        "@babel/generator": "^7.8.4",
         "@babel/helper-function-name": "^7.8.3",
         "@babel/helper-split-export-declaration": "^7.8.3",
-        "@babel/parser": "^7.8.3",
+        "@babel/parser": "^7.8.4",
         "@babel/types": "^7.8.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
@@ -196,9 +196,9 @@
       }
     },
     "@brightside/core": {
-      "version": "2.36.1",
-      "resolved": "https://dl.bintray.com//ca/brightside/@brightside/core/-/@brightside/core-2.36.1.tgz",
-      "integrity": "sha1-Pn9m4gFSTkGeuOI005cVqiPwcF8=",
+      "version": "2.36.4",
+      "resolved": "https://dl.bintray.com//ca/brightside/@brightside/core/-/@brightside/core-2.36.4.tgz",
+      "integrity": "sha1-HUPcvPOjUuX9Ty9KbqW2IHHXgTM=",
       "requires": {
         "@brightside/imperative": "2.7.5",
         "get-stdin": "7.0.0",
@@ -251,9 +251,9 @@
       }
     },
     "@cnakazawa/watch": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
-      "integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
+      "integrity": "sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==",
       "dev": true,
       "requires": {
         "exec-sh": "^0.3.2",
@@ -477,9 +477,9 @@
       },
       "dependencies": {
         "@types/yargs": {
-          "version": "13.0.5",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.5.tgz",
-          "integrity": "sha512-CF/+sxTO7FOwbIRL4wMv0ZYLCRfMid2HQpzDRyViH7kSpfoAFiMdGqKIxb1PxWfjtQXQhnQuD33lvRHNwr809Q==",
+          "version": "13.0.8",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+          "integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -488,9 +488,9 @@
       }
     },
     "@sinonjs/commons": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.0.tgz",
-      "integrity": "sha512-qbk9AP+cZUsKdW1GJsBpxPKFmCJ0T8swwzVje3qFd+AkQb74Q/tiuzrdfFg8AD2g5HH/XbE/I8Uc1KYHVYWfhg==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
+      "integrity": "sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -532,9 +532,9 @@
       "dev": true
     },
     "@types/babel__core": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
-      "integrity": "sha512-8fBo0UR2CcwWxeX7WIIgJ7lXjasFxoYgRnFHUj+hRvKkpiBJbxhdAPTCY6/ZKM0uxANFVzt4yObSLuTiTnazDA==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.4.tgz",
+      "integrity": "sha512-c/5MuRz5HM4aizqL5ViYfW4iEnmfPcfbH4Xa6GgLT21dMc1NGeNnuS6egHheOmP+kCJ9CAzC4pv4SDCWTnRkbg==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -573,9 +573,9 @@
       }
     },
     "@types/chai": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.7.tgz",
-      "integrity": "sha512-luq8meHGYwvky0O7u0eQZdA7B4Wd9owUCqvbw2m3XCrCU8mplYOujMBbvyS547AxJkC+pGnd0Cm15eNxEUNU8g==",
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.9.tgz",
+      "integrity": "sha512-NeXgZj+MFL4izGqA4sapdYzkzQG+MtGra9vhQ58dnmDY++VgJaRUws+aLVV5zRJCYJl/8s9IjMmhiUw1WsKSmw==",
       "dev": true
     },
     "@types/chai-as-promised": {
@@ -631,9 +631,9 @@
       "dev": true
     },
     "@types/istanbul-lib-report": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
-      "integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*"
@@ -693,9 +693,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.41.0.tgz",
-      "integrity": "sha512-7SfeY5u9jgiELwxyLB3z7l6l/GbN9CqpCQGkcRlB7tKRFBxzbz2PoBfGrLxI1vRfUCIq5+hg5vtDHExwq5j3+A==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.42.0.tgz",
+      "integrity": "sha512-ds6TceMsh77Fs0Mq0Vap6Y72JbGWB8Bay4DrnJlf5d9ui2RSe1wis13oQm+XhguOeH1HUfLGzaDAoupTUtgabw==",
       "dev": true
     },
     "@types/yargs": {
@@ -755,12 +755,12 @@
       }
     },
     "ajv": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
+      "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
@@ -1340,9 +1340,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
-          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -1618,9 +1618,9 @@
       }
     },
     "chownr": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true
     },
     "ci-info": {
@@ -2083,9 +2083,9 @@
       }
     },
     "deep-extend": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-      "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
     "deep-is": {
@@ -2353,9 +2353,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0.tgz",
-      "integrity": "sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==",
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
+      "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
@@ -2447,24 +2447,16 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.1.tgz",
-      "integrity": "sha512-Q8t2YZ+0e0pc7NRVj3B4tSQ9rim1oi4Fh46k2xhJ2qOiEwhQfdjyEQddWdj7ZFaKmU+5104vn1qrcjEPWq+bgQ==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
+      "integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
       "dev": true,
       "requires": {
-        "esprima": "^3.1.3",
+        "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
         "optionator": "^0.8.1",
         "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-          "dev": true
-        }
       }
     },
     "esprima": {
@@ -2743,9 +2735,9 @@
       }
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -2956,7 +2948,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2977,12 +2970,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2997,17 +2992,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3124,7 +3122,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3136,6 +3135,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3150,6 +3150,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3157,12 +3158,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3181,6 +3184,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3270,7 +3274,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3282,6 +3287,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3367,7 +3373,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3403,6 +3410,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3422,6 +3430,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3465,12 +3474,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4149,9 +4160,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -5149,9 +5160,9 @@
       },
       "dependencies": {
         "@types/yargs": {
-          "version": "13.0.5",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.5.tgz",
-          "integrity": "sha512-CF/+sxTO7FOwbIRL4wMv0ZYLCRfMid2HQpzDRyViH7kSpfoAFiMdGqKIxb1PxWfjtQXQhnQuD33lvRHNwr809Q==",
+          "version": "13.0.8",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+          "integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -5375,9 +5386,9 @@
       },
       "dependencies": {
         "@types/yargs": {
-          "version": "13.0.5",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.5.tgz",
-          "integrity": "sha512-CF/+sxTO7FOwbIRL4wMv0ZYLCRfMid2HQpzDRyViH7kSpfoAFiMdGqKIxb1PxWfjtQXQhnQuD33lvRHNwr809Q==",
+          "version": "13.0.8",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+          "integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -5422,12 +5433,12 @@
       }
     },
     "js2xmlparser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.0.tgz",
-      "integrity": "sha512-WuNgdZOXVmBk5kUPMcTcVUpbGRzLfNkv7+7APq7WiDihpXVKrgxo6wwRpRl9OQeEBgKCVk9mR7RbzrnNWC8oBw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.1.tgz",
+      "integrity": "sha512-KrPTolcw6RocpYjdC7pL7v62e55q7qOMHvLX1UCLc5AAS8qeJ6nukarEJAF2KL2PZxlbGueEbINqZR2bDe/gUw==",
       "dev": true,
       "requires": {
-        "xmlcreate": "^2.0.0"
+        "xmlcreate": "^2.0.3"
       }
     },
     "jsbn": {
@@ -5591,9 +5602,9 @@
       "dev": true
     },
     "keytar": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/keytar/-/keytar-5.1.0.tgz",
-      "integrity": "sha512-SptCrRDqLbTeOMB2Z9UmVOS+OKguIrMft+EUaCB8xJPiFMjy6Jnmjgv/LA0rg1ENgLelzwSsC5PSQXF0uoqNDQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/keytar/-/keytar-5.2.0.tgz",
+      "integrity": "sha512-vsIX6n2BgTwzbKOSPIiJ8YduwHlPEE/G5dkmZWXaQK9qiGZMQyhxlFA4O6vrvM5fsXTMgUOrODYAqgpfNSRLDw==",
       "dev": true,
       "requires": {
         "nan": "2.14.0",
@@ -5601,9 +5612,9 @@
       }
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
     "klaw": {
@@ -5830,9 +5841,9 @@
       }
     },
     "make-error": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
     "make-iterator": {
@@ -5929,6 +5940,12 @@
         "rc": "~1.2.7"
       },
       "dependencies": {
+        "deep-extend": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+          "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+          "dev": true
+        },
         "get-stdin": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
@@ -6064,9 +6081,9 @@
       "dev": true
     },
     "mimic-response": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.0.0.tgz",
-      "integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
       "dev": true
     },
     "minimatch": {
@@ -6289,9 +6306,9 @@
       }
     },
     "node-abi": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.13.0.tgz",
-      "integrity": "sha512-9HrZGFVTR5SOu3PZAnAY2hLO36aW1wmA+FDsVkr85BTST32TLCA1H/AEcatVRAsWLyXS3bqUDYCAjq5/QGuSTA==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.15.0.tgz",
+      "integrity": "sha512-FeLpTS0F39U7hHZU1srAK4Vx+5AHNVOTP+hxBNQknR/54laTHSFIJkDWDqiquY1LeLUgTfPN7sLPhMubx0PLAg==",
       "dev": true,
       "requires": {
         "semver": "^5.4.1"
@@ -7066,13 +7083,13 @@
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
     },
     "prompts": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.0.tgz",
-      "integrity": "sha512-NfbbPPg/74fT7wk2XYQ7hAIp9zJyZp5Fu19iRbORqqy1BhtrkZ0fPafBU+7bmn8ie69DpT0R6QpJIN2oisYjJg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.1.tgz",
+      "integrity": "sha512-qIP2lQyCwYbdzcqHIUi2HAxiWixhoM9OdLCWf8txXsapC/X9YdsCoeyRIXE/GP+Q0J37Q7+XN/MFqbUa7IzXNA==",
       "dev": true,
       "requires": {
         "kleur": "^3.0.3",
-        "sisteransi": "^1.0.3"
+        "sisteransi": "^1.0.4"
       }
     },
     "psl": {
@@ -7132,12 +7149,6 @@
         "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
-        "deep-extend": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-          "dev": true
-        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -7319,9 +7330,9 @@
       }
     },
     "request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -7331,7 +7342,7 @@
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
         "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
+        "har-validator": "~5.1.3",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
@@ -7341,27 +7352,9 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
+        "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        },
-        "tough-cookie": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-          "dev": true,
-          "requires": {
-            "psl": "^1.1.24",
-            "punycode": "^1.4.1"
-          }
-        }
       }
     },
     "request-promise-core": {
@@ -7410,9 +7403,9 @@
       }
     },
     "resolve": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
-      "integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -8195,9 +8188,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
-          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -8374,6 +8367,15 @@
       "requires": {
         "es5-ext": "~0.10.46",
         "next-tick": "1"
+      }
+    },
+    "tmp": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
+      "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.1"
       }
     },
     "tmpl": {
@@ -8640,9 +8642,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.4.tgz",
-      "integrity": "sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==",
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
       "dev": true
     },
     "uc.micro": {
@@ -8802,19 +8804,21 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
+      "integrity": "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "object.getownpropertydescriptors": "^2.0.3"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.2",
+        "has-symbols": "^1.0.1",
+        "object.getownpropertydescriptors": "^2.1.0"
       }
     },
     "uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "dev": true
     },
     "v8flags": {
@@ -8908,9 +8912,9 @@
       }
     },
     "vsce": {
-      "version": "1.71.0",
-      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.71.0.tgz",
-      "integrity": "sha512-7k+LPC4oJYPyyxs0a5nh4A8CleQ6+2EMPiAiX/bDyN+PmwJFm2FFPqLRxdIsIWfFnkW4ZMQBf10+W62dCRd9kQ==",
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.73.0.tgz",
+      "integrity": "sha512-6W37Ebbkj3uF3WhT+SCfRtsneRQEFcGvf/XYz+b6OAgDCj4gPurWyDVrqw/HLsbP1WflGIyUfVZ8t5M7kQp6Uw==",
       "dev": true,
       "requires": {
         "azure-devops-node-api": "^7.2.0",
@@ -8933,17 +8937,6 @@
         "url-join": "^1.1.0",
         "yauzl": "^2.3.1",
         "yazl": "^2.2.2"
-      },
-      "dependencies": {
-        "tmp": {
-          "version": "0.0.29",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
-          "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "~1.0.1"
-          }
-        }
       }
     },
     "vscode": {
@@ -9301,9 +9294,9 @@
       "dev": true
     },
     "xmlcreate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.1.tgz",
-      "integrity": "sha512-MjGsXhKG8YjTKrDCXseFo3ClbMGvUD4en29H2Cev1dv4P/chlpw6KdYmlCWDkhosBVKRDjM836+3e3pm1cBNJA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.3.tgz",
+      "integrity": "sha512-HgS+X6zAztGa9zIK3Y3LXuJes33Lz9x+YyTxgrkIdabu2vqcGOWwdfCpf1hWLRrd553wd4QCDf6BBO6FfdsRiQ==",
       "dev": true
     },
     "xtend": {

--- a/src/KeytarCredentialManager.ts
+++ b/src/KeytarCredentialManager.ts
@@ -1,0 +1,167 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { AbstractCredentialManager, ImperativeError, SecureCredential } from "@brightside/imperative";
+import * as nls from "vscode-nls";
+
+// Localization support
+const localize = nls.config({messageFormat: nls.MessageFormat.file})();
+
+/**
+ * Keytar - Securely store user credentials in the system keychain
+ *
+ * @export
+ * @class KeytarCredentialManager
+ */
+export class KeytarCredentialManager extends AbstractCredentialManager {
+    /**
+     * Reference to the lazily loaded keytar module.
+     *
+     * @public
+     */
+    public static keytar: any;
+
+    /**
+     * Combined list of services that credentials may be stored under
+     */
+    private allServices: string[] = ["Zowe-Plugin", "@brightside/core", "@zowe/cli", "Broadcom-Plugin"];
+
+    /**
+     * Preferred service name to store credentials with
+     */
+    private preferredService: string;
+
+    /**
+     * Pass-through to the superclass constructor.
+     *
+     * @param {string} service The service string to send to the superclass constructor.
+     * @param {string} displayName The display name for this credential manager to send to the superclass constructor
+     */
+    constructor(service: string, displayName: string) {
+        // Always ensure that a manager instantiates the super class, even if the
+        // constructor doesn't do anything. Who knows what things might happen in
+        // the abstract class initialization in the future.
+        super(service, displayName);
+
+        if (this.allServices.indexOf(service) === -1) {
+            this.allServices.unshift(service);
+        }
+
+        this.preferredService = this.allServices[0];
+    }
+
+    /**
+     * Calls the keytar deletePassword service with {@link DefaultCredentialManager#service} and the
+     * account passed to the function by Imperative.
+     *
+     * @param {string} account The account for which to delete the password
+     *
+     * @returns {Promise<void>} A promise that the function has completed.
+     *
+     * @throws {@link ImperativeError} if keytar is not defined.
+     * @throws {@link ImperativeError} when keytar.deletePassword returns false.
+     */
+    protected async deleteCredentials(account: string): Promise<void> {
+        if (!await this.deleteCredentialsHelper(account)) {
+            throw new ImperativeError({
+                msg: localize("errorHandling.deleteCredentials", "Unable to delete credentials."),
+                additionalDetails: this.getMissingEntryMessage(account)
+            });
+        }
+    }
+
+    /**
+     * Calls the keytar getPassword service with {@link DefaultCredentialManager#service} and the
+     * account passed to the function by Imperative.
+     *
+     * @param {string} account The account for which to get credentials
+     * @returns {Promise<SecureCredential>} A promise containing the credentials stored in keytar.
+     *
+     * @throws {@link ImperativeError} if keytar is not defined.
+     * @throws {@link ImperativeError} when keytar.getPassword returns null or undefined.
+     */
+    protected async loadCredentials(account: string): Promise<SecureCredential> {
+        // Helper function to handle all breaking changes
+        const loadHelper = async (service: string) => {
+            let secureValue: string = await KeytarCredentialManager.keytar.getPassword(service, account);
+            // Handle user vs username case // Zowe v1 -> v2 (i.e. @brightside/core@2.x -> @zowe/cli@6+ )
+            if (secureValue == null && account.endsWith("_username")) {
+                secureValue = await KeytarCredentialManager.keytar.getPassword(service, account.replace("_username", "_user"));
+            }
+            // Handle pass vs password case // Zowe v0 -> v1 (i.e. @brightside/core@1.x -> @brightside/core@2.x)
+            if (secureValue == null && account.endsWith("_pass")) {
+                secureValue = await KeytarCredentialManager.keytar.getPassword(service, account.replace("_pass", "_password"));
+            }
+            return secureValue;
+        };
+
+        let password;
+
+        // Check for stored credentials under each of the known services
+        // We will stop checking once we find them somewhere
+        for (const service of this.allServices) {
+            password = await loadHelper(service);
+
+            if (password != null) {
+                break;
+            }
+        }
+
+        // Throw an error if credentials could not be found
+        if (password == null) {
+            throw new ImperativeError({
+                msg: localize("errorHandling.loadCredentials", "Unable to load credentials."),
+                additionalDetails: this.getMissingEntryMessage(account)
+            });
+        }
+
+        return password;
+    }
+
+    /**
+     * Calls the keytar setPassword service with {@link DefaultCredentialManager#service} and the
+     * account and credentials passed to the function by Imperative.
+     *
+     * @param {string} account The account to set credentials
+     * @param {SecureCredential} credentials The credentials to store
+     *
+     * @returns {Promise<void>} A promise that the function has completed.
+     *
+     * @throws {@link ImperativeError} if keytar is not defined.
+     */
+    protected async saveCredentials(account: string, credentials: SecureCredential): Promise<void> {
+        await this.deleteCredentialsHelper(account, true);
+        await KeytarCredentialManager.keytar.setPassword(this.preferredService, account, credentials);
+    }
+
+    private async deleteCredentialsHelper(account: string, skipPreferredService?: boolean): Promise<boolean> {
+        let wasDeleted = false;
+        for (const service of this.allServices) {
+            if (skipPreferredService && service === this.preferredService) {
+                continue;
+            }
+            if (await KeytarCredentialManager.keytar.deletePassword(service, account)) {
+                wasDeleted = true;
+            }
+        }
+        return wasDeleted;
+    }
+
+    private getMissingEntryMessage(account: string) {
+        return localize("credentials.missingEntryMessage.1", "Could not find an entry in the credential vault for the following:\n") +
+            localize("credentials.missingEntryMessage.2", "  Service = {0}\n", this.allServices.join(", ")) +
+            localize("credentials.missingEntryMessage.3", "  Account = {0}\n\n", account) +
+            localize("credentials.missingEntryMessage.4", "Possible Causes:\n") +
+            localize("credentials.missingEntryMessage.5", "  This could have been caused by any manual removal of credentials from your vault.\n\n") +
+            localize("credentials.missingEntryMessage.6", "Resolutions:\n") +
+            localize("credentials.missingEntryMessage.7", "  Recreate the credentials in the vault for the particular service in the vault.");
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,7 @@ import * as utils from "./utils";
 import SpoolProvider, { encodeJobFile } from "./SpoolProvider";
 import { attachRecentSaveListener, disposeRecentSaveListener, getRecentSaveStatus } from "./utils/file";
 import { ZoweExplorerApiRegister } from "./api/ZoweExplorerApiRegister";
+import { KeytarCredentialManager } from "./KeytarCredentialManager";
 
 // Localization support
 const localize = nls.config({messageFormat: nls.MessageFormat.file})();
@@ -126,7 +127,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<ZoweEx
 
         const keytar = getSecurityModules("keytar");
         if (keytar) {
-            const KeytarCredentialManager = require("./KeytarCredentialManager");
             KeytarCredentialManager.keytar = keytar;
             const service: string = vscode.workspace.getConfiguration().get("Zowe Security: Credential Key");
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,7 +36,6 @@ import * as utils from "./utils";
 import SpoolProvider, { encodeJobFile } from "./SpoolProvider";
 import { attachRecentSaveListener, disposeRecentSaveListener, getRecentSaveStatus } from "./utils/file";
 import { ZoweExplorerApiRegister } from "./api/ZoweExplorerApiRegister";
-// import { KeytarCredentialManager } from "./KeytarCredentialManager";
 
 // Localization support
 const localize = nls.config({messageFormat: nls.MessageFormat.file})();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,7 +36,7 @@ import * as utils from "./utils";
 import SpoolProvider, { encodeJobFile } from "./SpoolProvider";
 import { attachRecentSaveListener, disposeRecentSaveListener, getRecentSaveStatus } from "./utils/file";
 import { ZoweExplorerApiRegister } from "./api/ZoweExplorerApiRegister";
-import { KeytarCredentialManager } from "./KeytarCredentialManager";
+// import { KeytarCredentialManager } from "./KeytarCredentialManager";
 
 // Localization support
 const localize = nls.config({messageFormat: nls.MessageFormat.file})();
@@ -128,6 +128,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<ZoweEx
 
         const keytar = getSecurityModules("keytar");
         if (keytar) {
+            const KeytarCredentialManager = require("./KeytarCredentialManager");
             KeytarCredentialManager.keytar = keytar;
             const service: string = vscode.workspace.getConfiguration().get("Zowe Security: Credential Key");
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,8 +19,7 @@ import * as vscode from "vscode";
 import { ZoweNode } from "./ZoweNode";
 import { ZoweUSSNode } from "./ZoweUSSNode";
 import { IZoweTree, IZoweTreeNode } from "./ZoweTree";
-import { Logger, TextUtils, IProfileLoaded, ImperativeConfig, Session, CredentialManagerFactory,
-         ImperativeError, DefaultCredentialManager } from "@brightside/imperative";
+import { Logger, TextUtils, IProfileLoaded, ImperativeConfig, Session, CredentialManagerFactory, ImperativeError } from "@brightside/imperative";
 import { DatasetTree, createDatasetTree } from "./DatasetTree";
 import { ZosJobsProvider, createJobsTree } from "./ZosJobsProvider";
 import { Job } from "./ZoweJobNode";


### PR DESCRIPTION
This PR adds support for profiles created with any version of the SCS plugin, without needing to have a credential key configured in VSCode settings.

The `KeytarCredentialManager` checks for credentials stored securely under any of the following IDs which have been used over time:

* `Zowe-Plugin`
* `@brightside/core`
* `@zowe/cli`
* `Broadcom-Plugin`

Much of the added code was taken from @zFernand0 's credential manager implementation in the SCS plugin. 😄 

When this PR is merged, a 1.2.3 patch release of Zowe Explorer should go out.