### PR TITLE
Added getCommonApi() to API registry

### DIFF
--- a/__tests__/__unit__/api/ZoweExplorerApiRegister.unit.test.ts
+++ b/__tests__/__unit__/api/ZoweExplorerApiRegister.unit.test.ts
@@ -164,4 +164,23 @@ describe("ZoweExplorerApiRegister unit testing", () => {
         expect(() => {registry.getMvsApi(undefined);}).toThrow();
         expect(() => {registry.getJesApi(undefined);}).toThrow();
     });
+
+    it("provides access to the common api for a profile registered to any api regsitry", () => {
+        const defaultProfile = profiles.getDefaultProfile();
+        const ussApi = ZoweExplorerApiRegister.getUssApi(defaultProfile);
+        const profileUnused: IProfileLoaded = {
+            name: "profileUnused",
+            profile: {
+                user: undefined,
+                password: undefined
+            },
+            type: "zftp",
+            message: "",
+            failNotFound: false
+        };
+
+        expect(ZoweExplorerApiRegister.getCommonApi(defaultProfile)).toEqual(ussApi);
+        expect(ZoweExplorerApiRegister.getCommonApi(defaultProfile).getProfileTypeName()).toEqual(defaultProfile.type);
+        expect(() => {ZoweExplorerApiRegister.getCommonApi(profileUnused);}).toThrow();
+    });
 });

--- a/src/api/ZoweExplorerApiRegister.ts
+++ b/src/api/ZoweExplorerApiRegister.ts
@@ -59,6 +59,15 @@ export class ZoweExplorerApiRegister implements ZoweExplorerApi.IApiRegisterClie
     }
 
     /**
+     * Static lookup of an API Common interface for a given profile for any of the registries supported.
+     * @param profile {IProfileLoaded} a profile to be used with this instance of the API returned
+     * @returns an instance of the Commin API that uses the profile provided; could be an instance any of its subclasses
+     */
+    public static getCommonApi(profile: IProfileLoaded): ZoweExplorerApi.ICommon {
+        return ZoweExplorerApiRegister.getInstance().getCommonApi(profile);
+    }
+
+    /**
      * Lookup for generic extender API implementation.
      * @returns an instance of the API
      */
@@ -219,6 +228,25 @@ export class ZoweExplorerApiRegister implements ZoweExplorerApi.IApiRegisterClie
             throw new Error(
                 localize("getJesApi.error", "Internal error: Tried to call a non-existing JES API in API register: ") + profile.type);
         }
+    }
+
+    public getCommonApi(profile: IProfileLoaded): ZoweExplorerApi.ICommon {
+        let result: ZoweExplorerApi.ICommon;
+        try {
+            result = this.getUssApi(profile);
+        } catch (error) {
+            try {
+                result = this.getMvsApi(profile);
+            } catch (error) {
+                try {
+                result = this.getJesApi(profile);
+                } catch (error) {
+                    throw new Error(
+                        localize("getCommonApi.error", "Internal error: Tried to call a non-existing Common API in API register: ") + profile.type);
+                }
+            }
+        }
+        return result;
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Peter Haumer <4391934+phaumer@users.noreply.github.com>

In discussion around Issue https://github.com/zowe/vscode-extension-for-zowe/issues/309 and PR https://github.com/zowe/vscode-extension-for-zowe/pull/787 the need came up to provide access to the Common API for a profile independent if it was registered just with MVS, USS, JES (either one or more) to allowing adding generic functions such as `validateProfile()` that are independent of MVS, USSm or JES, but are dependent on the registered protocol providers such as zosmf or zftp.

This PR adds the `getCommonApi(IProfileLoad)` that looks in all three registries for the profile and returns the first it can find.
