### PR TITLE
Bugfix issue 1134: Add parentPath check for existing USS node children

### DIFF
--- a/packages/zowe-explorer/src/uss/ZoweUSSNode.ts
+++ b/packages/zowe-explorer/src/uss/ZoweUSSNode.ts
@@ -124,6 +124,15 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
         return this.returnmProfileName();
     }
 
+    /**
+     * Get parent path for USS node.
+     *
+     * @returns {string}
+     */
+    public getParentPath(): string {
+        return this.parentPath;
+    }
+
     public getSessionNode(): IZoweUSSTreeNode {
         return this.session ? this : this.getParent().getSessionNode();
     }
@@ -185,7 +194,11 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
 
             // Loops through all the returned file references members and creates nodes for them
             for (const item of response.apiResponse.items) {
-                const existing = this.children.find((element) => element.label.trim() === item.name);
+                const existing = this.children.find(
+                    // Ensure both parent path and short label match.
+                    // (Can't use mParent fullPath since that is already updated with new value by this point in getChildren.)
+                    (element: ZoweUSSNode) => element.parentPath === this.fullPath && element.label.trim() === item.name
+                );
                 if (existing) {
                     elementChildren[existing.label] = existing;
                 } else if (item.name !== "." && item.name !== "..") {

--- a/packages/zowe-explorer/src/uss/ZoweUSSNode.ts
+++ b/packages/zowe-explorer/src/uss/ZoweUSSNode.ts
@@ -124,15 +124,6 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
         return this.returnmProfileName();
     }
 
-    /**
-     * Get parent path for USS node.
-     *
-     * @returns {string}
-     */
-    public getParentPath(): string {
-        return this.parentPath;
-    }
-
     public getSessionNode(): IZoweUSSTreeNode {
         return this.session ? this : this.getParent().getSessionNode();
     }


### PR DESCRIPTION
## Proposed changes

Resolves issue #1134 (USS files menu serves incorrect content from another directory).

This PR adds a `parentPath` (file path) check to the check for existing USS node children when `getChildren` is called on the USS node. Previously, only the label (i.e. the very last part of the filepath) was being compared, leading to identically-named files/folders being identified as "existing children", when they were in fact residing under different directories (e.g. different user directories).

## Release Notes

Milestone: 1.13.0

Changelog: Bugfix to check file path when comparing for existing USS node children.

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [x] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)