### PR TITLE
Issue 1403: Ensure status icons are reset when refreshing view

### DIFF
--- a/packages/zowe-explorer/src/shared/actions.ts
+++ b/packages/zowe-explorer/src/shared/actions.ts
@@ -229,9 +229,14 @@ export async function openRecentMemberPrompt(
 }
 
 export async function returnIconState(node: IZoweNodeType) {
-    const activePath = getIconById(IconId.sessionActive);
-    const inactivePath = getIconById(IconId.sessionInactive);
-    if (node.iconPath === activePath.path || node.iconPath === inactivePath.path) {
+    const activePathClosed = getIconById(IconId.sessionActive);
+    const activePathOpen = getIconById(IconId.sessionActiveOpen);
+    const inactivePathClosed = getIconById(IconId.sessionInactive); // So far, we only ever reference the closed inactive icon, not the open one
+    if (
+        node.iconPath === activePathClosed.path ||
+        node.iconPath === activePathOpen.path ||
+        node.iconPath === inactivePathClosed.path
+    ) {
         const sessionIcon = getIconById(IconId.session);
         if (sessionIcon) {
             node.iconPath = sessionIcon.path;
@@ -243,6 +248,8 @@ export async function returnIconState(node: IZoweNodeType) {
 export async function resetValidationSettings(node: IZoweNodeType, setting: boolean) {
     if (setting) {
         await Profiles.getInstance().enableValidationContext(node);
+        // Ensure validation status is also reset
+        node.contextValue = node.contextValue.replace(/(_Active)/g, "").replace(/(_Inactive)/g, "");
     } else {
         await Profiles.getInstance().disableValidationContext(node);
     }

--- a/packages/zowe-explorer/src/shared/refresh.ts
+++ b/packages/zowe-explorer/src/shared/refresh.ts
@@ -32,11 +32,11 @@ export async function refreshAll(treeProvider: IZoweTree<IZoweTreeNode>) {
             labelRefresh(sessNode);
             sessNode.children = [];
             sessNode.dirty = true;
+            resetValidationSettings(sessNode, setting);
+            returnIconState(sessNode);
             await syncSessionNode(Profiles.getInstance())((profileValue) =>
                 ZoweExplorerApiRegister.getCommonApi(profileValue).getSession()
             )(sessNode);
-            resetValidationSettings(sessNode, setting);
-            returnIconState(sessNode);
         }
     });
     treeProvider.refresh();


### PR DESCRIPTION
## Proposed changes

Fixes issue #1403 (Refresh view does not consistently reset profile status).
(See issue for recreate/testing steps.)

Gif of fix:

![ze-refreshIconsFix](https://user-images.githubusercontent.com/45975633/126639754-d445cf99-bfce-4bcf-85f2-f3dc51e69f7e.gif)

## Release Notes

Milestone: 1.17.1 hotfix or 1.18.0

Changelog: Ensure status icons are reset when refreshing views

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [x] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
