### PR TITLE
Issue #1046: Data loss when saving a member

### DIFF
--- a/packages/zowe-explorer/i18n/sample/src/dataset/actions.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/dataset/actions.i18n.json
@@ -80,5 +80,6 @@
   "saveFile.error.saveFailed": "Data set failed to save. Data set may have been deleted on mainframe.",
   "saveFile.response.save.title": "Saving data set...",
   "saveFile.error.ZosmfEtagMismatchError": "Rest API failure with HTTP(S) status 412",
-  "saveFile.error.etagMismatch": "Remote file has been modified in the meantime.\nSelect 'Compare' to resolve the conflict."
+  "saveFile.error.etagMismatch": "Remote file has been modified in the meantime.\nSelect 'Compare' to resolve the conflict.",
+  "saveFile.error.fileClosed": "The file was closed before save could be completed."
 }


### PR DESCRIPTION
## Proposed changes

This should fix issue #1046.

I managed to reproduce the error by changing tabs before the file was saved in VSCode. There was a slight delay between clicking save and the file being saved in VSCode, since we are getting the ETag from MF to check if the file was saved there.

I don't know if this was how the user managed to cause this error, but I got the same symptoms by doing this XD So this is what I fixed.

## Release Notes

Milestone: Backlog
Changelog: Fixed issue with overwriting wrong file in Editor

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [x] Any PR dependencies have been merged and published (if appropriate)