### PR TITLE
Copyedit suggestions for 1152 FTP API readme updates

### DIFF
--- a/packages/zowe-explorer-api/README.md
+++ b/packages/zowe-explorer-api/README.md
@@ -4,24 +4,24 @@ Extensibility API for Zowe Explorer is a collection of APIs that can be used to 
 
 The current state of this API is experimental, but the goal is provide a stabilized version that can be used for Zowe Conformance certifications in the future. See this issue for more details: <https://github.com/zowe/vscode-extension-for-zowe/issues/837>.
 
-However, the current API is being used by other extensions already such as for Zowe Explorer with the [Zowe Explorer FTP Extension](../zowe-explorer-ftp-extension) that you can find in this same Git repository, as well as commercial extensions maintained by Zowe's contributor's and available on their company Web sites.
+However, the current API is being used by other extensions already, such as for Zowe Explorer with the [Zowe Explorer FTP Extension](../zowe-explorer-ftp-extension) that you can find in this same Git repository, as well as for commercial extensions maintained by Zowe's contributors and available on their company websites.
 
-Currently, the API is organized into two modules, which both are rolled up into the top-level index.ts file for convenient access.
+Currently, the API is organized into two modules, which both are rolled up into the top-level `index.ts` file for convenient access.
 
-- `/profiles`: As the name implies it provides access to common Zowe CLI profiles management APIs as well as abstractions for providing alternative z/OS interactions that use protocols other than z/OSMF, based on alternative Zowe CLI profile types.
+- `/profiles`: Provides access to common Zowe CLI profile management APIs, as well as abstractions for providing alternative z/OS interactions that use protocols other than z/OSMF, based on alternative Zowe CLI profile types.
 - `/tree`: Provides abstractions for accessing and extending the Zowe Explorer VS Code tree views.
 
 ## Profiles API
 
-The `/profiles` module has no dependency to VS Code and could be used in Zowe CLI extensions as well as VS Code extensions. If you want to use it without pulling in dependencies to VS Code that are needed by the `/tree` module, you can import it like this
+The `/profiles` module has no dependency to VS Code and could be used in Zowe CLI extensions as well as VS Code extensions. If you want to use it without pulling in dependencies to VS Code that are needed by the `/tree` module, you can import it like this:
 
 ```ts
 import { ZoweExplorerApi } from "@zowe/zowe-explorer-api/lib/profiles";
 ```
 
-The main API provided by the `/profiles` module is called `ZoweExplorerApi`. It defines a namespace for interfaces for implementing access to z/OS MVS, USS, and JES. You can see that the Zowe Explorer FTP Extension provides such an alternative implementation for USS using the FTP protocol in [packages/zowe-explorer-ftp-extension/src/ZoweExplorerFtpApi.ts](../zowe-explorer-ftp-extension/src/ZoweExplorerFtpApi.ts). The profiles module itself contains Zowe Explorer's default implementation using z/OSMF in [packages/zowe-explorer-api/src/profiles/ZoweExplorerZosmfApi.ts](./src/profiles/ZoweExplorerZosmfApi.ts)
+The main API provided by the `/profiles` module is called `ZoweExplorerApi`. It defines a namespace for interfaces for implementing access to z/OS MVS, USS, and JES. You can see that the Zowe Explorer FTP Extension provides such an alternative implementation for USS using the FTP protocol in [packages/zowe-explorer-ftp-extension/src/ZoweExplorerFtpApi.ts](../zowe-explorer-ftp-extension/src/ZoweExplorerFtpApi.ts). The `/profiles` module itself contains Zowe Explorer's default implementation using z/OSMF in [packages/zowe-explorer-api/src/profiles/ZoweExplorerZosmfApi.ts](./src/profiles/ZoweExplorerZosmfApi.ts)
 
