### PR TITLE
PR #1120 linked issue: Always allow prompting

### DIFF
--- a/packages/zowe-explorer/__tests__/__unit__/Profiles.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/Profiles.unit.test.ts
@@ -2022,10 +2022,6 @@ describe("Profiles Unit Tests - Function checkCurrentProfile", () => {
         Object.defineProperty(theProfiles, "validateProfiles", {
             value: mockValidateProfiles,
         });
-        mockValidateProfiles.mockReturnValueOnce({
-            status: "active",
-            name: blockMocks.invalidProfile.name,
-        });
         mockValidateProfiles.mockReturnValue({
             status: "inactive",
             name: blockMocks.invalidProfile.name,

--- a/packages/zowe-explorer/__tests__/__unit__/Profiles.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/Profiles.unit.test.ts
@@ -2018,13 +2018,17 @@ describe("Profiles Unit Tests - Function checkCurrentProfile", () => {
         const blockMocks = await createBlockMocks(globalMocks);
 
         const theProfiles = await Profiles.createInstance(blockMocks.log);
+        const mockValidateProfiles = jest.fn();
         Object.defineProperty(theProfiles, "validateProfiles", {
-            value: jest.fn(() => {
-                return {
-                    status: "active",
-                    name: blockMocks.invalidProfile.name,
-                };
-            }),
+            value: mockValidateProfiles,
+        });
+        mockValidateProfiles.mockReturnValueOnce({
+            status: "active",
+            name: blockMocks.invalidProfile.name,
+        });
+        mockValidateProfiles.mockReturnValue({
+            status: "inactive",
+            name: blockMocks.invalidProfile.name,
         });
         blockMocks.profiles.promptCredentials = jest.fn(() => {
             return undefined;

--- a/packages/zowe-explorer/src/Profiles.ts
+++ b/packages/zowe-explorer/src/Profiles.ts
@@ -71,27 +71,13 @@ export class Profiles extends ProfilesCache {
     private dsSchema: string = "Zowe-DS-Persistent";
     private ussSchema: string = "Zowe-USS-Persistent";
     private jobsSchema: string = "Zowe-Jobs-Persistent";
-    private usrNme: string;
-    private passWrd: string;
-    private baseEncd: string;
     public constructor(log: Logger) {
         super(log);
     }
 
     public async checkCurrentProfile(theProfile: IProfileLoaded) {
         let profileStatus: IProfileValidation;
-
-        // This step is for prompting of credentials. It will be triggered if it meets the following conditions:
-        // - The service does not have username or password and base profile doesn't exists
-        // - The service does not have username or password and the base profile has a different host and port
-        const baseProfile = this.getBaseProfile();
-
-        if (
-            (!theProfile.profile.tokenType && (!theProfile.profile.user || !theProfile.profile.password)) ||
-            (baseProfile &&
-                baseProfile.profile.host !== theProfile.profile.host &&
-                baseProfile.profile.port !== theProfile.profile.port)
-        ) {
+        if (!theProfile.profile.tokenType && (!theProfile.profile.user || !theProfile.profile.password)) {
             // The profile will need to be reactivated, so remove it from profilesForValidation
             this.profilesForValidation.filter((profile, index) => {
                 if (profile.name === theProfile.name && profile.status !== "unverified") {

--- a/packages/zowe-explorer/src/Profiles.ts
+++ b/packages/zowe-explorer/src/Profiles.ts
@@ -79,16 +79,7 @@ export class Profiles extends ProfilesCache {
     }
 
     public async checkCurrentProfile(theProfile: IProfileLoaded) {
-        const profileStatus: IProfileValidation = await this.getProfileSetting(theProfile);
-        if (profileStatus.status === "inactive") {
-            this.validProfile = ValidProfileEnum.INVALID;
-            return profileStatus;
-        }
-
-        // if (profileStatus.status === "unverified") {
-        //     this.validProfile = ValidProfileEnum.UNVERIFIED;
-        //     return profileStatus;
-        // }
+        let profileStatus: IProfileValidation = await this.getProfileSetting(theProfile);
 
         // This step is for prompting of credentials. It will be triggered if it meets the following conditions:
         // - The service does not have username or password and base profile doesn't exists
@@ -101,12 +92,18 @@ export class Profiles extends ProfilesCache {
                 baseProfile.profile.host !== theProfile.profile.host &&
                 baseProfile.profile.port !== theProfile.profile.port)
         ) {
+            // The profile will need to be reactivated, so remove it from profilesForValidation
+            this.profilesForValidation.filter((profile, index) => {
+                if (profile.name === theProfile.name && profile.status !== "unverified") {
+                    this.profilesForValidation.splice(index, 1);
+                }
+            });
             try {
-                const values = await Profiles.getInstance().promptCredentials(theProfile.name);
+                const values = await Profiles.getInstance().promptCredentials(theProfile.name, true);
                 if (values !== undefined) {
-                    this.usrNme = values[0];
-                    this.passWrd = values[1];
-                    this.baseEncd = values[2];
+                    theProfile.profile.user = values[0];
+                    theProfile.profile.password = values[1];
+                    theProfile.profile.base64EncodedAuth = values[2];
                 }
             } catch (error) {
                 errorHandling(
@@ -117,33 +114,22 @@ export class Profiles extends ProfilesCache {
                 );
                 return profileStatus;
             }
-            if (this.usrNme !== undefined && this.passWrd !== undefined && this.baseEncd !== undefined) {
-                theProfile.profile.user = this.usrNme;
-                theProfile.profile.password = this.passWrd;
-                theProfile.profile.base64EncodedAuth = this.baseEncd;
-                if (profileStatus.status === "unverified") {
-                    this.validProfile = ValidProfileEnum.UNVERIFIED;
-                } else {
-                    this.validProfile = ValidProfileEnum.VALID;
-                }
-                return profileStatus;
-            } else {
-                // return invalid if credentials are not provided
-                if (profileStatus.status === "unverified") {
-                    this.validProfile = ValidProfileEnum.UNVERIFIED;
-                } else {
-                    this.validProfile = ValidProfileEnum.INVALID;
-                }
-                return profileStatus;
-            }
-        } else {
-            if (profileStatus.status === "unverified") {
-                this.validProfile = ValidProfileEnum.UNVERIFIED;
-            } else {
-                this.validProfile = ValidProfileEnum.VALID;
-            }
-            return profileStatus;
+
+            // Revalidate profile
+            profileStatus = await this.getProfileSetting(theProfile);
         }
+        switch (profileStatus.status) {
+            case "unverified":
+                this.validProfile = ValidProfileEnum.UNVERIFIED;
+                break;
+            case "inactive":
+                this.validProfile = ValidProfileEnum.INVALID;
+                break;
+            case "active":
+                this.validProfile = ValidProfileEnum.VALID;
+                break;
+        }
+        return profileStatus;
     }
 
     public async getProfileSetting(theProfile: IProfileLoaded): Promise<IProfileValidation> {
@@ -754,7 +740,7 @@ export class Profiles extends ProfilesCache {
             newUser = loadSession.user = loadProfile.profile.user;
         }
 
-        if (newUser === undefined) {
+        if (newUser === undefined || (rePrompt && newUser === "")) {
             vscode.window.showInformationMessage(
                 localize("promptCredentials.undefined.username", "Operation Cancelled")
             );
@@ -769,7 +755,7 @@ export class Profiles extends ProfilesCache {
             }
         }
 
-        if (newPass === undefined) {
+        if (newPass === undefined || (rePrompt && newUser === "")) {
             vscode.window.showInformationMessage(
                 localize("promptCredentials.undefined.password", "Operation Cancelled")
             );

--- a/packages/zowe-explorer/src/Profiles.ts
+++ b/packages/zowe-explorer/src/Profiles.ts
@@ -79,7 +79,7 @@ export class Profiles extends ProfilesCache {
     }
 
     public async checkCurrentProfile(theProfile: IProfileLoaded) {
-        let profileStatus: IProfileValidation = await this.getProfileSetting(theProfile);
+        let profileStatus: IProfileValidation;
 
         // This step is for prompting of credentials. It will be triggered if it meets the following conditions:
         // - The service does not have username or password and base profile doesn't exists
@@ -115,7 +115,10 @@ export class Profiles extends ProfilesCache {
                 return profileStatus;
             }
 
-            // Revalidate profile
+            // Validate profile
+            profileStatus = await this.getProfileSetting(theProfile);
+        } else {
+            // Profile should have enough information to allow validation
             profileStatus = await this.getProfileSetting(theProfile);
         }
         switch (profileStatus.status) {

--- a/packages/zowe-explorer/src/abstract/ZoweTreeProvider.ts
+++ b/packages/zowe-explorer/src/abstract/ZoweTreeProvider.ts
@@ -193,10 +193,8 @@ export class ZoweTreeProvider {
                 node.contextValue.toLowerCase().includes("session") ||
                 node.contextValue.toLowerCase().includes("server")
             ) {
-                // change contextValue only if the word inactive is not there
-                if (node.contextValue.toLowerCase().indexOf("inactive") === -1) {
-                    node.contextValue = node.contextValue + globals.INACTIVE_CONTEXT;
-                }
+                node.contextValue = node.contextValue.replace(/(?<=.*)(_Active|_Inactive|_Unverified)$/, "");
+                node.contextValue = node.contextValue + globals.INACTIVE_CONTEXT;
                 const inactiveIcon = getIconById(IconId.sessionInactive);
                 if (inactiveIcon) {
                     node.iconPath = inactiveIcon.path;
@@ -224,10 +222,8 @@ export class ZoweTreeProvider {
                 node.contextValue.toLowerCase().includes("session") ||
                 node.contextValue.toLowerCase().includes("server")
             ) {
-                // change contextValue only if the word active is not there
-                if (node.contextValue.toLowerCase().indexOf("active") === -1) {
-                    node.contextValue = node.contextValue + globals.ACTIVE_CONTEXT;
-                }
+                node.contextValue = node.contextValue.replace(/(?<=.*)(_Active|_Inactive|_Unverified)$/, "");
+                node.contextValue = node.contextValue + globals.ACTIVE_CONTEXT;
                 const activeIcon = getIconById(IconId.sessionActive);
                 if (activeIcon) {
                     node.iconPath = activeIcon.path;
@@ -238,10 +234,8 @@ export class ZoweTreeProvider {
                 node.contextValue.toLowerCase().includes("session") ||
                 node.contextValue.toLowerCase().includes("server")
             ) {
-                // change contextValue only if the word unverified is not there
-                if (node.contextValue.toLowerCase().indexOf("unverified") === -1) {
-                    node.contextValue = node.contextValue + globals.UNVERIFIED_CONTEXT;
-                }
+                node.contextValue = node.contextValue.replace(/(?<=.*)(_Active|_Inactive|_Unverified)$/, "");
+                node.contextValue = node.contextValue + globals.UNVERIFIED_CONTEXT;
             }
         }
         await this.refresh();


### PR DESCRIPTION
## Proposed changes

In PR #1120, we noticed that users won't be prompted to enter their credentials, if a profile was previously marked `invalid`.

This should cause prompting to occur if the user is missing enough credentials in their session/combined profiles, no matter whether the profile was validated before or not.

I've tested this with the contents of PRs #1120 & #1150 and found no huge showstoppers.

## Release Notes
Milestone: 1.12.1
Changelog: Updated credential prompting to occur even if profile has been marked "invalid".

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

Would prefer this to be merged before #1120 & #1150 (not absolutely necessary but that's how I tested them)