### PR TITLE
Fix: bugs found for edit session

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-extension-for-zowe",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Profiles.ts
+++ b/src/Profiles.ts
@@ -180,8 +180,11 @@ export class Profiles {
     }
 
     public async getUrl(urlInputBox): Promise<string | undefined> {
-        return new Promise<string | undefined> ((resolve) => {
-            urlInputBox.onDidHide(() => { resolve(urlInputBox.value); });
+        return new Promise<string | undefined> ((resolve, reject) => {
+            urlInputBox.onDidHide(() => {
+                reject(undefined);
+                resolve(urlInputBox.value);
+            });
             urlInputBox.onDidAccept(() => {
                 if (this.validateAndParseUrl(urlInputBox.value).valid) {
                     resolve(urlInputBox.value);

--- a/src/abstract/ZoweTreeProvider.ts
+++ b/src/abstract/ZoweTreeProvider.ts
@@ -134,7 +134,7 @@ export class ZoweTreeProvider {
             node.getProfile().profile= EditSession as IProfile;
             await setProfile(node, EditSession as IProfile);
             await setSession(node, EditSession as ISession);
-            await this.refresh();
+            this.refresh();
         }
     }
 

--- a/src/abstract/ZoweTreeProvider.ts
+++ b/src/abstract/ZoweTreeProvider.ts
@@ -126,16 +126,15 @@ export class ZoweTreeProvider {
         return undefined;
     }
 
-    public async editSession(node: IZoweDatasetTreeNode) {
+    public async editSession(node: IZoweTreeNode) {
         const profile = node.getProfile();
         const profileName = node.getProfileName();
         const EditSession = await Profiles.getInstance().editSession(profile, profileName);
-
         if (EditSession) {
             node.getProfile().profile= EditSession as IProfile;
-            setProfile(node, EditSession as IProfile);
-            setSession(node, EditSession as ISession);
-            this.refresh();
+            await setProfile(node, EditSession as IProfile);
+            await setSession(node, EditSession as ISession);
+            await this.refresh();
         }
     }
 


### PR DESCRIPTION
### Addresses:
**Fix #767** - Editing of Credentials and setting them to spaces
**Fix #748** - Pressing Escape does not abort Edit profile dialogue

### Details:
The prompt function is triggered if the profile is changed to spaces
When you press escape when editing the URL, it will not go through the next dialogue box

### Release Notes:
**Milestone:** v1.5.1
**Changelog:** Fix bugs for edit session