### PR TITLE
Update filepaths for monorepo

### DIFF
--- a/packages/zowe-explorer/src/ZoweExplorerExtender.ts
+++ b/packages/zowe-explorer/src/ZoweExplorerExtender.ts
@@ -20,7 +20,7 @@ import {
     IZoweJobTreeNode,
 } from "@zowe/zowe-explorer-api";
 import { Profiles } from "./Profiles";
-import { getProfile, getLinkedProfile } from "../../zowe-explorer/src/ProfileLink";
+import { getProfile, getLinkedProfile } from "./ProfileLink";
 import { ZoweExplorerApiRegister } from "./ZoweExplorerApiRegister";
 
 /**

--- a/scripts/systemTestEnv.ts
+++ b/scripts/systemTestEnv.ts
@@ -1,4 +1,4 @@
-import { profile, normalPattern, ussPattern } from "../resources/testProfileData";
+import { profile, normalPattern, ussPattern } from "../packages/zowe-explorer/resources/testProfileData";
 import { Create, CreateDataSetTypeEnum, Upload, Delete } from "@zowe/cli";
 import { Session, Logger } from "@zowe/imperative";
 


### PR DESCRIPTION
Update filepaths so integration tests run for the zowe-explorer package.

- I updated the top-level `scripts/systemTestEnv.ts` to use the zowe-explorer package's `resources/testProfileData.ts` file for now. In the future, if we want to instead bring that file to the top level to use in other packages' integration tests, we can change the path back.