### PR TITLE
Remove zosmf specific code

### DIFF
--- a/src/ZoweUSSNode.ts
+++ b/src/ZoweUSSNode.ts
@@ -282,7 +282,12 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
         this.tooltip = injectAdditionalDataToTooltip(this, newFullPath);
 
         vscode.commands.executeCommand("zowe.uss.refreshUSSInTree", this);
-        vscode.commands.executeCommand("zowe.uss.ZoweUSSNode.open", this);
+        if (this.contextValue === extension.DS_TEXT_FILE_CONTEXT ||
+            this.contextValue === extension.DS_FAV_TEXT_FILE_CONTEXT) {
+            vscode.commands.executeCommand("zowe.uss.ZoweUSSNode.open", this);
+        } else {
+            this.getChildren();
+        }
     }
 
     /**

--- a/src/ZoweUSSNode.ts
+++ b/src/ZoweUSSNode.ts
@@ -295,8 +295,6 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
     }
 
     public async deleteUSSNode(ussFileProvider: IZoweTree<IZoweUSSTreeNode>, filePath: string) {
-        // handle zosmf api issue with file paths
-        const nodePath = this.fullPath.startsWith("/") ? this.fullPath.substring(1) : this.fullPath;
         const quickPickOptions: vscode.QuickPickOptions = {
             placeHolder: localize("deleteUSSNode.quickPickOption", "Are you sure you want to delete ") + this.label,
             ignoreFocusOut: true,
@@ -309,7 +307,7 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
         }
         try {
             const isRecursive = this.contextValue === extension.USS_DIR_CONTEXT ? true : false;
-            await ZoweExplorerApiRegister.getUssApi(this.profile).delete(nodePath, isRecursive);
+            await ZoweExplorerApiRegister.getUssApi(this.profile).delete(this.fullPath, isRecursive);
             this.getParent().dirty = true;
             try {
                 if (fs.existsSync(filePath)) {

--- a/src/ZoweUSSNode.ts
+++ b/src/ZoweUSSNode.ts
@@ -282,10 +282,7 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
         this.tooltip = injectAdditionalDataToTooltip(this, newFullPath);
 
         vscode.commands.executeCommand("zowe.uss.refreshUSSInTree", this);
-        if (this.contextValue === extension.DS_TEXT_FILE_CONTEXT ||
-            this.contextValue === extension.DS_FAV_TEXT_FILE_CONTEXT) {
-            vscode.commands.executeCommand("zowe.uss.ZoweUSSNode.open", this);
-        }
+        vscode.commands.executeCommand("zowe.uss.ZoweUSSNode.open", this);
     }
 
     /**

--- a/src/ZoweUSSNode.ts
+++ b/src/ZoweUSSNode.ts
@@ -285,8 +285,6 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
         if (this.contextValue === extension.DS_TEXT_FILE_CONTEXT ||
             this.contextValue === extension.DS_FAV_TEXT_FILE_CONTEXT) {
             vscode.commands.executeCommand("zowe.uss.ZoweUSSNode.open", this);
-        } else {
-            this.getChildren();
         }
     }
 


### PR DESCRIPTION
deleteUSSNode() in src/ZoweUSSNode.ts was modifying the path for a zosmf bug that would break other implementations such as zFTP.  The same fix was already present in src/api/ZoweExplorerZosmfApi.ts (line 90).
 