### PR TITLE
Add check for baseProfile before running getCombinedProfile in syncSessionNode

### DIFF
--- a/packages/zowe-explorer/__tests__/__unit__/shared/utils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/shared/utils.unit.test.ts
@@ -105,7 +105,7 @@ describe("Shared Utils Unit Tests - Function node.labelRefresh()", () => {
     });
 });
 
-describe("syncSession shared util function", () => {
+describe("syncSessionNode shared util function", () => {
     const serviceProfileName = "test";
     const serviceProfileValue = {
         name: serviceProfileName,
@@ -178,6 +178,21 @@ describe("syncSession shared util function", () => {
         const initialProfile = sessionNode.getProfile();
         expect(sessionNode.getSession()).toEqual(initialSession);
         expect(sessionNode.getProfile()).toEqual(initialProfile);
+        expect(sessionNode.collapsibleState).toEqual(vscode.TreeItemCollapsibleState.Collapsed);
+    });
+    it("should not try to combine service and base profiles when no base profile exists", async () => {
+        const getCombinedProfileSpy = jest.spyOn(Profiles.getInstance(), "getCombinedProfile");
+        const profiles = createInstanceOfProfile(serviceProfile);
+        profiles.loadNamedProfile = jest.fn(() => serviceProfileValue);
+        profiles.getBaseProfile = jest.fn(() => undefined);
+        const expectedSession = new Session({});
+        const sessionFromProfile = () => expectedSession;
+        // when
+        await utils.syncSessionNode(profiles)(sessionFromProfile)(sessionNode);
+        // then
+        expect(getCombinedProfileSpy).toBeCalledTimes(0);
+        expect(sessionNode.getSession()).toEqual(expectedSession);
+        expect(sessionNode.getProfile()).toEqual(serviceProfileValue);
         expect(sessionNode.collapsibleState).toEqual(vscode.TreeItemCollapsibleState.Collapsed);
     });
 });

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -141,7 +141,6 @@ export const syncSessionNode = (profiles: Profiles) => (getSessionForProfile: Se
     if (baseProfile) {
         profile = await profiles.getCombinedProfile(profile, baseProfile);
     }
-    // const combinedProfile = await profiles.getCombinedProfile(profile, baseProfile);
     const session = getSessionForProfile(profile);
     sessionNode.setSessionToChoice(session);
 };

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -138,8 +138,11 @@ export const syncSessionNode = (profiles: Profiles) => (getSessionForProfile: Se
     sessionNode.setProfileToChoice(profile);
 
     const baseProfile = profiles.getBaseProfile();
-    const combinedProfile = await profiles.getCombinedProfile(profile, baseProfile);
-    const session = getSessionForProfile(combinedProfile);
+    if (baseProfile) {
+        profile = await profiles.getCombinedProfile(profile, baseProfile);
+    }
+    // const combinedProfile = await profiles.getCombinedProfile(profile, baseProfile);
+    const session = getSessionForProfile(profile);
     sessionNode.setSessionToChoice(session);
 };
 


### PR DESCRIPTION
## Proposed changes

Fixes issue #1469 by checking that a base profile exists before running `getCombinedProfile()` in `syncSessionNode()`.

## Release Notes

Milestone: 1.19.0, ideally

Changelog: Check that a base profile exists before running the function to combine base and service profiles.

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [x] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Reminder

After a PR is merged into the `master` branch, create a PR from `master` to the `next` branch resolving any conflicts.
