### PR TITLE
update check for missing creds to not rely on base profile

### DIFF
--- a/packages/zowe-explorer/src/Profiles.ts
+++ b/packages/zowe-explorer/src/Profiles.ts
@@ -71,27 +71,13 @@ export class Profiles extends ProfilesCache {
     private dsSchema: string = "Zowe-DS-Persistent";
     private ussSchema: string = "Zowe-USS-Persistent";
     private jobsSchema: string = "Zowe-Jobs-Persistent";
-    private usrNme: string;
-    private passWrd: string;
-    private baseEncd: string;
     public constructor(log: Logger) {
         super(log);
     }
 
     public async checkCurrentProfile(theProfile: IProfileLoaded) {
         let profileStatus: IProfileValidation;
-
-        // This step is for prompting of credentials. It will be triggered if it meets the following conditions:
-        // - The service does not have username or password and base profile doesn't exists
-        // - The service does not have username or password and the base profile has a different host and port
-        const baseProfile = this.getBaseProfile();
-
-        if (
-            (!theProfile.profile.tokenType && (!theProfile.profile.user || !theProfile.profile.password)) ||
-            (baseProfile &&
-                baseProfile.profile.host !== theProfile.profile.host &&
-                baseProfile.profile.port !== theProfile.profile.port)
-        ) {
+        if (!theProfile.profile.tokenType && (!theProfile.profile.user || !theProfile.profile.password)) {
             // The profile will need to be reactivated, so remove it from profilesForValidation
             this.profilesForValidation.filter((profile, index) => {
                 if (profile.name === theProfile.name && profile.status !== "unverified") {


### PR DESCRIPTION
Signed-off-by: Billie Simmons <49491949+JillieBeanSim@users.noreply.github.com>

 I believe these lines can be taken out since the prompt doesn't worry about host and port, and after testing all profiles work (creds included, creds as empty string, and creds as undefined) https://github.com/zowe/vscode-extension-for-zowe/blob/62442606b95dc048d2c829b78d0ee7e93029facb/packages/zowe-explorer/src/Profiles.ts#L91. By the time this method is called the base profile merging is already done so that line I mentioned isn't useful and the prompting that is called within that try is only dealing with user/pass not other values.  So if a profile has user/pass but doesn't match the host and port of the base profile you are prompted. Once that is taken out line 87 is no longer needed as well.  Also lines 74-76 can be removed as lines 105-107 are using diff variables now.