### PR TITLE
fix for zosmf overwriting issue

### DIFF
--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -206,12 +206,11 @@ export async function uploadContent(node: IZoweDatasetTreeNode | IZoweUSSTreeNod
                                     etagToUpload?: string,
                                     returnEtag?: boolean): Promise<IZosFilesResponse> {
 
-    // Upload without passing the etag to force upload
-    const uploadOptions: IUploadOptions = {
-        returnEtag: true
-    };
-
     if (isZoweDatasetTreeNode(node)) {
+        // Upload without passing the etag to force upload
+        const uploadOptions: IUploadOptions = {
+            returnEtag: true
+        };
         const prof = node.getProfile();
         if (prof.profile.encoding) {
             uploadOptions.encoding = prof.profile.encoding;


### PR DESCRIPTION
Signed-off-by: Billie Simmons <49491949+JillieBeanSim@users.noreply.github.com>

@zFernand0 with further testing it looks like just passing the etag isn't fixing the issue for #928 I am noticing that it fixes the issue seen among extenders (rse & zftp) but with zosmf profiles it is still overwriting without doing the compare. It looks like this line is causing the issue:
`// Upload without passing the etag to force upload`
`const uploadOptions: IUploadOptions = {`
`returnEtag: true`
`};`

If I move it into the if (isZoweDatasetTreeNode(node)) section it fixes the issue for USS, but I don't think we want to force upload data set changes either.

Update: moving this piece of code into the if (isZoweDatasetTreeNode(node)) doesn't force the upload to MVS, the compare box is working as it should.


## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [ ] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [ ] PR Description is included
- [ ] `npm run vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...