### PR TITLE
Fix issue 962

### DIFF
--- a/__tests__/__integration__/DatasetTree.integration.test.ts
+++ b/__tests__/__integration__/DatasetTree.integration.test.ts
@@ -358,6 +358,30 @@ describe("DatasetTree Integration Tests", async () => {
                     expectChai(beforeList.apiResponse.returnedRows).to.equal(0);
                     expectChai(afterList.apiResponse.returnedRows).to.equal(1);
                 }).timeout(TIMEOUT);
+                it("should rename a data set in uppercase when given lowercase name", async () => {
+                    let error;
+                    let beforeList;
+                    let afterList;
+
+                    const lowercaseAfterDataSetName = `${pattern}.RENAME.after.TEST`;
+
+                    try {
+                        const testNode = new ZoweDatasetNode(beforeDataSetName, vscode.TreeItemCollapsibleState.None, sessNode, session);
+                        const inputBoxStub = sandbox.stub(vscode.window, "showInputBox");
+                        inputBoxStub.returns(lowercaseAfterDataSetName);
+
+                        await testTree.rename(testNode);
+                        beforeList = await zowe.List.dataSet(sessNode.getSession(), beforeDataSetName);
+                        afterList = await zowe.List.dataSet(sessNode.getSession(), afterDataSetName);
+                    } catch (err) {
+                        error = err;
+                    }
+
+                    expectChai(error).to.be.equal(undefined);
+
+                    expectChai(beforeList.apiResponse.returnedRows).to.equal(0);
+                    expectChai(afterList.apiResponse.returnedRows).to.equal(1);
+                }).timeout(TIMEOUT);
             });
         });
         describe("Failure Scenarios", () => {
@@ -389,6 +413,27 @@ describe("DatasetTree Integration Tests", async () => {
                         inputBoxStub.returns("mem2");
 
                         await testTree.rename(childNode);
+                    } catch (err) {
+                        error = err;
+                    }
+
+                    expectChai(error).not.to.be.equal(undefined);
+                }).timeout(TIMEOUT);
+                it("should throw an error if the new dataset name is the same as the original", async () => {
+                    let error;
+                    let beforeList;
+                    let afterList;
+
+                    const sameBeforeDataSetName = `${pattern}.RENAME.AFTER.TEST`;
+
+                    try {
+                        const testNode = new ZoweDatasetNode(sameBeforeDataSetName, vscode.TreeItemCollapsibleState.None, sessNode, session);
+                        const inputBoxStub = sandbox.stub(vscode.window, "showInputBox");
+                        inputBoxStub.returns(afterDataSetName);
+
+                        await testTree.rename(testNode);
+                        beforeList = await zowe.List.dataSet(sessNode.getSession(), sameBeforeDataSetName);
+                        afterList = await zowe.List.dataSet(sessNode.getSession(), afterDataSetName);
                     } catch (err) {
                         error = err;
                     }

--- a/__tests__/__integration__/DatasetTree.integration.test.ts
+++ b/__tests__/__integration__/DatasetTree.integration.test.ts
@@ -38,7 +38,7 @@ describe("DatasetTree Integration Tests", async () => {
     // Uses loaded profile to create a zosmf session with Zowe
     const session = zowe.ZosmfSession.createBasicZosmfSession(testConst.profile);
     const sessNode = new ZoweDatasetNode(testConst.profile.name, vscode.TreeItemCollapsibleState.Expanded,
-                                         null, session, undefined, undefined, testProfile);
+        null, session, undefined, undefined, testProfile);
     sessNode.contextValue = DS_SESSION_CONTEXT;
     const pattern = testConst.normalPattern.toUpperCase();
     sessNode.pattern = pattern + ".PUBLIC";
@@ -92,16 +92,16 @@ describe("DatasetTree Integration Tests", async () => {
         ];
         sampleRChildren[2].dirty = false; // Because getChildren was subsequently called.
 
-        sampleRChildren[0].command = {command: "zowe.ZoweNode.openPS", title: "", arguments: [sampleRChildren[0]]};
-        sampleRChildren[3].command = {command: "zowe.ZoweNode.openPS", title: "", arguments: [sampleRChildren[3]]};
+        sampleRChildren[0].command = { command: "zowe.ZoweNode.openPS", title: "", arguments: [sampleRChildren[0]] };
+        sampleRChildren[3].command = { command: "zowe.ZoweNode.openPS", title: "", arguments: [sampleRChildren[3]] };
 
         const samplePChildren: ZoweDatasetNode[] = [
             new ZoweDatasetNode("TCHILD1", vscode.TreeItemCollapsibleState.None, sampleRChildren[2], null),
             new ZoweDatasetNode("TCHILD2", vscode.TreeItemCollapsibleState.None, sampleRChildren[2], null),
         ];
 
-        samplePChildren[0].command = {command: "zowe.ZoweNode.openPS", title: "", arguments: [samplePChildren[0]]};
-        samplePChildren[1].command = {command: "zowe.ZoweNode.openPS", title: "", arguments: [samplePChildren[1]]};
+        samplePChildren[0].command = { command: "zowe.ZoweNode.openPS", title: "", arguments: [samplePChildren[0]] };
+        samplePChildren[1].command = { command: "zowe.ZoweNode.openPS", title: "", arguments: [samplePChildren[1]] };
         sampleRChildren[2].children = samplePChildren;
 
         // Checking that the rootChildren are what they are expected to be
@@ -291,6 +291,30 @@ describe("DatasetTree Integration Tests", async () => {
                     expectChai(beforeList.apiResponse.returnedRows).to.equal(0);
                     expectChai(afterList.apiResponse.returnedRows).to.equal(1);
                 }).timeout(TIMEOUT);
+                it("should rename a data set in uppercase when given lowercase name", async () => {
+                    let error;
+                    let beforeList;
+                    let afterList;
+
+                    const lowercaseAfterDataSetName = `${pattern}.RENAME.after.TEST`;
+
+                    try {
+                        const testNode = new ZoweDatasetNode(beforeDataSetName, vscode.TreeItemCollapsibleState.None, sessNode, session);
+                        const inputBoxStub = sandbox.stub(vscode.window, "showInputBox");
+                        inputBoxStub.returns(lowercaseAfterDataSetName);
+
+                        await testTree.rename(testNode);
+                        beforeList = await zowe.List.dataSet(sessNode.getSession(), beforeDataSetName);
+                        afterList = await zowe.List.dataSet(sessNode.getSession(), afterDataSetName);
+                    } catch (err) {
+                        error = err;
+                    }
+
+                    expectChai(error).to.be.equal(undefined);
+
+                    expectChai(beforeList.apiResponse.returnedRows).to.equal(0);
+                    expectChai(afterList.apiResponse.returnedRows).to.equal(1);
+                }).timeout(TIMEOUT);
             });
             describe("Rename Member", () => {
                 beforeEach(async () => {
@@ -306,6 +330,27 @@ describe("DatasetTree Integration Tests", async () => {
                     );
                 });
                 it("should rename a data set member", async () => {
+                    let error;
+                    let list;
+
+                    try {
+                        const parentNode = new ZoweDatasetNode(beforeDataSetName, vscode.TreeItemCollapsibleState.None, sessNode, session);
+                        const childNode = new ZoweDatasetNode("mem1", vscode.TreeItemCollapsibleState.None, parentNode, session);
+                        const inputBoxStub = sandbox.stub(vscode.window, "showInputBox");
+                        inputBoxStub.returns("MEM2");
+
+                        await testTree.rename(childNode);
+                        list = await zowe.List.allMembers(sessNode.getSession(), beforeDataSetName);
+                    } catch (err) {
+                        error = err;
+                    }
+
+                    expectChai(error).to.be.equal(undefined);
+
+                    expectChai(list.apiResponse.returnedRows).to.equal(1);
+                    expectChai(list.apiResponse.items[0].member).to.equal("MEM2");
+                }).timeout(TIMEOUT);
+                it("should rename a data set member in uppercase when given lowercase", async () => {
                     let error;
                     let list;
 
@@ -410,30 +455,9 @@ describe("DatasetTree Integration Tests", async () => {
                         const parentNode = new ZoweDatasetNode(beforeDataSetName, vscode.TreeItemCollapsibleState.None, sessNode, session);
                         const childNode = new ZoweDatasetNode("mem1", vscode.TreeItemCollapsibleState.None, parentNode, session);
                         const inputBoxStub = sandbox.stub(vscode.window, "showInputBox");
-                        inputBoxStub.returns("mem2");
+                        inputBoxStub.returns("MEM2");
 
                         await testTree.rename(childNode);
-                    } catch (err) {
-                        error = err;
-                    }
-
-                    expectChai(error).not.to.be.equal(undefined);
-                }).timeout(TIMEOUT);
-                it("should throw an error if the new dataset name is the same as the original", async () => {
-                    let error;
-                    let beforeList;
-                    let afterList;
-
-                    const sameBeforeDataSetName = `${pattern}.RENAME.AFTER.TEST`;
-
-                    try {
-                        const testNode = new ZoweDatasetNode(sameBeforeDataSetName, vscode.TreeItemCollapsibleState.None, sessNode, session);
-                        const inputBoxStub = sandbox.stub(vscode.window, "showInputBox");
-                        inputBoxStub.returns(afterDataSetName);
-
-                        await testTree.rename(testNode);
-                        beforeList = await zowe.List.dataSet(sessNode.getSession(), sameBeforeDataSetName);
-                        afterList = await zowe.List.dataSet(sessNode.getSession(), afterDataSetName);
                     } catch (err) {
                         error = err;
                     }

--- a/__tests__/__unit__/dataset/DatasetTree.unit.test.ts
+++ b/__tests__/__unit__/dataset/DatasetTree.unit.test.ts
@@ -1076,6 +1076,25 @@ describe("Dataset Tree Unit Tests - Function rename", () => {
 
         expect(renameDataSetSpy).toHaveBeenLastCalledWith("HLQ.TEST.RENAME.NODE", "HLQ.TEST.RENAME.NODE.NEW");
     });
+
+    it("Checking function with PS Dataset given lowercase name", async () => {
+        globals.defineGlobals("");
+        createGlobalMocks();
+        const blockMocks = createBlockMocks();
+        mocked(Profiles.getInstance).mockReturnValue(blockMocks.profileInstance);
+        mocked(workspaceUtils.closeOpenedTextFile).mockResolvedValueOnce(false);
+        mocked(vscode.window.showInputBox).mockResolvedValueOnce("HLQ.TEST.RENAME.NODE.new");
+        mocked(vscode.window.createTreeView).mockReturnValueOnce(blockMocks.treeView);
+        const testTree = new DatasetTree();
+        testTree.mSessionNodes.push(blockMocks.datasetSessionNode);
+        const node = new ZoweDatasetNode("HLQ.TEST.RENAME.NODE", vscode.TreeItemCollapsibleState.None, testTree.mSessionNodes[1], blockMocks.session);
+        const renameDataSetSpy = jest.spyOn(blockMocks.mvsApi, "renameDataSet");
+
+        await testTree.rename(node);
+
+        expect(renameDataSetSpy).toHaveBeenLastCalledWith("HLQ.TEST.RENAME.NODE", "HLQ.TEST.RENAME.NODE.NEW");
+    });
+
     it("Checking function with Favorite PS Dataset", async () => {
         globals.defineGlobals("");
         createGlobalMocks();
@@ -1128,6 +1147,26 @@ describe("Dataset Tree Unit Tests - Function rename", () => {
         const blockMocks = createBlockMocks();
         mocked(Profiles.getInstance).mockReturnValue(blockMocks.profileInstance);
         mocked(workspaceUtils.closeOpenedTextFile).mockResolvedValueOnce(false);
+        mocked(vscode.window.showInputBox).mockResolvedValueOnce("MEM2");
+        mocked(vscode.window.createTreeView).mockReturnValueOnce(blockMocks.treeView);
+        const testTree = new DatasetTree();
+        testTree.mSessionNodes.push(blockMocks.datasetSessionNode);
+        const parent = new ZoweDatasetNode("HLQ.TEST.RENAME.NODE",
+            vscode.TreeItemCollapsibleState.None, testTree.mSessionNodes[1], blockMocks.session);
+        const child = new ZoweDatasetNode("mem1", vscode.TreeItemCollapsibleState.None, parent, blockMocks.session);
+        child.contextValue = globals.DS_MEMBER_CONTEXT;
+        const renameDataSetMemberSpy = jest.spyOn(blockMocks.mvsApi, "renameDataSetMember");
+
+        await testTree.rename(child);
+
+        expect(renameDataSetMemberSpy).toHaveBeenLastCalledWith("HLQ.TEST.RENAME.NODE", "mem1", "MEM2");
+    });
+    it("Checking function with PDS Member given in lowercase", async () => {
+        globals.defineGlobals("");
+        createGlobalMocks();
+        const blockMocks = createBlockMocks();
+        mocked(Profiles.getInstance).mockReturnValue(blockMocks.profileInstance);
+        mocked(workspaceUtils.closeOpenedTextFile).mockResolvedValueOnce(false);
         mocked(vscode.window.showInputBox).mockResolvedValueOnce("mem2");
         mocked(vscode.window.createTreeView).mockReturnValueOnce(blockMocks.treeView);
         const testTree = new DatasetTree();
@@ -1140,7 +1179,7 @@ describe("Dataset Tree Unit Tests - Function rename", () => {
 
         await testTree.rename(child);
 
-        expect(renameDataSetMemberSpy).toHaveBeenLastCalledWith("HLQ.TEST.RENAME.NODE", "mem1", "mem2");
+        expect(renameDataSetMemberSpy).toHaveBeenLastCalledWith("HLQ.TEST.RENAME.NODE", "mem1", "MEM2");
     });
     it("Checking function with favorite PDS Member", async () => {
         globals.defineGlobals("");
@@ -1148,7 +1187,7 @@ describe("Dataset Tree Unit Tests - Function rename", () => {
         const blockMocks = createBlockMocks();
         mocked(Profiles.getInstance).mockReturnValue(blockMocks.profileInstance);
         mocked(workspaceUtils.closeOpenedTextFile).mockResolvedValueOnce(false);
-        mocked(vscode.window.showInputBox).mockResolvedValueOnce("mem2");
+        mocked(vscode.window.showInputBox).mockResolvedValueOnce("MEM2");
         mocked(vscode.window.createTreeView).mockReturnValueOnce(blockMocks.treeView);
         const testTree = new DatasetTree();
         testTree.mSessionNodes.push(blockMocks.datasetSessionNode);
@@ -1161,7 +1200,7 @@ describe("Dataset Tree Unit Tests - Function rename", () => {
 
         await testTree.rename(child);
 
-        expect(renameDataSetMemberSpy).toHaveBeenLastCalledWith("HLQ.TEST.RENAME.NODE", "mem1", "mem2");
+        expect(renameDataSetMemberSpy).toHaveBeenLastCalledWith("HLQ.TEST.RENAME.NODE", "mem1", "MEM2");
     });
     it("Checking failed attempt to rename PDS Member", async () => {
         globals.defineGlobals("");
@@ -1173,7 +1212,7 @@ describe("Dataset Tree Unit Tests - Function rename", () => {
         mocked(zowe.Rename.dataSetMember).mockImplementation(() => {
             throw defaultError;
         });
-        mocked(vscode.window.showInputBox).mockResolvedValueOnce("mem2");
+        mocked(vscode.window.showInputBox).mockResolvedValueOnce("MEM2");
         mocked(vscode.window.createTreeView).mockReturnValueOnce(blockMocks.treeView);
         const testTree = new DatasetTree();
         testTree.mSessionNodes.push(blockMocks.datasetSessionNode);
@@ -1190,7 +1229,7 @@ describe("Dataset Tree Unit Tests - Function rename", () => {
             error = err;
         }
 
-        expect(renameDataSetMemberSpy).toHaveBeenLastCalledWith("HLQ.TEST.RENAME.NODE", "mem1", "mem2");
+        expect(renameDataSetMemberSpy).toHaveBeenLastCalledWith("HLQ.TEST.RENAME.NODE", "mem1", "MEM2");
         expect(error).toBe(defaultError);
     });
 });

--- a/i18n/sample/src/dataset/DatasetTree.i18n.json
+++ b/i18n/sample/src/dataset/DatasetTree.i18n.json
@@ -15,6 +15,7 @@
     "enterPattern.pattern": "No selection made.",
     "enterPattern.options.prompt": "Search data sets by entering patterns: use a comma to separate multiple patterns",
     "datasetFilterPrompt.enterPattern": "You must enter a pattern.",
+    "renameDataSet.cancelled": "Rename operation cancelled.",
     "renameDataSet.log.debug": "Renaming data set ",
     "renameDataSet.log.error": "Error encountered when renaming data set! ",
     "renameDataSet.error": "Unable to rename data set: ",

--- a/src/dataset/DatasetTree.ts
+++ b/src/dataset/DatasetTree.ts
@@ -632,19 +632,18 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
         } else {
             dataSetName = node.getParent().getLabel();
         }
-        const afterMemberName = (await vscode.window.showInputBox({ value: beforeMemberName })).toUpperCase();
+        const afterMemberName = await vscode.window.showInputBox({ value: beforeMemberName });
         const beforeFullPath = getDocumentFilePath(`${node.getParent().getLabel()}(${node.getLabel()})`, node);
         const closedOpenedInstance = await closeOpenedTextFile(beforeFullPath);
 
-        if (!afterMemberName || afterMemberName == beforeMemberName) {
-            throw new Error("New member name empty or unchanged.");
-        }
-
         this.log.debug(localize("renameDataSet.log.debug", "Renaming data set ") + afterMemberName);
-        if (afterMemberName) {
+        if (afterMemberName && afterMemberName.toUpperCase() !== beforeMemberName) {
             try {
-                await ZoweExplorerApiRegister.getMvsApi(node.getProfile()).renameDataSetMember(dataSetName, beforeMemberName, afterMemberName);
-                node.label = afterMemberName;
+                await ZoweExplorerApiRegister.getMvsApi(node.getProfile()).renameDataSetMember(
+                    dataSetName,
+                    beforeMemberName,
+                    afterMemberName.toUpperCase());
+                node.label = afterMemberName.toUpperCase();
             } catch (err) {
                 this.log.error(localize("renameDataSet.log.error", "Error encountered when renaming data set! ") + JSON.stringify(err));
                 await errorHandling(err, profileLabel, localize("renameDataSet.error", "Unable to rename data set: ") + err.message);
@@ -659,7 +658,7 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
             if (otherParent) {
                 const otherMember = otherParent.children.find((child) => child.label === beforeMemberName);
                 if (otherMember) {
-                    otherMember.label = afterMemberName;
+                    otherMember.label = afterMemberName.toUpperCase();
                     this.refreshElement(otherMember);
                 }
             }
@@ -689,28 +688,24 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
             favPrefix = node.label.substring(0, node.label.indexOf(":") + 2);
             beforeDataSetName = node.label.substring(node.label.indexOf(":") + 2);
         }
-        const afterDataSetName = (await vscode.window.showInputBox({ value: beforeDataSetName })).toUpperCase();
+        const afterDataSetName = await vscode.window.showInputBox({ value: beforeDataSetName });
         const beforeFullPath = getDocumentFilePath(node.getLabel(), node);
         const closedOpenedInstance = await closeOpenedTextFile(beforeFullPath);
 
-        if (!afterDataSetName || afterDataSetName == beforeDataSetName) {
-            throw new Error("New dataset name empty or unchanged.");
-        }
-
         this.log.debug(localize("renameDataSet.log.debug", "Renaming data set ") + afterDataSetName);
-        if (afterDataSetName) {
+        if (afterDataSetName && afterDataSetName.toUpperCase() !== beforeDataSetName) {
             try {
-                await ZoweExplorerApiRegister.getMvsApi(node.getProfile()).renameDataSet(beforeDataSetName, afterDataSetName);
-                node.label = `${favPrefix}${afterDataSetName}`;
-                node.tooltip = `${favPrefix}${afterDataSetName}`;
+                await ZoweExplorerApiRegister.getMvsApi(node.getProfile()).renameDataSet(beforeDataSetName, afterDataSetName.toUpperCase());
+                node.label = `${favPrefix}${afterDataSetName.toUpperCase()}`;
+                node.tooltip = `${favPrefix}${afterDataSetName.toUpperCase()}`;
 
                 if (isFavourite) {
                     const profile = favPrefix.substring(1, favPrefix.indexOf("]"));
-                    this.renameNode(profile, beforeDataSetName, afterDataSetName);
+                    this.renameNode(profile, beforeDataSetName, afterDataSetName.toUpperCase());
                 } else {
                     const temp = node.label;
                     node.label = "[" + node.getSessionNode().label.trim() + "]: " + beforeDataSetName;
-                    this.renameFavorite(node, afterDataSetName);
+                    this.renameFavorite(node, afterDataSetName.toUpperCase());
                     node.label = temp;
                 }
                 this.refreshElement(node);

--- a/src/dataset/DatasetTree.ts
+++ b/src/dataset/DatasetTree.ts
@@ -69,7 +69,7 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
             this.mFavoriteSession.iconPath = icon.path;
         }
         this.mSessionNodes = [this.mFavoriteSession];
-        this.treeView = vscode.window.createTreeView("zowe.explorer", {treeDataProvider: this});
+        this.treeView = vscode.window.createTreeView("zowe.explorer", { treeDataProvider: this });
     }
 
     /**
@@ -159,7 +159,7 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
                     } else {
                         node = new ZoweDatasetNode(line.substring(0, line.indexOf("{")), vscode.TreeItemCollapsibleState.None,
                             this.mFavoriteSession, session, undefined, undefined, profile);
-                        node.command = {command: "zowe.ZoweNode.openPS", title: "", arguments: [node]};
+                        node.command = { command: "zowe.ZoweNode.openPS", title: "", arguments: [node] };
                     }
                     node.contextValue = contextually.asFavorite(node);
                     const icon = getIconByNode(node);
@@ -196,7 +196,7 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
                 const session = ZoweExplorerApiRegister.getMvsApi(profile).getSession();
                 const node = new ZoweDatasetNode(line.substring(0, line.lastIndexOf("{")),
                     vscode.TreeItemCollapsibleState.None, this.mFavoriteSession, session, undefined, undefined, profile);
-                node.command = {command: "zowe.pattern", title: "", arguments: [node]};
+                node.command = { command: "zowe.pattern", title: "", arguments: [node] };
                 node.contextValue = globals.DS_SESSION_CONTEXT + globals.FAV_SUFFIX;
                 const icon = getIconByNode(node);
                 if (icon) {
@@ -291,13 +291,13 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
                 temp.iconPath = icon.path;
             }
             // add a command to execute the search
-            temp.command = {command: "zowe.pattern", title: "", arguments: [temp]};
+            temp.command = { command: "zowe.pattern", title: "", arguments: [temp] };
         } else {    // pds | ds
             temp = new ZoweDatasetNode("[" + node.getSessionNode().label.trim() + "]: " + node.label, node.collapsibleState,
                 this.mFavoriteSession, node.getSession(), node.contextValue, node.getEtag(), node.getProfile());
             temp.contextValue = contextually.asFavorite(temp);
             if (contextually.isFavoriteDs(temp)) {
-                temp.command = {command: "zowe.ZoweNode.openPS", title: "", arguments: [temp]};
+                temp.command = { command: "zowe.ZoweNode.openPS", title: "", arguments: [temp] };
             }
 
             const icon = getIconByNode(temp);
@@ -391,7 +391,7 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
 
     public async updateFavorites() {
         const settings = this.mFavorites.map((fav) =>
-        fav.label + "{" + contextually.getBaseContext(fav) + "}"
+            fav.label + "{" + contextually.getBaseContext(fav) + "}"
         );
         this.mHistory.updateFavorites(settings);
     }
@@ -399,7 +399,7 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
     public async onDidChangeConfiguration(e) {
         // Empties the persistent favorites & history arrays, if the user has set persistence to False
         if (e.affectsConfiguration(DatasetTree.persistenceSchema)) {
-            const setting: any = {...vscode.workspace.getConfiguration().get(DatasetTree.persistenceSchema)};
+            const setting: any = { ...vscode.workspace.getConfiguration().get(DatasetTree.persistenceSchema) };
             if (!setting.persistence) {
                 setting.favorites = [];
                 setting.history = [];
@@ -632,9 +632,13 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
         } else {
             dataSetName = node.getParent().getLabel();
         }
-        const afterMemberName = await vscode.window.showInputBox({value: beforeMemberName});
+        const afterMemberName = (await vscode.window.showInputBox({ value: beforeMemberName })).toUpperCase();
         const beforeFullPath = getDocumentFilePath(`${node.getParent().getLabel()}(${node.getLabel()})`, node);
         const closedOpenedInstance = await closeOpenedTextFile(beforeFullPath);
+
+        if (!afterMemberName || afterMemberName == beforeMemberName) {
+            throw new Error("New member name empty or unchanged.");
+        }
 
         this.log.debug(localize("renameDataSet.log.debug", "Renaming data set ") + afterMemberName);
         if (afterMemberName) {
@@ -685,9 +689,13 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
             favPrefix = node.label.substring(0, node.label.indexOf(":") + 2);
             beforeDataSetName = node.label.substring(node.label.indexOf(":") + 2);
         }
-        const afterDataSetName = await vscode.window.showInputBox({value: beforeDataSetName});
+        const afterDataSetName = (await vscode.window.showInputBox({ value: beforeDataSetName })).toUpperCase();
         const beforeFullPath = getDocumentFilePath(node.getLabel(), node);
         const closedOpenedInstance = await closeOpenedTextFile(beforeFullPath);
+
+        if (!afterDataSetName || afterDataSetName == beforeDataSetName) {
+            throw new Error("New dataset name empty or unchanged.");
+        }
 
         this.log.debug(localize("renameDataSet.log.debug", "Renaming data set ") + afterDataSetName);
         if (afterDataSetName) {
@@ -709,7 +717,7 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
                 this.updateFavorites();
 
                 if (fs.existsSync(beforeFullPath)) {
-                  fs.unlinkSync(beforeFullPath);
+                    fs.unlinkSync(beforeFullPath);
                 }
 
                 if (closedOpenedInstance) {

--- a/src/dataset/DatasetTree.ts
+++ b/src/dataset/DatasetTree.ts
@@ -632,18 +632,23 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
         } else {
             dataSetName = node.getParent().getLabel();
         }
-        const afterMemberName = await vscode.window.showInputBox({ value: beforeMemberName });
+        let afterMemberName = await (vscode.window.showInputBox({ value: beforeMemberName }));
+        if (!afterMemberName) {
+            vscode.window.showInformationMessage(localize("renameDataSet.cancelled", "Rename operation cancelled."));
+            return;
+        }
+        afterMemberName = afterMemberName.toUpperCase();
         const beforeFullPath = getDocumentFilePath(`${node.getParent().getLabel()}(${node.getLabel()})`, node);
         const closedOpenedInstance = await closeOpenedTextFile(beforeFullPath);
 
         this.log.debug(localize("renameDataSet.log.debug", "Renaming data set ") + afterMemberName);
-        if (afterMemberName && afterMemberName.toUpperCase() !== beforeMemberName) {
+        if (afterMemberName && afterMemberName !== beforeMemberName) {
             try {
                 await ZoweExplorerApiRegister.getMvsApi(node.getProfile()).renameDataSetMember(
                     dataSetName,
                     beforeMemberName,
-                    afterMemberName.toUpperCase());
-                node.label = afterMemberName.toUpperCase();
+                    afterMemberName);
+                node.label = afterMemberName;
             } catch (err) {
                 this.log.error(localize("renameDataSet.log.error", "Error encountered when renaming data set! ") + JSON.stringify(err));
                 await errorHandling(err, profileLabel, localize("renameDataSet.error", "Unable to rename data set: ") + err.message);
@@ -658,7 +663,7 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
             if (otherParent) {
                 const otherMember = otherParent.children.find((child) => child.label === beforeMemberName);
                 if (otherMember) {
-                    otherMember.label = afterMemberName.toUpperCase();
+                    otherMember.label = afterMemberName;
                     this.refreshElement(otherMember);
                 }
             }
@@ -688,24 +693,29 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
             favPrefix = node.label.substring(0, node.label.indexOf(":") + 2);
             beforeDataSetName = node.label.substring(node.label.indexOf(":") + 2);
         }
-        const afterDataSetName = await vscode.window.showInputBox({ value: beforeDataSetName });
+        let afterDataSetName = await vscode.window.showInputBox({ value: beforeDataSetName });
+        if (!afterDataSetName) {
+            vscode.window.showInformationMessage(localize("renameDataSet.cancelled", "Rename operation cancelled."));
+            return;
+        }
+        afterDataSetName = afterDataSetName.toUpperCase();
         const beforeFullPath = getDocumentFilePath(node.getLabel(), node);
         const closedOpenedInstance = await closeOpenedTextFile(beforeFullPath);
 
         this.log.debug(localize("renameDataSet.log.debug", "Renaming data set ") + afterDataSetName);
-        if (afterDataSetName && afterDataSetName.toUpperCase() !== beforeDataSetName) {
+        if (afterDataSetName && afterDataSetName !== beforeDataSetName) {
             try {
-                await ZoweExplorerApiRegister.getMvsApi(node.getProfile()).renameDataSet(beforeDataSetName, afterDataSetName.toUpperCase());
-                node.label = `${favPrefix}${afterDataSetName.toUpperCase()}`;
-                node.tooltip = `${favPrefix}${afterDataSetName.toUpperCase()}`;
+                await ZoweExplorerApiRegister.getMvsApi(node.getProfile()).renameDataSet(beforeDataSetName, afterDataSetName);
+                node.label = `${favPrefix}${afterDataSetName}`;
+                node.tooltip = `${favPrefix}${afterDataSetName}`;
 
                 if (isFavourite) {
                     const profile = favPrefix.substring(1, favPrefix.indexOf("]"));
-                    this.renameNode(profile, beforeDataSetName, afterDataSetName.toUpperCase());
+                    this.renameNode(profile, beforeDataSetName, afterDataSetName);
                 } else {
                     const temp = node.label;
                     node.label = "[" + node.getSessionNode().label.trim() + "]: " + beforeDataSetName;
-                    this.renameFavorite(node, afterDataSetName.toUpperCase());
+                    this.renameFavorite(node, afterDataSetName);
                     node.label = temp;
                 }
                 this.refreshElement(node);


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

Resolves #962. This fix ensures datasets and dataset members are displayed in uppercase when renamed by the user.
Not sure which milestone this falls under.

## Release Notes
<!-- Include the Milestone Number and a small description of your change that will be added to the changelog -->
<!-- If there is a linked issue, it should have the same milestone as this PR -->

Milestone:

Changelog: Ensures datasets and dataset members are displayed in uppercase when renamed by the user.

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `npm run vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [x] I have added unit test and it is passing
- [x] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)
