### PR TITLE
chore: move vsix deployment to the Theia pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,22 +68,6 @@ node('ca-jenkins-agent') {
         // Create a dummy TestProfileData in order to build the source code. See issue #556
         sh "cp resources/testProfileData.example.ts resources/testProfileData.ts"
         sh "npm run build"
-      },
-      archiveOperation: {
-        // Gather details for build archives
-        def vscodePackageJson = readJSON file: "package.json"
-        def date = new Date()
-        String buildDate = date.format("yyyyMMddHHmmss")
-        def fileName = "vscode-extension-for-zowe-v${vscodePackageJson.version}-${BRANCH_NAME}-${buildDate}"
-
-        // Generate a vsix for archiving purposes
-        sh "npx vsce package -o ${fileName}.vsix"
-
-        // Upload vsix to Artifactory
-        withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-          def uploadUrlArtifactory = "https://zowe.jfrog.io/zowe/libs-snapshot-local/org/zowe/vscode/${fileName}.vsix"
-          sh "curl -u ${USERNAME}:${PASSWORD} --data-binary \"@${fileName}.vsix\" -H \"Content-Type: application/octet-stream\" -X PUT ${uploadUrlArtifactory}"
-        }
       }
   )
 

--- a/package.json
+++ b/package.json
@@ -1084,6 +1084,7 @@
     "testRegex": "__tests__.*\\.(spec|test)\\.ts$",
     "modulePathIgnorePatterns": [
       "__tests__/__integration__/",
+      "__tests__/__theia__/",
       "out/"
     ],
     "reporters": [

--- a/theia_tests.Jenkinsfile
+++ b/theia_tests.Jenkinsfile
@@ -26,7 +26,7 @@ node('ibm-jenkins-slave-nvm') {
   pipeline.setup(
     packageName: 'ze-regression-test',
     nodeJsVersion: 'v10.18.1',
-    // FIXME: this line should be removed after fix the audit error	
+    // FIXME: this line should be removed after fix the audit error
     ignoreAuditFailure: true
   )
 
@@ -54,6 +54,10 @@ node('ibm-jenkins-slave-nvm') {
   pipeline.createStage(
     name: "Build vsix as plugin",
     stage: {
+      //Run build
+      sh "cp resources/testProfileData.example.ts resources/testProfileData.ts"
+      pipeline.nvmShell "npm run build"
+      
       // Gather details for build archives
       def vscodePackageJson = readJSON file: "package.json"
       def date = new Date()
@@ -80,7 +84,7 @@ node('ibm-jenkins-slave-nvm') {
         unit: 'MINUTES'
     ]
   )
-  
+
   pipeline.createStage(
     name: "Check Firefox",
     stage: {
@@ -114,10 +118,6 @@ node('ibm-jenkins-slave-nvm') {
             }
         }, "Run Mocha Test": {
             stage("Run Mocha Test") {
-              sh "pwd"
-              sh "ls"
-              sh "cp resources/testProfileData.example.ts resources/testProfileData.ts"
-              pipeline.nvmShell "npm run build"
               pipeline.nvmShell "npm run test:theia"
             }
         }

--- a/theia_tests.Jenkinsfile
+++ b/theia_tests.Jenkinsfile
@@ -118,6 +118,8 @@ node('ibm-jenkins-slave-nvm') {
             }
         }, "Run Mocha Test": {
             stage("Run Mocha Test") {
+              // give it a little time to start the server
+              sleep time: 2, unit: 'MINUTES'
               pipeline.nvmShell "npm run test:theia"
             }
         }

--- a/theia_tests.Jenkinsfile
+++ b/theia_tests.Jenkinsfile
@@ -46,6 +46,7 @@ node('ibm-jenkins-slave-nvm') {
           pipeline.nvmShell "npm cache clean --force"
           pipeline.nvmShell "yarn cache clean"
           pipeline.nvmShell "yarn"
+        }
       }
     },
     timeout: [


### PR DESCRIPTION
### Addresses:
#702 - Move vsix deployment to the Theia pipeline

### Details:
- Remove vsix deployment from the main build pipeline
- Add a stage in Theia pipeline to build and upload vsix file from branch build to Zowe artifactory
- Use this VSIX file to perform the smoke test in Theia

### Release Notes:
**Milestone:** v1.5
**Changelog:** N/A