### PR TITLE
Add new setting to hide temp folder from settings

### DIFF
--- a/packages/zowe-explorer/i18n/sample/package.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/package.i18n.json
@@ -67,6 +67,7 @@
   "Zowe-Default-Datasets-PS": "Default values of Sequential data set creation",
   "Zowe-Default-Datasets-Favorites": "Toggle if favorite files persist locally",
   "Zowe-Temp-Folder-Loacation": "Path to temporary folder location",
+  "Zowe-Hide-Temp-Folder": "Hide the Zowe temporary folder from the workspace",
   "Zowe-Builtin-Security": "Built-in Security. Specify a service of either 'Zowe-Plugin' when using the Secure Credentials Store plugin or @zowe/cli to describe a keytar based solution. The Default 'blank' represents no security. User names and passwords are stored in the clear.",
   "Zowe-Default-USS-Persistent-Favorites": "Toggle if USS favorite files persist locally",
   "Zowe-Default-Jobs-Persistent-Favorites": "Toggle if Jobs favorite files persist locally",

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -1562,6 +1562,12 @@
           "description": "Zowe-Temp-Folder-Loacation",
           "scope": "window"
         },
+        "Zowe-Hide-Temp-Folder": {
+          "type": "boolean",
+          "default": true,
+          "description": "%Zowe-Hide-Temp-Folder%",
+          "scope": "window"
+        },
         "Zowe Security: Credential Key": {
           "type": "string",
           "default": "",

--- a/packages/zowe-explorer/package.nls.json
+++ b/packages/zowe-explorer/package.nls.json
@@ -67,6 +67,7 @@
   "Zowe-Default-Datasets-PS": "Default values of Sequential data set creation",
   "Zowe-Default-Datasets-Favorites": "Toggle if favorite files persist locally",
   "Zowe-Temp-Folder-Loacation": "Path to temporary folder location",
+  "Zowe-Hide-Temp-Folder": "Hide the Zowe temporary folder from the workspace",
   "Zowe-Builtin-Security": "Built-in Security. Specify a service of either 'Zowe-Plugin' when using the Secure Credentials Store plugin or @zowe/cli to describe a keytar based solution. The Default 'blank' represents no security. User names and passwords are stored in the clear.",
   "Zowe-Default-USS-Persistent-Favorites": "Toggle if USS favorite files persist locally",
   "Zowe-Default-Jobs-Persistent-Favorites": "Toggle if Jobs favorite files persist locally",

--- a/packages/zowe-explorer/src/extension.ts
+++ b/packages/zowe-explorer/src/extension.ts
@@ -41,6 +41,7 @@ import SpoolProvider from "./SpoolProvider";
 import * as nls from "vscode-nls";
 import { TsoCommandHandler } from "./command/TsoCommandHandler";
 import { cleanTempDir, moveTempFolder } from "./utils/TempFolder";
+import { PersistentFilters } from "./PersistentFilters";
 
 // Set up localization
 nls.config({
@@ -65,6 +66,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<ZoweEx
 
     // Determine the runtime framework to support special behavior for Theia
     globals.defineGlobals(preferencesTempPath);
+
+    if (PersistentFilters.getDirectValue("Zowe-Hide-Temp-Folder") as boolean) {
+        vscode.workspace
+            .getConfiguration("files")
+            .update(
+                "exclude",
+                { [getZoweDir()]: true, [globals.ZOWETEMPFOLDER]: true },
+                vscode.ConfigurationTarget.Workspace
+            );
+    }
 
     // Call cleanTempDir before continuing
     // this is to handle if the application crashed on a previous execution and


### PR DESCRIPTION
Signed-off-by: Richelle Anne Craw <richelleanne.craw@broadcom.com>

## Proposed changes

Add a new setting to hide the Zowe Temp Folder from the workspace
<img src="https://user-images.githubusercontent.com/45845502/123245833-7de9b680-d4e5-11eb-8285-ba7587dcd52e.png" alt="setting" width="400"/>

## Release Notes

Milestone: 1.17.0

Changelog: Added a new setting to hide the Zowe Temp Folder from the workspace

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [x] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

Changes here wer proposed in the comments from PR #1367 
