### PR TITLE
Fix/issue 552 - merge conflict not triggered

### DIFF
--- a/__tests__/__unit__/extension.unit.test.ts
+++ b/__tests__/__unit__/extension.unit.test.ts
@@ -2022,12 +2022,7 @@ describe("Extension Unit Tests", () => {
         };
         dataSet.mockResolvedValue(downloadResponse);
 
-        try {
-            
-            await extension.saveFile(testDoc, testTree);
-        } catch (error) {
-            console.log(error)
-        }
+        await extension.saveFile(testDoc, testTree);
         expect(showWarningMessage.mock.calls[0][0]).toBe("Remote file has been modified in the meantime.\nSelect 'Compare' to resolve the conflict.");
         expect(concatChildNodes.mock.calls.length).toBe(1);
     });

--- a/__tests__/__unit__/extension.unit.test.ts
+++ b/__tests__/__unit__/extension.unit.test.ts
@@ -2012,6 +2012,7 @@ describe("Extension Unit Tests", () => {
         testResponse.commandResponse = "Rest API failure with HTTP(S) status 412";
         withProgress.mockResolvedValueOnce(testResponse);
         dataSet.mockReset();
+        testDoc.getText = jest.fn();
         const downloadResponse = {
             success: true,
             commandResponse: "",
@@ -2021,7 +2022,12 @@ describe("Extension Unit Tests", () => {
         };
         dataSet.mockResolvedValue(downloadResponse);
 
-        await extension.saveFile(testDoc, testTree);
+        try {
+            
+            await extension.saveFile(testDoc, testTree);
+        } catch (error) {
+            console.log(error)
+        }
         expect(showWarningMessage.mock.calls[0][0]).toBe("Remote file has been modified in the meantime.\nSelect 'Compare' to resolve the conflict.");
         expect(concatChildNodes.mock.calls.length).toBe(1);
     });

--- a/i18n/sample/src/extension.i18n.json
+++ b/i18n/sample/src/extension.i18n.json
@@ -90,7 +90,6 @@
     "saveFile.log.debug.sessionNode": "couldn't find session node, loading profile with CLI profile manager",
     "saveFile.log.debug.saving": "Saving file ",
     "saveFile.error.saveFailed": "Data set failed to save. Data set may have been deleted on mainframe.",
-    "saveFile.error.ZosmfEtagMismatchError": "Rest API failure with HTTP(S) status 412",
     "saveFile.error.etagMismatch": "Remote file has been modified in the meantime.\nSelect 'Compare' to resolve the conflict.",
     "saveUSSFile.log.debug.saveRequest": "save requested for USS file ",
     "saveUSSFile.response.title": "Saving file...",


### PR DESCRIPTION
### Addresses:
fix #552 - merge conflict not triggered
fix #682 - Saving a USS file in a merge conflict situation fails silently

### Details:
- fixing reference to saveUSSFile() in the save listener
- remove localization around the z/OSMF http message (that comes only in english)
    - removed message from localization file
- moved up the lines storing the text of the doc (issue with content after download)
- removed line setting `downloaded` state. Not needed anymore here, and it was generating internal error (see #)
- update test cases
- #682 was opened during investigation of #552 and is mandatory for this one to work