### PR TITLE
Support "Broadcom-Plugin" as credential key

### DIFF
--- a/__tests__/__unit__/KeytarCredentialManager.unit.test.ts
+++ b/__tests__/__unit__/KeytarCredentialManager.unit.test.ts
@@ -45,6 +45,10 @@ describe("KeytarCredentialManager Unit Tests", () => {
         })
     };
 
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
     it("Test loading passwords from credential store", async () => {
         let secret = await credentialMgr.load("user1");
         expect(KeytarCredentialManager.keytar.getPassword).toHaveBeenLastCalledWith("Zowe-Plugin", "user1");

--- a/__tests__/__unit__/KeytarCredentialManager.unit.test.ts
+++ b/__tests__/__unit__/KeytarCredentialManager.unit.test.ts
@@ -24,7 +24,7 @@ describe("KeytarCredentialManager Unit Tests", () => {
         "Broadcom-Plugin_user4_user": b64Encode("froyo")
     };
 
-    const credentialMgr = new KeytarCredentialManager("Awesome-Service", "");
+    let credentialMgr = new KeytarCredentialManager("Awesome-Service", "");
 
     // Mock the Keytar module
     KeytarCredentialManager.keytar = {
@@ -98,5 +98,15 @@ describe("KeytarCredentialManager Unit Tests", () => {
         const secret = await credentialMgr.load("user1");
         expect(KeytarCredentialManager.keytar.getPassword).toHaveBeenLastCalledWith("Awesome-Service", "user1");
         expect(secret).toBe("cupcake");
+    });
+
+    it("Test saving passwords to credential store under previous service name", async () => {
+        credentialMgr = new KeytarCredentialManager("Broadcom-Plugin", "");
+
+        expect(credentialStore["Broadcom-Plugin_user5"]).toBeUndefined();
+        await credentialMgr.save("user5", "gingerbread");
+        expect(KeytarCredentialManager.keytar.setPassword).toHaveBeenCalledTimes(1);
+        expect(KeytarCredentialManager.keytar.setPassword).toHaveBeenLastCalledWith("Broadcom-Plugin", "user5", b64Encode("gingerbread"));
+        expect(credentialStore["Broadcom-Plugin_user5"]).toBeDefined();
     });
 });

--- a/__tests__/__unit__/KeytarCredentialManager.unit.test.ts
+++ b/__tests__/__unit__/KeytarCredentialManager.unit.test.ts
@@ -75,8 +75,8 @@ describe("KeytarCredentialManager Unit Tests", () => {
             error = err;
         }
         expect(error).toBeDefined();
-        expect(error.additionalDetails).toContain("Service = Awesome-Service");
-        expect(error.additionalDetails).toContain("Account = user3");
+        expect(error.additionalDetails).toContain("Service = Zowe-Plugin");
+        expect(error.additionalDetails).toContain("Awesome-Service\n  Account = user3");
 
         try {
             await credentialMgr.delete("user5");
@@ -84,8 +84,8 @@ describe("KeytarCredentialManager Unit Tests", () => {
             error = err;
         }
         expect(error).toBeDefined();
-        expect(error.additionalDetails).toContain("Service = Awesome-Service");
-        expect(error.additionalDetails).toContain("Account = user5");
+        expect(error.additionalDetails).toContain("Service = Zowe-Plugin");
+        expect(error.additionalDetails).toContain("Awesome-Service\n  Account = user5");
     });
 
     it("Test saving passwords to credential store", async () => {

--- a/__tests__/__unit__/KeytarCredentialManager.unit.test.ts
+++ b/__tests__/__unit__/KeytarCredentialManager.unit.test.ts
@@ -105,12 +105,12 @@ describe("KeytarCredentialManager Unit Tests", () => {
     });
 
     it("Test saving passwords to credential store under previous service name", async () => {
-        credentialMgr = new KeytarCredentialManager("Broadcom-Plugin", "");
+        credentialMgr = new KeytarCredentialManager("@zowe/cli", "");
 
-        expect(credentialStore["Broadcom-Plugin_user5"]).toBeUndefined();
+        expect(credentialStore["@zowe/cli_user5"]).toBeUndefined();
         await credentialMgr.save("user5", "gingerbread");
         expect(KeytarCredentialManager.keytar.setPassword).toHaveBeenCalledTimes(1);
-        expect(KeytarCredentialManager.keytar.setPassword).toHaveBeenLastCalledWith("Broadcom-Plugin", "user5", b64Encode("gingerbread"));
-        expect(credentialStore["Broadcom-Plugin_user5"]).toBeDefined();
+        expect(KeytarCredentialManager.keytar.setPassword).toHaveBeenLastCalledWith("@zowe/cli", "user5", b64Encode("gingerbread"));
+        expect(credentialStore["@zowe/cli_user5"]).toBeDefined();
     });
 });

--- a/src/KeytarCredentialManager.ts
+++ b/src/KeytarCredentialManager.ts
@@ -52,10 +52,10 @@ export class KeytarCredentialManager extends AbstractCredentialManager {
         super(service, displayName);
 
         if (this.allServices.indexOf(service) === -1) {
-            this.allServices.unshift(service);
+            this.allServices.push(service);
         }
 
-        this.preferredService = this.allServices[0];
+        this.preferredService = service;
     }
 
     /**


### PR DESCRIPTION
Fixes #541 

This makes Zowe Explorer compatible with the lts-incremental version of the Secure Credential Store plugin, which doesn't support the credential key "Zowe-Plugin".

This fix is also present in patch release 1.2.4, as part of #540