### PR TITLE
Allow refresh for dataset member names

### DIFF
--- a/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
@@ -116,6 +116,7 @@ async function createGlobalMocks() {
             "zowe.addFavorite",
             "zowe.refreshAll",
             "zowe.refreshNode",
+            "zowe.refreshDataset",
             "zowe.pattern",
             "zowe.editSession",
             "zowe.ZoweNode.openPS",

--- a/packages/zowe-explorer/i18n/sample/package.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/package.i18n.json
@@ -26,6 +26,7 @@
   "uploadDialog": "Upload Member...",
   "pattern": "Search Data Sets",
   "refreshNode": "Pull from Mainframe",
+  "refreshDataset": "Refresh",
   "refreshAll": "Refresh Data Sets View",
   "removeFavorite": "Remove Favorite",
   "uss.removeFavorite": "Remove Favorite",

--- a/packages/zowe-explorer/i18n/sample/package.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/package.i18n.json
@@ -26,7 +26,7 @@
   "uploadDialog": "Upload Member...",
   "pattern": "Search Data Sets",
   "refreshNode": "Pull from Mainframe",
-  "refreshDataset": "Refresh",
+  "refreshDataset": "Refresh Data Set",
   "refreshAll": "Refresh Data Sets View",
   "removeFavorite": "Remove Favorite",
   "uss.removeFavorite": "Remove Favorite",

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -865,7 +865,7 @@
           "group": "1_create@2"
         },
         {
-          "when": "view == zowe.explorer && viewItem =~ /^(ds|pds).*/",
+          "when": "view == zowe.explorer && viewItem =~ /^pds.*/",
           "command": "zowe.refreshDataset",
           "group": "1_create@2"
         },

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -336,6 +336,15 @@
         }
       },
       {
+        "command": "zowe.refreshDataset",
+        "title": "%refreshDataset%",
+        "category": "Zowe Explorer",
+        "icon": {
+          "light": "./resources/light/download.svg",
+          "dark": "./resources/dark/download.svg"
+        }
+      },
+      {
         "command": "zowe.removeFavorite",
         "title": "%removeFavorite%",
         "category": "Zowe Explorer",
@@ -856,6 +865,11 @@
           "group": "1_create@2"
         },
         {
+          "when": "view == zowe.explorer && viewItem =~ /^(ds|pds).*/",
+          "command": "zowe.refreshDataset",
+          "group": "1_create@2"
+        },
+        {
           "when": "view == zowe.explorer && viewItem =~ /^(?!.*_fav.*)session.*/",
           "command": "zowe.createDataset",
           "group": "1_create@2"
@@ -1168,6 +1182,10 @@
         },
         {
           "command": "zowe.refreshNode",
+          "when": "never"
+        },
+        {
+          "command": "zowe.refreshDataset",
           "when": "never"
         },
         {

--- a/packages/zowe-explorer/package.nls.json
+++ b/packages/zowe-explorer/package.nls.json
@@ -26,6 +26,7 @@
   "uploadDialog": "Upload Member...",
   "pattern": "Search Data Sets",
   "refreshNode": "Pull from Mainframe",
+  "refreshDataset": "Refresh",
   "refreshAll": "Refresh Data Sets View",
   "removeFavorite": "Remove Favorite",
   "uss.removeFavorite": "Remove Favorite",

--- a/packages/zowe-explorer/package.nls.json
+++ b/packages/zowe-explorer/package.nls.json
@@ -26,7 +26,7 @@
   "uploadDialog": "Upload Member...",
   "pattern": "Search Data Sets",
   "refreshNode": "Pull from Mainframe",
-  "refreshDataset": "Refresh",
+  "refreshDataset": "Refresh Data Set",
   "refreshAll": "Refresh Data Sets View",
   "removeFavorite": "Remove Favorite",
   "uss.removeFavorite": "Remove Favorite",

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -945,6 +945,21 @@ export async function refreshPS(node: IZoweDatasetTreeNode) {
 }
 
 /**
+ * Refreshes the names of each member within a PDS
+ *
+ * @param {IZoweDatasetTreeNode} node - The node which represents the parent PDS of members
+ * @param datasetProvider
+ */
+export async function refreshDataset(node: IZoweDatasetTreeNode) {
+    try {
+        await node.getChildren();
+        await this.refreshElement(node);
+    } catch (err) {
+        console.error(err.message);
+    }
+}
+
+/**
  * Prompts the user for a pattern, and populates the [TreeView]{@link vscode.TreeView} based on the pattern
  *
  * @param {IZoweDatasetTreeNode} node - The session node

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -950,12 +950,12 @@ export async function refreshPS(node: IZoweDatasetTreeNode) {
  * @param {IZoweDatasetTreeNode} node - The node which represents the parent PDS of members
  * @param datasetProvider
  */
-export async function refreshDataset(node: IZoweDatasetTreeNode) {
+export async function refreshDataset(node: IZoweDatasetTreeNode, datasetProvider: IZoweTree<IZoweDatasetTreeNode>) {
     try {
         await node.getChildren();
-        await this.refreshElement(node);
+        datasetProvider.refreshElement(node);
     } catch (err) {
-        console.error(err.message);
+        errorHandling(err, node.getProfileName(), err.message);
     }
 }
 

--- a/packages/zowe-explorer/src/extension.ts
+++ b/packages/zowe-explorer/src/extension.ts
@@ -226,6 +226,7 @@ function initDatasetProvider(context: vscode.ExtensionContext, datasetProvider: 
     vscode.commands.registerCommand("zowe.addFavorite", async (node) => datasetProvider.addFavorite(node));
     vscode.commands.registerCommand("zowe.refreshAll", () => refreshActions.refreshAll(datasetProvider));
     vscode.commands.registerCommand("zowe.refreshNode", (node) => dsActions.refreshPS(node));
+    vscode.commands.registerCommand("zowe.refreshDataset", (node) => dsActions.refreshDataset(node));
     vscode.commands.registerCommand("zowe.pattern", (node) => datasetProvider.filterPrompt(node));
     vscode.commands.registerCommand("zowe.editSession", async (node) =>
         datasetProvider.editSession(node, datasetProvider)

--- a/packages/zowe-explorer/src/extension.ts
+++ b/packages/zowe-explorer/src/extension.ts
@@ -226,7 +226,7 @@ function initDatasetProvider(context: vscode.ExtensionContext, datasetProvider: 
     vscode.commands.registerCommand("zowe.addFavorite", async (node) => datasetProvider.addFavorite(node));
     vscode.commands.registerCommand("zowe.refreshAll", () => refreshActions.refreshAll(datasetProvider));
     vscode.commands.registerCommand("zowe.refreshNode", (node) => dsActions.refreshPS(node));
-    vscode.commands.registerCommand("zowe.refreshDataset", (node) => dsActions.refreshDataset(node));
+    vscode.commands.registerCommand("zowe.refreshDataset", (node) => dsActions.refreshDataset(node, datasetProvider));
     vscode.commands.registerCommand("zowe.pattern", (node) => datasetProvider.filterPrompt(node));
     vscode.commands.registerCommand("zowe.editSession", async (node) =>
         datasetProvider.editSession(node, datasetProvider)

--- a/packages/zowe-explorer/src/globals.ts
+++ b/packages/zowe-explorer/src/globals.ts
@@ -29,7 +29,7 @@ export let USS_DIR;
 export let DS_DIR;
 export let ISTHEIA: boolean = false; // set during activate
 export let LOG: Logger;
-export const COMMAND_COUNT = 93;
+export const COMMAND_COUNT = 94;
 export const MAX_SEARCH_HISTORY = 5;
 export const MAX_FILE_HISTORY = 10;
 export const CONTEXT_PREFIX = "_";


### PR DESCRIPTION
Signed-off-by: Rudy Flores <68666202+rudyflores@users.noreply.github.com>

## Proposed changes
Adding a right-click action to refresh data sets to retrieve new list of members from the mainframe

![refresh-pds](https://user-images.githubusercontent.com/68666202/120826342-f16c5980-c51f-11eb-95b7-85a88654aa6a.gif)

## Release Notes

Milestone: Release v1.16.0
Changelog: Refresh feature for data set member names in a profile.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [x] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments
