### PR TITLE
fix: do not modify fs node module

### DIFF
--- a/__tests__/__unit__/dataset/dsNodeActions.unit.test.ts
+++ b/__tests__/__unit__/dataset/dsNodeActions.unit.test.ts
@@ -23,8 +23,6 @@ jest.mock("vscode");
 jest.mock("Session");
 jest.mock("@zowe/cli");
 jest.mock("@zowe/imperative");
-jest.mock("fs");
-jest.mock("fs-extra");
 jest.mock("util");
 jest.mock("isbinaryfile");
 jest.mock("DatasetTree");

--- a/__tests__/__unit__/job/jobNodeActions.unit.test.ts
+++ b/__tests__/__unit__/job/jobNodeActions.unit.test.ts
@@ -23,8 +23,6 @@ jest.mock("vscode");
 jest.mock("Session");
 jest.mock("@zowe/cli");
 jest.mock("@zowe/imperative");
-jest.mock("fs");
-jest.mock("fs-extra");
 jest.mock("util");
 jest.mock("isbinaryfile");
 jest.mock("DatasetTree");

--- a/__tests__/__unit__/uss/ussNodeActions.unit.test.ts
+++ b/__tests__/__unit__/uss/ussNodeActions.unit.test.ts
@@ -18,7 +18,6 @@ import * as zowe from "@zowe/cli";
 import * as ussNodeActions from "../../../src/uss/actions";
 import * as globals from "../../../src/globals";
 import * as path from "path";
-import * as fs from "fs";
 import * as isbinaryfile from "isbinaryfile";
 import { Profiles, ValidProfileEnum } from "../../../src/Profiles";
 
@@ -47,7 +46,6 @@ const openTextDocument = jest.fn();
 const Upload = jest.fn();
 const fileToUSSFile = jest.fn();
 const writeText = jest.fn();
-const existsSync = jest.fn();
 const createBasicZosmfSession = jest.fn();
 const isBinaryFileSync = jest.fn();
 
@@ -158,7 +156,6 @@ describe("ussNodeActions", () => {
     Object.defineProperty(vscode.window, "showOpenDialog", {value: showOpenDialog});
     Object.defineProperty(vscode.workspace, "openTextDocument", {value: openTextDocument});
     Object.defineProperty(vscode.env.clipboard, "writeText", {value: writeText});
-    Object.defineProperty(fs, "existsSync", {value: existsSync});
     Object.defineProperty(zowe.ZosmfSession, "createBasicZosmfSession", { value: createBasicZosmfSession});
 
     beforeEach(() => {
@@ -168,7 +165,6 @@ describe("ussNodeActions", () => {
         testUSSTree.refreshElement.mockReset();
         showQuickPick.mockReset();
         showInputBox.mockReset();
-        existsSync.mockReturnValue(true);
     });
     afterEach(() => {
         jest.resetAllMocks();

--- a/__tests__/__unit__/utils/profileLink.unit.test.ts
+++ b/__tests__/__unit__/utils/profileLink.unit.test.ts
@@ -22,8 +22,7 @@ import { Profiles } from "../../../src/Profiles";
 import { linkProfileDialog, getLinkedProfile } from "../../../src/utils/profileLink";
 import { ZoweDatasetNode } from "../../../src/dataset/ZoweDatasetNode";
 
-// jest.mock("vscode");
-// jest.mock("fs");
+jest.mock("fs");
 
 const existsSync = jest.fn();
 const mkdirSync = jest.fn();

--- a/package.json
+++ b/package.json
@@ -1195,6 +1195,9 @@
     "testPathIgnorePatterns": [
       "<rootDir>/src/decorators"
     ],
+    "watchPathIgnorePatterns": [
+        "<rootDir>/results/unit"
+    ],
     "transform": {
       "^.+\\.(ts|tsx)$": "ts-jest"
     },


### PR DESCRIPTION
to mock `fs` and other core node modules,
explicit call to jest.mock('<module-name>') is required

Signed-off-by: Vit Gottwald <vit.gottwald@gmail.com>