### PR TITLE
Issue 917 Refresh for Profile Validation

### DIFF
--- a/__tests__/__unit__/Profiles.unit.test.ts
+++ b/__tests__/__unit__/Profiles.unit.test.ts
@@ -1612,3 +1612,30 @@ describe("Profiles Unit Tests - Function validateProfiles", () => {
     });
 });
 
+describe("Profiles Unit Tests - Function refresh", () => {
+    async function createBlockMocks(globalMocks) {
+        const newMocks = {
+            log: Logger.getAppLogger(),
+            profiles: null,
+            invalidProfile: createInvalidIProfile(),
+            validProfile: createValidIProfile(),
+            profileInstance: null,
+        };
+        newMocks.profiles = await Profiles.createInstance(newMocks.log);
+        newMocks.profileInstance = createInstanceOfProfile(newMocks.profiles);
+        globalMocks.mockGetInstance.mockReturnValue(newMocks.profiles);
+
+        return newMocks;
+    }
+
+    it("Tests that Profile refresh empties profilesForValidation[]", async () => {
+        const globalMocks = await createGlobalMocks();
+        const blockMocks = await createBlockMocks(globalMocks);
+
+        const theProfiles = await Profiles.createInstance(blockMocks.log);
+        theProfiles.profilesForValidation.push({status: "active", name: blockMocks.validProfile.name});
+        await theProfiles.refresh();
+        expect(theProfiles.profilesForValidation.length).toBe(0);
+    });
+});
+

--- a/__tests__/__unit__/shared/actions.unit.test.ts
+++ b/__tests__/__unit__/shared/actions.unit.test.ts
@@ -24,6 +24,8 @@ import * as sharedActions from "../../../src/shared/actions";
 import { createUSSSessionNode, createUSSTree } from "../../../__mocks__/mockCreators/uss";
 import * as dsActions from "../../../src/dataset/actions";
 import { ZoweUSSNode } from "../../../src/uss/ZoweUSSNode";
+import { getIconById, IconId, getIconByNode } from "../../../src/generators/icons";
+import { IZoweNodeType } from "../../../src/api/IZoweTreeNode";
 
 async function createGlobalMocks() {
     const globalMocks = {
@@ -277,5 +279,53 @@ describe("Shared Actions Unit Tests - Function openRecentMemberPrompt", () => {
 
         await sharedActions.openRecentMemberPrompt(blockMocks.testDatasetTree, blockMocks.testUSSTree);
         expect(blockMocks.testUSSTree.openItemFromPath).toBeCalledWith(`/node1/node2/node3.txt`, blockMocks.ussSessionNode);
+    });
+});
+
+describe("Shared Actions Unit Tests - Function returnIconState", () => {
+    function createBlockMocks() {
+        const newMocks = {
+            session: createISessionWithoutCredentials(),
+            treeView: createTreeView(),
+            dsNode: null,
+            imperativeProfile: createIProfile(),
+            profileInstance: null,
+            datasetSessionNode: null,
+        };
+
+        newMocks.profileInstance = createInstanceOfProfile(newMocks.imperativeProfile);
+        mocked(Profiles.getInstance).mockReturnValue(newMocks.profileInstance);
+        newMocks.dsNode = new ZoweDatasetNode("node", vscode.TreeItemCollapsibleState.Collapsed, newMocks.datasetSessionNode, null);
+        newMocks.datasetSessionNode = createDatasetSessionNode(newMocks.session, newMocks.imperativeProfile);
+
+        return newMocks;
+    }
+
+    it("Tests that returnIconState is resetting active icons", async () => {
+        const blockMocks = createBlockMocks();
+        const resultNode: IZoweNodeType = blockMocks.datasetSessionNode;
+        const resultIcon = getIconById(IconId.session);
+        resultNode.iconPath = resultIcon.path;
+
+        const testNode: IZoweNodeType = blockMocks.datasetSessionNode;
+        const sessionIcon = getIconById(IconId.sessionActive);
+        testNode.iconPath = sessionIcon.path;
+
+        const response = await sharedActions.returnIconState(testNode);
+        expect(getIconByNode(response)).toEqual(getIconByNode(resultNode));
+    });
+
+    it("Tests that returnIconState is resetting inactive icons", async () => {
+        const blockMocks = createBlockMocks();
+        const resultNode: IZoweNodeType = blockMocks.datasetSessionNode;
+        const resultIcon = getIconById(IconId.session);
+        resultNode.iconPath = resultIcon.path;
+
+        const testNode: IZoweNodeType = blockMocks.datasetSessionNode;
+        const sessionIcon = getIconById(IconId.sessionInactive);
+        testNode.iconPath = sessionIcon.path;
+
+        const response = await sharedActions.returnIconState(testNode);
+        expect(getIconByNode(response)).toEqual(getIconByNode(resultNode));
     });
 });

