### PR TITLE
(doc)1.18.1 updates into v1.18.x branch

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -5,9 +5,8 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 ## `1.18.1`
 
 - Improved integration tests for greater efficiency [#1430](https://github.com/zowe/vscode-extension-for-zowe/pull/1430). Thanks @katelynienaber
-- Introduced improvements for @dependabot. Bumped path-parse from 1.0.6 to 1.0.7 [#1441](https://github.com/zowe/vscode-extension-for-zowe/pull/1441). Thanks @lauren-li
 - Added a reminder to the PR template to create a PR from `master` to `next` after PR is merged into `master` branch [#1446](https://github.com/zowe/vscode-extension-for-zowe/pull/1446). Thanks @JillieBeanSim
-- Added CLI dependency to api [#1445](https://github.com/zowe/vscode-extension-for-zowe/pull/1445). Thanks @phaumer
+- Added CLI dependency to API [#1445](https://github.com/zowe/vscode-extension-for-zowe/pull/1445). Thanks @phaumer
 - Fix for the issue that caused mismatching of GitHub VSIX Zowe Explorer releases [#1442](https://github.com/zowe/vscode-extension-for-zowe/pull/1442). Thanks @katelynienaber
 
 ## `1.18.0`

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 - Improved integration tests for greater efficiency [#1430](https://github.com/zowe/vscode-extension-for-zowe/pull/1430). Thanks @katelynienaber
 - Added a reminder to the PR template to create a PR from `master` to `next` after PR is merged into `master` branch [#1446](https://github.com/zowe/vscode-extension-for-zowe/pull/1446). Thanks @JillieBeanSim
-- Added CLI dependency to API [#1445](https://github.com/zowe/vscode-extension-for-zowe/pull/1445). Thanks @phaumer
+- Added @zowe/cli dependency to API [#1445](https://github.com/zowe/vscode-extension-for-zowe/pull/1445). Thanks @phaumer
 - Fix for the issue that caused mismatching of GitHub VSIX Zowe Explorer releases [#1442](https://github.com/zowe/vscode-extension-for-zowe/pull/1442). Thanks @katelynienaber
 
 ## `1.18.0`

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the "vscode-extension-for-zowe" extension will be documented in this file.
 
+## `1.18.1`
+
+- Improved integration tests for greater efficiency [#1430](https://github.com/zowe/vscode-extension-for-zowe/pull/1430). Thanks @katelynienaber
+- Introduced improvements for @dependabot. Bumped path-parse from 1.0.6 to 1.0.7 [#1441](https://github.com/zowe/vscode-extension-for-zowe/pull/1441). Thanks @lauren-li
+- Added a reminder to the PR template to create a PR from `master` to `next` after PR is merged into `master` branch [#1446](https://github.com/zowe/vscode-extension-for-zowe/pull/1446). Thanks @JillieBeanSim
+- Added cli dependency to api [#1445](https://github.com/zowe/vscode-extension-for-zowe/pull/1445). Thanks @phaumer
+- Fix for the issue that caused mismatching of GitHub VSIX Zowe Explorer releases [#1442](https://github.com/zowe/vscode-extension-for-zowe/pull/1442). Thanks @katelynienaber
+
 ## `1.18.0`
 
 - Added the ability to register custom profile types in `ProfilesCache` for extenders [#1419](https://github.com/zowe/vscode-extension-for-zowe/pull/1419). Thanks @phaumer

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Improved integration tests for greater efficiency [#1430](https://github.com/zowe/vscode-extension-for-zowe/pull/1430). Thanks @katelynienaber
 - Introduced improvements for @dependabot. Bumped path-parse from 1.0.6 to 1.0.7 [#1441](https://github.com/zowe/vscode-extension-for-zowe/pull/1441). Thanks @lauren-li
 - Added a reminder to the PR template to create a PR from `master` to `next` after PR is merged into `master` branch [#1446](https://github.com/zowe/vscode-extension-for-zowe/pull/1446). Thanks @JillieBeanSim
-- Added cli dependency to api [#1445](https://github.com/zowe/vscode-extension-for-zowe/pull/1445). Thanks @phaumer
+- Added CLI dependency to api [#1445](https://github.com/zowe/vscode-extension-for-zowe/pull/1445). Thanks @phaumer
 - Fix for the issue that caused mismatching of GitHub VSIX Zowe Explorer releases [#1442](https://github.com/zowe/vscode-extension-for-zowe/pull/1442). Thanks @katelynienaber
 
 ## `1.18.0`

--- a/packages/zowe-explorer/README.md
+++ b/packages/zowe-explorer/README.md
@@ -36,7 +36,7 @@ More information:
 Added:
 
 - Added a reminder to the PR template to create a PR from `master` to `next` after PR is merged into `master` branch.
-- Added cli dependency to API.
+- Added CLI dependency to API.
 
 **Changed**:
 

--- a/packages/zowe-explorer/README.md
+++ b/packages/zowe-explorer/README.md
@@ -33,7 +33,7 @@ More information:
 
 ## What's new in Zowe Explorer 1.18.1
 
-Added:
+**Added**:
 
 - Added a reminder to the PR template to create a PR from `master` to `next` after PR is merged into `master` branch.
 - Added CLI dependency to API.

--- a/packages/zowe-explorer/README.md
+++ b/packages/zowe-explorer/README.md
@@ -41,7 +41,6 @@ Added:
 **Changed**:
 
 - Improved integration tests for greater efficiency.
-- Introduced improvements for @dependabot. Bumped path-parse from 1.0.6 to 1.0.7
 
 **Fixed**:
 

--- a/packages/zowe-explorer/README.md
+++ b/packages/zowe-explorer/README.md
@@ -36,7 +36,7 @@ More information:
 **Added**:
 
 - Added a reminder to the PR template to create a PR from `master` to `next` after PR is merged into `master` branch.
-- Added CLI dependency to API.
+- Added @zowe/cli dependency to API.
 
 **Changed**:
 

--- a/packages/zowe-explorer/README.md
+++ b/packages/zowe-explorer/README.md
@@ -23,7 +23,7 @@ More information:
 
 ## Contents
 
-- [What's new in Zowe Explorer 1.18.1](#whats-new-in-zowe-explorer-1.18.1)
+- [What's new in Zowe Explorer 1.18.1](#whats-new-in-zowe-explorer-1181)
 - [Prerequisites](#prerequisites)
 - [Getting Started](#getting-started)
 - [Sample Use Cases](#sample-use-cases)

--- a/packages/zowe-explorer/README.md
+++ b/packages/zowe-explorer/README.md
@@ -23,7 +23,7 @@ More information:
 
 ## Contents
 
-- [What's new in Zowe Explorer 1.18.0](#whats-new-in-zowe-explorer-1.18.0)
+- [What's new in Zowe Explorer 1.18.1](#whats-new-in-zowe-explorer-1.18.1)
 - [Prerequisites](#prerequisites)
 - [Getting Started](#getting-started)
 - [Sample Use Cases](#sample-use-cases)
@@ -31,23 +31,21 @@ More information:
 - [Usage Tips](#usage-tips)
 - [Extending Zowe Explorer](#extending-zowe-explorer)
 
-## What's new in Zowe Explorer 1.18.0
+## What's new in Zowe Explorer 1.18.1
 
-**Added**:
+Added:
 
-- Added the ability to register custom profile types in `ProfilesCache` for extenders.
-- Added the ability to pass account and other information from tso profile.
-- Add profiles cache to extenders.
+- Added a reminder to the PR template to create a PR from `master` to `next` after PR is merged into `master` branch.
+- Added cli dependency to API.
 
 **Changed**:
 
-- Status icons now reset when refreshing the explorer views.
+- Improved integration tests for greater efficiency.
+- Introduced improvements for @dependabot. Bumped path-parse from 1.0.6 to 1.0.7
 
 **Fixed**:
 
-- Fixed the issue that prevented the expected error message `No valid value for z/OS URL. Operation Cancelled` from being displayed while escaping the host text box during the creation or update of a profile.
-- Fixed the issue that invoked profile validation before updating a profile. Now a profile is validated only after the update.
-- Fixed the issue of Zowe profiles encoding value when opening a USS file in the text editor.
+- Fix for the issue that caused mismatching of GitHub VSIX Zowe Explorer releases.
 
 For more information, see [Changelog](https://marketplace.visualstudio.com/items/Zowe.vscode-extension-for-zowe/changelog).
 


### PR DESCRIPTION
## Proposed changes

Moves doc updates into `v1.18.x` branch from PR #1451 (Update Readme and Changelog for 1.18.1).