### PR TITLE
Revert "(Docs) Update Readme and Changelog for 1.18.1"

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -2,13 +2,6 @@
 
 All notable changes to the "vscode-extension-for-zowe" extension will be documented in this file.
 
-## `1.18.1`
-
-- Improved integration tests for greater efficiency [#1430](https://github.com/zowe/vscode-extension-for-zowe/pull/1430). Thanks @katelynienaber
-- Added a reminder to the PR template to create a PR from `master` to `next` after PR is merged into `master` branch [#1446](https://github.com/zowe/vscode-extension-for-zowe/pull/1446). Thanks @JillieBeanSim
-- Added @zowe/cli dependency to API [#1445](https://github.com/zowe/vscode-extension-for-zowe/pull/1445). Thanks @phaumer
-- Fix for the issue that caused mismatching of GitHub VSIX Zowe Explorer releases [#1442](https://github.com/zowe/vscode-extension-for-zowe/pull/1442). Thanks @katelynienaber
-
 ## `1.18.0`
 
 - Added the ability to register custom profile types in `ProfilesCache` for extenders [#1419](https://github.com/zowe/vscode-extension-for-zowe/pull/1419). Thanks @phaumer

--- a/packages/zowe-explorer/README.md
+++ b/packages/zowe-explorer/README.md
@@ -23,7 +23,7 @@ More information:
 
 ## Contents
 
-- [What's new in Zowe Explorer 1.18.1](#whats-new-in-zowe-explorer-1181)
+- [What's new in Zowe Explorer 1.18.0](#whats-new-in-zowe-explorer-1.18.0)
 - [Prerequisites](#prerequisites)
 - [Getting Started](#getting-started)
 - [Sample Use Cases](#sample-use-cases)
@@ -31,20 +31,23 @@ More information:
 - [Usage Tips](#usage-tips)
 - [Extending Zowe Explorer](#extending-zowe-explorer)
 
-## What's new in Zowe Explorer 1.18.1
+## What's new in Zowe Explorer 1.18.0
 
 **Added**:
 
-- Added a reminder to the PR template to create a PR from `master` to `next` after PR is merged into `master` branch.
-- Added @zowe/cli dependency to API.
+- Added the ability to register custom profile types in `ProfilesCache` for extenders.
+- Added the ability to pass account and other information from tso profile.
+- Add profiles cache to extenders.
 
 **Changed**:
 
-- Improved integration tests for greater efficiency.
+- Status icons now reset when refreshing the explorer views.
 
 **Fixed**:
 
-- Fix for the issue that caused mismatching of GitHub VSIX Zowe Explorer releases.
+- Fixed the issue that prevented the expected error message `No valid value for z/OS URL. Operation Cancelled` from being displayed while escaping the host text box during the creation or update of a profile.
+- Fixed the issue that invoked profile validation before updating a profile. Now a profile is validated only after the update.
+- Fixed the issue of Zowe profiles encoding value when opening a USS file in the text editor.
 
 For more information, see [Changelog](https://marketplace.visualstudio.com/items/Zowe.vscode-extension-for-zowe/changelog).
 


### PR DESCRIPTION
Reverts zowe/vscode-extension-for-zowe#1451 due to incorrect base branch for hotfix.

Contents of #1451 will be moved to the `v1.18.x` branch via #1452.