--- a/src/Profiles.ts
+++ b/src/Profiles.ts
@@ -157,8 +157,6 @@ export class Profiles {
             }
         }
         while (this.profilesForValidation.length > 0) {
-            // tslint:disable-next-line:no-console
-            console.log(this.profilesForValidation);
             this.profilesForValidation.pop();
         }
     }

--- a/src/Profiles.ts
+++ b/src/Profiles.ts
@@ -156,6 +156,11 @@ export class Profiles {
                 }
             }
         }
+        while (this.profilesForValidation.length > 0) {
+            // tslint:disable-next-line:no-console
+            console.log(this.profilesForValidation);
+            this.profilesForValidation.pop();
+        }
     }
 
     public validateAndParseUrl(newUrl: string): IUrlValidator {
@@ -908,7 +913,7 @@ export class Profiles {
             }
         });
 
-        // If not yet validated, call getStatus and validate the profile
+        // If not yet validated or inactive, call getStatus and validate the profile
         // status will be stored in profilesForValidation
         if (filteredProfile === undefined) {
             try {

--- a/src/Profiles.ts
+++ b/src/Profiles.ts
@@ -898,9 +898,9 @@ export class Profiles {
         let profileStatus;
         const getSessStatus = await ZoweExplorerApiRegister.getInstance().getCommonApi(theProfile);
 
-        // Filter profilesForValidation to check if the profile is already validated
+        // Filter profilesForValidation to check if the profile is already validated as active
         this.profilesForValidation.filter((profile) => {
-            if (profile.name === theProfile.name) {
+            if ((profile.name === theProfile.name) && (profile.status === "active")){
                 filteredProfile = {
                     status: profile.status,
                     name: profile.name

--- a/src/dataset/actions.ts
+++ b/src/dataset/actions.ts
@@ -26,6 +26,7 @@ import { IZoweDatasetTreeNode, IZoweTreeNode, IZoweNodeType } from "../api/IZowe
 import { ZoweDatasetNode } from "./ZoweDatasetNode";
 import { DatasetTree } from "./DatasetTree";
 import * as contextually from "../shared/context";
+import { returnIconState } from "../shared/actions";
 import { closeOpenedTextFile, setFileSaved } from "../utils/workspace";
 
 import * as nls from "vscode-nls";
@@ -47,6 +48,7 @@ export async function refreshAll(datasetProvider: IZoweTree<IZoweDatasetTreeNode
             sessNode.dirty = true;
             refreshTree(sessNode);
         }
+        returnIconState(sessNode);
     });
     datasetProvider.refresh();
 }

--- a/src/dataset/dsNodeActions.ts
+++ b/src/dataset/dsNodeActions.ts
@@ -14,6 +14,7 @@ import { Profiles } from "../Profiles";
 import { IZoweTree } from "../api/IZoweTree";
 import { IZoweDatasetTreeNode } from "../api/IZoweTreeNode";
 import { labelRefresh, refreshTree } from "../shared/utils";
+import { returnIconState } from "../shared/actions";
 
 /**
  * Refreshes treeView
@@ -29,6 +30,7 @@ export async function refreshAll(datasetProvider: IZoweTree<IZoweDatasetTreeNode
             sessNode.dirty = true;
             refreshTree(sessNode);
         }
+        returnIconState(sessNode);
     });
     await datasetProvider.refresh();
 }

--- a/src/job/actions.ts
+++ b/src/job/actions.ts
@@ -21,7 +21,6 @@ import { ZoweExplorerApiRegister } from "../api/ZoweExplorerApiRegister";
 import { Job } from "./ZoweJobNode";
 import * as contextually from "../shared/context";
 import { returnIconState } from "../shared/actions";
-
 import * as nls from "vscode-nls";
 import { encodeJobFile } from "../SpoolProvider";
 

--- a/src/job/actions.ts
+++ b/src/job/actions.ts
@@ -20,6 +20,7 @@ import { IZoweJobTreeNode } from "../api/IZoweTreeNode";
 import { ZoweExplorerApiRegister } from "../api/ZoweExplorerApiRegister";
 import { Job } from "./ZoweJobNode";
 import * as contextually from "../shared/context";
+import { returnIconState } from "../shared/actions";
 
 import * as nls from "vscode-nls";
 import { encodeJobFile } from "../SpoolProvider";
@@ -42,6 +43,7 @@ export async function refreshAllJobs(jobsProvider: IZoweTree<IZoweJobTreeNode>) 
             jobNode.dirty = true;
             refreshTree(jobNode);
         }
+        returnIconState(jobNode);
     });
     await jobsProvider.refresh();
 }

--- a/src/shared/actions.ts
+++ b/src/shared/actions.ts
@@ -208,4 +208,5 @@ export async function returnIconState(node: IZoweNodeType) {
             node.iconPath = sessionIcon.path;
         }
     }
+    return node;
 }

--- a/src/shared/actions.ts
+++ b/src/shared/actions.ts
@@ -196,17 +196,16 @@ export async function openRecentMemberPrompt(datasetTree: IZoweTree<IZoweDataset
 }
 
 export async function returnIconState(node: IZoweNodeType) {
-    if (getIconByNode(node) !== getIconById(IconId.sessionFavourite)) {
-        if (getIconByNode(node) !== getIconById(IconId.sessionFavouriteOpen)) {
+    if (getIconByNode(node) === getIconById(IconId.sessionActive)) {
             const sessionIcon = getIconById(IconId.session);
             if (sessionIcon) {
                 node.iconPath = sessionIcon.path;
             }
-        } else {
-            const sessionIcon = getIconById(IconId.sessionFavourite);
-            if (sessionIcon) {
-                node.iconPath = sessionIcon.path;
-            }
+    }
+    if (getIconByNode(node) === getIconById(IconId.sessionInactive)) {
+        const sessionIcon = getIconById(IconId.session);
+        if (sessionIcon) {
+            node.iconPath = sessionIcon.path;
         }
     }
 }

--- a/src/shared/actions.ts
+++ b/src/shared/actions.ts
@@ -196,17 +196,11 @@ export async function openRecentMemberPrompt(datasetTree: IZoweTree<IZoweDataset
 }
 
 export async function returnIconState(node: IZoweNodeType) {
-    if (getIconByNode(node) === getIconById(IconId.sessionActive)) {
+    if ((getIconByNode(node) === getIconById(IconId.sessionActive)) || (getIconByNode(node) === getIconById(IconId.sessionInactive))) {
             const sessionIcon = getIconById(IconId.session);
             if (sessionIcon) {
                 node.iconPath = sessionIcon.path;
             }
-    }
-    if (getIconByNode(node) === getIconById(IconId.sessionInactive)) {
-        const sessionIcon = getIconById(IconId.session);
-        if (sessionIcon) {
-            node.iconPath = sessionIcon.path;
-        }
     }
     return node;
 }

--- a/src/shared/actions.ts
+++ b/src/shared/actions.ts
@@ -13,7 +13,7 @@
 import * as vscode from "vscode";
 import * as globals from "../globals";
 import { openPS } from "../dataset/actions";
-import { IZoweDatasetTreeNode, IZoweUSSTreeNode, IZoweNodeType, IZoweJobTreeNode, IZoweTreeNode } from "../api/IZoweTreeNode";
+import { IZoweDatasetTreeNode, IZoweUSSTreeNode, IZoweNodeType } from "../api/IZoweTreeNode";
 import { IZoweTree } from "../api/IZoweTree";
 import { filterTreeByString } from "../shared/utils";
 import { FilterItem, resolveQuickPickHelper, FilterDescriptor } from "../utils";

--- a/src/shared/actions.ts
+++ b/src/shared/actions.ts
@@ -195,11 +195,7 @@ export async function openRecentMemberPrompt(datasetTree: IZoweTree<IZoweDataset
     }
 }
 
-// tslint:disable-next-line:max-line-length
 export async function returnIconState(node: IZoweNodeType) {
-    // tslint:disable-next-line:no-console
-    console.log(getIconByNode(node));
-
     if (getIconByNode(node) !== getIconById(IconId.sessionFavourite)) {
         if (getIconByNode(node) !== getIconById(IconId.sessionFavouriteOpen)) {
             const sessionIcon = getIconById(IconId.session);

--- a/src/shared/actions.ts
+++ b/src/shared/actions.ts
@@ -13,12 +13,13 @@
 import * as vscode from "vscode";
 import * as globals from "../globals";
 import { openPS } from "../dataset/actions";
-import { IZoweDatasetTreeNode, IZoweUSSTreeNode, IZoweNodeType } from "../api/IZoweTreeNode";
+import { IZoweDatasetTreeNode, IZoweUSSTreeNode, IZoweNodeType, IZoweJobTreeNode, IZoweTreeNode } from "../api/IZoweTreeNode";
 import { IZoweTree } from "../api/IZoweTree";
 import { filterTreeByString } from "../shared/utils";
 import { FilterItem, resolveQuickPickHelper, FilterDescriptor } from "../utils";
 import * as contextually from "../shared/context";
 import * as nls from "vscode-nls";
+import { getIconByNode, getIconById, IconId } from "../generators/icons";
 
 // Set up localization
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
@@ -191,5 +192,25 @@ export async function openRecentMemberPrompt(datasetTree: IZoweTree<IZoweDataset
     } else {
         vscode.window.showInformationMessage(localize("getRecentMembers.empty", "No recent members found."));
         return;
+    }
+}
+
+// tslint:disable-next-line:max-line-length
+export async function returnIconState(node: IZoweNodeType) {
+    // tslint:disable-next-line:no-console
+    console.log(getIconByNode(node));
+
+    if (getIconByNode(node) !== getIconById(IconId.sessionFavourite)) {
+        if (getIconByNode(node) !== getIconById(IconId.sessionFavouriteOpen)) {
+            const sessionIcon = getIconById(IconId.session);
+            if (sessionIcon) {
+                node.iconPath = sessionIcon.path;
+            }
+        } else {
+            const sessionIcon = getIconById(IconId.sessionFavourite);
+            if (sessionIcon) {
+                node.iconPath = sessionIcon.path;
+            }
+        }
     }
 }

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -208,12 +208,11 @@ export async function uploadContent(node: IZoweDatasetTreeNode | IZoweUSSTreeNod
                                     etagToUpload?: string,
                                     returnEtag?: boolean): Promise<IZosFilesResponse> {
 
-    // Upload without passing the etag to force upload
-    const uploadOptions: IUploadOptions = {
-        returnEtag: true
-    };
-
     if (isZoweDatasetTreeNode(node)) {
+        // Upload without passing the etag to force upload
+        const uploadOptions: IUploadOptions = {
+            returnEtag: true
+        };
         const prof = node.getProfile();
         if (prof.profile.encoding) {
             uploadOptions.encoding = prof.profile.encoding;

--- a/src/uss/actions.ts
+++ b/src/uss/actions.ts
@@ -26,6 +26,7 @@ import { Session } from "@zowe/imperative";
 import * as contextually from "../shared/context";
 import { setFileSaved } from "../utils/workspace";
 import * as nls from "vscode-nls";
+import { returnIconState } from "../shared/actions";
 
 // Set up localization
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
@@ -92,6 +93,7 @@ export async function refreshAllUSS(ussFileProvider: IZoweTree<IZoweUSSTreeNode>
             sessNode.dirty = true;
             refreshTree(sessNode);
         }
+        returnIconState(sessNode);
     });
     await ussFileProvider.refresh();
 }


### PR DESCRIPTION
## Proposed changes

Re validation for invalid profiles automatically, refresh tree clears profilesForValidation[] and resets icons.

## Release Notes

Milestone: 1.8.0

Changelog: Ability to clear validations and re-validate as needed using refresh view.

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [x] `npm run vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [x] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...