-Zowe Explorer itself exports a `ZoweExplorerApi.IApiRegisterClient` object that can be used for such an alternative implementation to be registered with Zowe Explorer as you can find an example for doing that in [packages/zowe-explorer-ftp-extension/src/extension.ts](../zowe-explorer-ftp-extension/src/extension.ts). To be able to do that you VS Code extension must define a dependency to Zowe Explorer to ensure that VS Code extension activation is performed in the correct order. Therefore, your VS Code extension's `package.json` must contain
+Zowe Explorer itself exports a `ZoweExplorerApi.IApiRegisterClient` object that can be used for an alternative implementation to be registered with Zowe Explorer. You can find an example for doing this in [packages/zowe-explorer-ftp-extension/src/extension.ts](../zowe-explorer-ftp-extension/src/extension.ts). To be able to do this, your VS Code extension must define a dependency to Zowe Explorer to ensure that VS Code extension activation is performed in the correct order. Therefore, your VS Code extension's `package.json` must contain
 
 ```json
 "extensionDependencies": [
@@ -45,4 +45,4 @@ See this [special extension document](../../docs/README-Extending.md) to learn m
 
 Extensibility API for Zowe Explorer is part of the [Zowe Explorer monorepo on Github](https://github.com/zowe/vscode-extension-for-zowe). You find the sources there in the `/packages/zowe-explorer-api` sub-folder.
 
-To file issues use the [Zowe Explorer issue list](https://github.com/zowe/vscode-extension-for-zowe/issues) after reviewing the [API Roadmap item](https://github.com/zowe/vscode-extension-for-zowe/issues/837).
+To file issues, use the [Zowe Explorer issue list](https://github.com/zowe/vscode-extension-for-zowe/issues) after reviewing the [API Roadmap item](https://github.com/zowe/vscode-extension-for-zowe/issues/837).

--- a/packages/zowe-explorer-ftp-extension/README.md
+++ b/packages/zowe-explorer-ftp-extension/README.md
@@ -1,53 +1,56 @@
 # Zowe Explorer Extension for FTP
 
-Zowe Explorer's FTP extension adds the FTP protocol to the [Zowe Explorer](https://github.com/zowe/vscode-extension-for-zowe) VS Code extension allowing you to use [z/OS FTP Plug-in for Zowe CLI](https://github.com/zowe/zowe-cli-ftp-plugin) profiles to connect and interact with z/OS USS.
+Zowe Explorer's FTP extension adds the FTP protocol to the [Zowe Explorer](https://github.com/zowe/vscode-extension-for-zowe) VS Code extension, allowing you to use [z/OS FTP Plug-in for Zowe CLI](https://github.com/zowe/zowe-cli-ftp-plugin) profiles to connect and interact with z/OS USS.
 
 This VS Code extension also serves as a [source code example](https://github.com/zowe/vscode-extension-for-zowe/tree/master/packages/zowe-explorer-ftp-extension) demonstrating how to use the [Zowe Explorer Extensibility API](https://github.com/zowe/vscode-extension-for-zowe/tree/master/packages/zowe-explorer-api) to create VS Code extensions that extend the Zowe Explorer VS Code extensions with new capabilities.
 
 ## Create a Zowe FTP profile
 
-To use this extension we recommend that you are already familiar with the [z/OS FTP Plug-in for Zowe CLI](https://github.com/zowe/zowe-cli-ftp-plugin) and have installed it and created a profile. These steps are not required, as the Zowe Explorer FTP extension also includes the capability of creating such a profile in the Zowe Explorer UI as described below.
+To use this extension, we recommend that you are already familiar with the [z/OS FTP Plug-in for Zowe CLI](https://github.com/zowe/zowe-cli-ftp-plugin) and have installed it and created a profile. These steps are not required, as the Zowe Explorer FTP extension also includes the capability of creating such a profile in the Zowe Explorer UI as described below.
 
-However, to also enable Zowe CLI for FTP and reuse the profile created for Zowe CLI also in Zowe Explorer install the plugin and create the profile via command line:
+However, to enable FTP for Zowe CLI and reuse the profile created for Zowe CLI also in Zowe Explorer, install the plugin and create the profile via command line:
 
-- Go to the [z/OS FTP Plug-in for Zowe CLI](https://github.com/zowe/zowe-cli-ftp-plugin) GitHub repository and review the installation instructions for installing it into Zowe CLI. In short the command is
-  ```bash
-  zowe plugins install @zowe/zos-ftp-for-zowe-cli@latest
-  ```
-- Create Zowe CLI FTP profile:
-  ```bash
-  zowe profiles create zftp <profile name> -H <host> -u <user> -p <password> -P <port>
-  ```
+1. Go to the [z/OS FTP Plug-in for Zowe CLI](https://github.com/zowe/zowe-cli-ftp-plugin) GitHub repository and review the installation instructions for installing it into Zowe CLI. In short, after [meeting the prerequisites](https://github.com/zowe/zowe-cli-ftp-plugin#software-requirements), the command is:
+
+   ```bash
+   zowe plugins install @zowe/zos-ftp-for-zowe-cli@latest
+   ```
+
+1. Create Zowe FTP profile:
+
+   ```bash
+   zowe profiles create zftp <profile name> -H <host> -u <user> -p <password> -P <port>
+   ```
 
 Now you can run `zowe zos-ftp` commands as documented in the docs for the plugin. This profile can then also be selected in Zowe Explorer's Add Profile dialogs once this Zowe Explorer FTP VS Code extension is installed.
 
 ## Installation
 
-- Install this VS Code extension from the [Microsoft](https://marketplace.visualstudio.com/items?itemName=Zowe.zowe-explorer-ftp-extension) or [Open VSX](https://open-vsx.org/extension/Zowe/zowe-explorer-ftp-extension) marketplace.
-- If you do not have Zowe Explorer installed it will automatically install it for you as it is a required dependency.
-- After the install when Zowe Explorer now activates it will show a VS Code info message "Zowe Explorer was modified for FTP support." to confirm that the FTP extension is available withing Zowe Explorer.
+1. Install this VS Code extension from the [Microsoft](https://marketplace.visualstudio.com/items?itemName=Zowe.zowe-explorer-ftp-extension) or [Open VSX](https://open-vsx.org/extension/Zowe/zowe-explorer-ftp-extension) marketplace.
+1. If you do not have Zowe Explorer installed, it will automatically install it for you as it is a required dependency.
+1. After the install, when Zowe Explorer now activates it will show a VS Code info message "Zowe Explorer was modified for FTP support." to confirm that the FTP extension is available within Zowe Explorer.
 
 ## Using the FTP Extension
 
 To use the FTP extension with Zowe Explorer:
 
-- Open the Zowe Explorer activity bar in VS Code to see its three explorer views.
-- In the USS view, click the `+` icon and you will see your exiting Zowe CLI FTP profiles listed in the drop-down to select.
-- Select it and it will appear in the USS Explorer.
-- Click the Search icon next to it to specify a USS path to list it.
-- Try opening and saving files.
+1. Open the Zowe Explorer activity bar in VS Code to see its three explorer views (Data Sets, USS, and Jobs).
+1. In the USS view, click the `+` icon and you will see your existing Zowe FTP profiles listed in the drop-down to select.
+1. Select your Zowe FTP profile and it will appear in the USS view.
+1. In the USS view, click the Search icon next to your newly-added profile, and specify a USS path to list it.
+1. Try opening and saving files.
 
-If you do not have a Zowe CLI FTP Plugin profile you can create it graphically with Zowe Explorer:
+If you do not have an existing Zowe FTP profile, you can create one graphically with Zowe Explorer:
 
-- In the USS Explorer view click the `+` icon and select `Create a New Connection to z/OS`
-- Provide a name for your profile
-- Now it will prompt you for the type of connection you want to create showing you the types of all the extension available, hence as a minimum `zosmf` and `zftp`.
-- Select `zftp` and continue providing value for the prompts shown. As you will see the questions prompted are now specific for the type FTP and match the parameters available for the FTP Zowe CLI plugin.
+1. In the USS Explorer view, click the `+` icon and select `Create a New Connection to z/OS`.
+1. Provide a name for your profile.
+1. You will be prompted for the type of connection you want to create. The drop-down dialog will show you the types of all the extension available, such as `zosmf` and `zftp`.
+1. Select `zftp` and continue providing values for the prompts shown. As you will see, the questions prompted are now specific for FTP-type connections and match the parameters available in the FTP plugin for Zowe CLI.
 
 ## Providing feedback or help contributing
 
-Zowe Explorer's FTP extension is now part of the [Zowe Explorer monorepo on Github](https://github.com/zowe/vscode-extension-for-zowe). You find the sources there in the `/packages/zowe-explorer-ftp-extension` sub-folder.
+Zowe Explorer's FTP extension is now part of the [Zowe Explorer monorepo on Github](https://github.com/zowe/vscode-extension-for-zowe). You can find the sources there in the `/packages/zowe-explorer-ftp-extension` sub-folder.
 
-To file issues use the [Zowe Explorer issue list](https://github.com/zowe/vscode-extension-for-zowe/issues).
+To file issues, use the [Zowe Explorer issue list](https://github.com/zowe/vscode-extension-for-zowe/issues).
 
-For [instructions for how to build](https://github.com/zowe/vscode-extension-for-zowe/tree/master/packages/zowe-explorer-ftp-extension/docs/README.md) the extension see the `docs` sub-folder.
+For [instructions on how to build](https://github.com/zowe/vscode-extension-for-zowe/tree/master/packages/zowe-explorer-ftp-extension/docs/README.md) the extension, see the `docs` sub-folder.

--- a/packages/zowe-explorer-ftp-extension/docs/README.md
+++ b/packages/zowe-explorer-ftp-extension/docs/README.md
@@ -1,33 +1,36 @@
 # Zowe Explorer Extension for FTP development guide
 
-Zowe Explorer Extension for FTP is an example for using the Zowe Explorer extensibility API to add an alternative implementation for interacting with z/OS. The default Zowe Explorer implementation using the default Zowe CLI APIs for using z/OSMF REST APIs. This implementation replaces these with z/OS FTP for interacting with USS.
+Zowe Explorer Extension for FTP is an example for using the Zowe Explorer extensibility API to add an alternative implementation for interacting with z/OS. The default Zowe Explorer implementation uses the default Zowe CLI APIs for using z/OSMF REST APIs. This implementation replaces these with z/OS FTP for interacting with USS.
 
-Although currently limited to USS the plan is to complete the implementation to supporting MVS and JES as well.
+Although currently limited to USS, the plan is to complete the implementation to supporting MVS and JES as well.
 
 ## How to build
 
 This repo uses [Yarn](https://yarnpkg.com/) for building.
 
-- Clone this `zowe-explorer` repo:
-  ```bash
-  git clone git@github.com:zowe/zowe/vscode-extension-for-zowe.git
-  ```
-- Build the entire repo comprising of Zowe Explorer, Zowe Explorer API, and Zowe Explorer FTP with
-  ```bash
-  yarn && yarn package
-  ```
+1. Clone this `zowe-explorer` repo:
+
+   ```bash
+   git clone git@github.com:zowe/zowe/vscode-extension-for-zowe.git
+   ```
+
+1. Build the entire repo comprising of Zowe Explorer, Zowe Explorer API, and Zowe Explorer FTP with the following command:
+
+   ```bash
+   yarn && yarn package
+   ```
 
 ## How to run and debug
 
-- Once the build is finished you find two VSIX files and one TGZ file in the top-level `dist` folder. If you have not installed Zowe Explorer yet into VS Code, then use the `dist/vscode-extension-for-zowe-1.??.?.vsix` file to install it as the FTP extension requires it to be installed.
-- In VS Code switch to the Run activity group.
-- In the RUN drop-down select `Run Zowe Explorer FTP VS Code Extension` and click the Play button to start it.
-- Set breakpoints to explore the code.
+1. Once the build is finished, you will find two VSIX files and one TGZ file in the top-level `dist` folder. If you have not installed Zowe Explorer yet into VS Code, then use the `dist/vscode-extension-for-zowe-1.??.?.vsix` file to install it as the FTP extension requires it to be installed.
+1. In VS Code, switch to the Run activity group.
+1. In the RUN drop-down select `Run Zowe Explorer FTP VS Code Extension` and click the Play button to start it.
+1. Set breakpoints to explore the code.
 
 ## Review the sources
 
-As you will see the implementation of this extension is very small and minimal. The main file to explore is `packages/zowe-explorer-ftp-extension/src/ZoweExplorerFtpApi.ts`, which is the FTP implementation of all the Zowe Explorer API methods required for USS. The interface defining these operations you find in the Zowe Explorer API under `packages/zowe-explorer-api/src/profiles/ZoweExplorerApi.ts`.
+As you will see, the implementation of this extension is very small and minimal. The main file to explore is `packages/zowe-explorer-ftp-extension/src/ZoweExplorerFtpApi.ts`, which is the FTP implementation of all the Zowe Explorer API methods required for USS. You can find the interface defining these operations in the Zowe Explorer API package under `packages/zowe-explorer-api/src/profiles/ZoweExplorerApi.ts`.
 
-As you will see, these FTO operation are not directly implemented in that file, but rather reuse and call the using the code provided by the z/OS FTP Plug-in for Zowe™ CLI and linked via `@zowe/zos-ftp-for-zowe-cli"` NPM dependency.
+These FTP operations are not directly implemented in that file, but rather reuse and call the code provided by the z/OS FTP Plug-in for Zowe™ CLI, and are linked via the `@zowe/zos-ftp-for-zowe-cli` NPM dependency.
 
-The other source file `packages/zowe-explorer-ftp-extension/src/extension.ts` defines the actual VS Code extension as well as implements the registration API required to link this VS Code extension to Zowe Explorer itself. You see the `registerFtpApi()` in `extension.ts` that queries the Zowe Explorer API and calls a registration method. This registration will make Zowe Explorer find this extension after activation and add its API implementation to the USS explorer view.
+The other source file `packages/zowe-explorer-ftp-extension/src/extension.ts` defines the actual VS Code extension as well as implements the registration API required to link this VS Code extension to Zowe Explorer itself. You can see that `registerFtpApi()` in `extension.ts` queries the Zowe Explorer API and calls a registration method. This registration will make Zowe Explorer find this extension after activation and add its API implementation to the USS explorer view.


### PR DESCRIPTION
## Proposed changes

Copyedit suggestions for #1152 (FTP API readme updates)

Includes:
- Minor punctuation/wording suggestions.
- Uses ordered lists for sequential instructions.
- In Zowe Explorer FTP extension's readme, I added a link to prerequisites for installing the FTP extension for Zowe CLI (in case the user happens to not realize they need to separately install Zowe CLI first).