### PR TITLE
Additional safety checks for profile links

### DIFF
--- a/src/utils/profileLink.ts
+++ b/src/utils/profileLink.ts
@@ -88,13 +88,17 @@ async function findLinkedProfile(aProfile: IProfileLoaded, type: string) {
         const file = path.join(linkRootDirectory, aProfile.type, aProfile.name + FILE_SUFFIX);
         if (fs.existsSync(file)) {
             const properties = readYaml.safeLoad(fs.readFileSync(file));
-            const links = properties.secondaries;
-            for (const element of Object.keys(links)) {
-                if (element === type) {
-                    try {
-                        profile = await Profiles.getInstance().directLoad(type, links[type]);
-                    } catch (err) {
-                        throw new Error(localize("profileLink.missingProfile", "Attempted to load a missing profile.") + " + " + err.message);
+            if (properties) {
+                const links = properties.secondaries;
+                if (links) {
+                    for (const element of Object.keys(links)) {
+                        if (element === type) {
+                            try {
+                                profile = await Profiles.getInstance().directLoad(type, links[type]);
+                            } catch (err) {
+                                throw new Error(localize("profileLink.missingProfile", "Attempted to load a missing profile.") + " + " + err.message);
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Signed-off-by: Colin Stone <30794003+Colin-Stone@users.noreply.github.com>

Edge condition. If manually deleting content from yaml file the content may be left in a corrupt state. If an extender application subsequently accesses the API before a user has used profile link which would fix the corrupt file an undefined error will occur.

This is an edge condition so next fix release would be fine

 