### PR TITLE
issue 1127: Pre-select existing reject unauthorized value for update profile

### DIFF
--- a/packages/zowe-explorer/i18n/sample/src/Profiles.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/Profiles.i18n.json
@@ -61,5 +61,7 @@
   "createNewConnection.undefined.passWord": "Operation Cancelled",
   "createNewConnection.option.prompt.password.placeholder": "Password",
   "createNewConnection.option.prompt.password": "Enter the password for the connection. Leave blank to not store.",
+  "createNewConnection.ru.false": "False - Accept connections with self-signed certificates",
+  "createNewConnection.ru.true": "True - Reject connections with self-signed certificates",
   "createNewConnection.option.prompt.ru.placeholder": "Reject Unauthorized Connections"
 }

--- a/packages/zowe-explorer/src/Profiles.ts
+++ b/packages/zowe-explorer/src/Profiles.ts
@@ -1474,32 +1474,49 @@ export class Profiles extends ProfilesCache {
 
     private async ruInfo(input?) {
         let rejectUnauthorize: boolean;
+        let placeholder: string;
+        let selectRU: string[];
 
-        if (input !== undefined) {
-            rejectUnauthorize = input;
-        }
+        const leadingFalse = [
+            "False - Accept connections with self-signed certificates",
+            "True - Reject connections with self-signed certificates",
+        ];
 
-        const quickPickOptions: vscode.QuickPickOptions = {
-            placeHolder: localize(
-                "createNewConnection.option.prompt.ru.placeholder",
-                "Reject Unauthorized Connections"
-            ),
-            ignoreFocusOut: true,
-            canPickMany: false,
-        };
-
-        const selectRU = [
+        const leadingTrue = [
             "True - Reject connections with self-signed certificates",
             "False - Accept connections with self-signed certificates",
         ];
+
+        if (input !== undefined) {
+            rejectUnauthorize = input;
+            if (!input) {
+                placeholder = "False - Accept connections with self-signed certificates";
+                selectRU = leadingFalse;
+            } else {
+                placeholder = "True - Reject connections with self-signed certificates";
+                selectRU = leadingTrue;
+            }
+        } else {
+            placeholder = localize(
+                "createNewConnection.option.prompt.ru.placeholder",
+                "Reject Unauthorized Connections"
+            );
+            selectRU = leadingTrue;
+        }
+
+        const quickPickOptions: vscode.QuickPickOptions = {
+            placeHolder: placeholder,
+            ignoreFocusOut: true,
+            canPickMany: false,
+        };
 
         const ruOptions = Array.from(selectRU);
 
         const chosenRU = await vscode.window.showQuickPick(ruOptions, quickPickOptions);
 
-        if (chosenRU === ruOptions[0]) {
+        if (chosenRU && chosenRU.includes("True")) {
             rejectUnauthorize = true;
-        } else if (chosenRU === ruOptions[1]) {
+        } else if (chosenRU && chosenRU.includes("False")) {
             rejectUnauthorize = false;
         } else {
             vscode.window.showInformationMessage(

--- a/packages/zowe-explorer/src/Profiles.ts
+++ b/packages/zowe-explorer/src/Profiles.ts
@@ -1476,32 +1476,30 @@ export class Profiles extends ProfilesCache {
         let rejectUnauthorize: boolean;
         let placeholder: string;
         let selectRU: string[];
-
-        const leadingFalse = [
-            "False - Accept connections with self-signed certificates",
-            "True - Reject connections with self-signed certificates",
-        ];
-
-        const leadingTrue = [
-            "True - Reject connections with self-signed certificates",
-            "False - Accept connections with self-signed certificates",
-        ];
+        const falseString = localize(
+            "createNewConnection.ru.false",
+            "False - Accept connections with self-signed certificates"
+        );
+        const trueString = localize(
+            "createNewConnection.ru.true",
+            "True - Reject connections with self-signed certificates"
+        );
 
         if (input !== undefined) {
             rejectUnauthorize = input;
             if (!input) {
-                placeholder = "False - Accept connections with self-signed certificates";
-                selectRU = leadingFalse;
+                placeholder = falseString;
+                selectRU = [falseString, trueString];
             } else {
-                placeholder = "True - Reject connections with self-signed certificates";
-                selectRU = leadingTrue;
+                placeholder = trueString;
+                selectRU = [trueString, falseString];
             }
         } else {
             placeholder = localize(
                 "createNewConnection.option.prompt.ru.placeholder",
                 "Reject Unauthorized Connections"
             );
-            selectRU = leadingTrue;
+            selectRU = [trueString, falseString];
         }
 
         const quickPickOptions: vscode.QuickPickOptions = {
@@ -1514,9 +1512,9 @@ export class Profiles extends ProfilesCache {
 
         const chosenRU = await vscode.window.showQuickPick(ruOptions, quickPickOptions);
 
-        if (chosenRU && chosenRU.includes("True")) {
+        if (chosenRU && chosenRU.includes(trueString)) {
             rejectUnauthorize = true;
-        } else if (chosenRU && chosenRU.includes("False")) {
+        } else if (chosenRU && chosenRU.includes(falseString)) {
             rejectUnauthorize = false;
         } else {
             vscode.window.showInformationMessage(


### PR DESCRIPTION
Signed-off-by: Billie Simmons <49491949+JillieBeanSim@users.noreply.github.com>

## Proposed changes

This will pre-fill the placeholder with a previously chosen `rejectUnauthorized` value as well as bring that selection to the top of the list and is highlighted to be entered passed or changed by user when editing a profile.  Creating a profile the placeholder is the same as before as well as the selection order.

![leading-selected-RU](https://user-images.githubusercontent.com/49491949/109711114-7f752480-7b6c-11eb-961b-9134da96f3c8.gif)

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog -->
<!-- If there is a linked issue, it should have the same milestone as this PR -->

Milestone: 1.13.0

Changelog: Bugfix to pre-select existing value for rejectUnauthorized and show existing value in the quickPick placeholder so it can be entered by unless user decides to change the value.

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [x] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
