### PR TITLE
Issue #992: File picker doesn't work

### DIFF
--- a/packages/zowe-explorer/i18n/sample/src/Profiles.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/Profiles.i18n.json
@@ -23,7 +23,6 @@
   "createNewConnection.undefined.port": "Invalid Port number provided or operation was cancelled",
   "createNewConnection.undefined.username": "Operation Cancelled",
   "createNewConnection.rejectUnauthorize": "Operation Cancelled",
-  "createNewConnection.number": "Operation Cancelled",
   "createNewConnection.booleanValue": "Operation Cancelled",
   "createNewConnection.default": "Operation Cancelled",
   "createNewConnection.duplicateProfileName": "Profile name already exists. Please create a profile using a different name",

--- a/packages/zowe-explorer/src/shared/actions.ts
+++ b/packages/zowe-explorer/src/shared/actions.ts
@@ -68,7 +68,7 @@ export async function searchInAllLoadedItems(
 
     let qpItem: vscode.QuickPickItem;
     for (const item of items) {
-        if (item.constructor.name === "ZoweDatasetNode") {
+        if (contextually.isDs(item) || contextually.isPdsNotFav(item) || contextually.isVsam(item)) {
             if (contextually.isDsMember(item)) {
                 qpItem = new FilterItem(
                     `[${item.getSessionNode().label.trim()}]: ${item.getParent().label.trim()}(${item.label.trim()})`,
@@ -78,7 +78,7 @@ export async function searchInAllLoadedItems(
                 qpItem = new FilterItem(`[${item.getSessionNode().label.trim()}]: ${item.label.trim()}`, "Data Set");
             }
             qpItems.push(qpItem);
-        } else if (item.constructor.name === "ZoweUSSNode") {
+        } else if (contextually.isUssDirectory(item) || contextually.isText(item) || contextually.isBinary(item)) {
             const filterItem = `[${item.getProfileName().trim()}]: ${item.getParent().fullPath}/${item.label.trim()}`;
             qpItem = new FilterItem(filterItem, "USS");
             qpItems.push(qpItem);


### PR DESCRIPTION
## Proposed changes

This fixes issue #992...apparently class name is not a reliable way to determine the type of a custom object in VSCode...

## Release Notes

Milestone: 1.13
Changelog: Fixed bug with listing files on CTRL+ALT+P command

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)