### PR TITLE
[Next] Do not show undefined spool files for a job

### DIFF
--- a/packages/zowe-explorer/i18n/sample/src/job/ZoweJobNode.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/job/ZoweJobNode.i18n.json
@@ -1,6 +1,7 @@
 {
   "getChildren.search": "Use the search button to display jobs",
   "ZoweJobNode.getJobs.spoolfiles": "Get Job Spool files command submitted.",
+  "getChildren.noSpoolFiles": "There are no JES spool messages to display",
   "ZoweJobNode.getJobs.jobs": "Get Jobs command submitted.",
   "getChildren.error.response": "Retrieving response from "
 }

--- a/packages/zowe-explorer/src/job/ZoweJobNode.ts
+++ b/packages/zowe-explorer/src/job/ZoweJobNode.ts
@@ -102,39 +102,52 @@ export class Job extends ZoweTreeNode implements IZoweJobTreeNode {
                         );
                     }
                 );
-                const refreshTimestamp = Date.now();
-                spools
+                spools = spools
                     // filter out all the objects which do not seem to be correct Job File Document types
                     // see an issue #845 for the details
                     .filter(
                         (item) => !(item.id === undefined && item.ddname === undefined && item.stepname === undefined)
-                    )
-                    .forEach((spool) => {
-                        let prefix = spool.stepname;
-                        if (prefix === undefined) {
-                            prefix = spool.procstep;
-                        }
-                        const sessionName = this.getProfileName();
-                        const spoolNode = new Spool(
-                            `${spool.stepname}:${spool.ddname}(${spool.id})`,
-                            vscode.TreeItemCollapsibleState.None,
-                            this,
-                            this.session,
-                            spool,
-                            this.job,
-                            this
-                        );
-                        const icon = getIconByNode(spoolNode);
-                        if (icon) {
-                            spoolNode.iconPath = icon.path;
-                        }
-                        spoolNode.command = {
-                            command: "zowe.jobs.zosJobsOpenspool",
-                            title: "",
-                            arguments: [sessionName, spool, refreshTimestamp],
-                        };
-                        elementChildren.push(spoolNode);
-                    });
+                    );
+                if (!spools.length) {
+                    const noSpoolNode = new Spool(
+                        localize("getChildren.noSpoolFiles", "There are no JES spool messages to display"),
+                        vscode.TreeItemCollapsibleState.None,
+                        this,
+                        null,
+                        null,
+                        null,
+                        this
+                    );
+                    noSpoolNode.iconPath = null;
+                    return [noSpoolNode];
+                }
+                const refreshTimestamp = Date.now();
+                spools.forEach((spool) => {
+                    let prefix = spool.stepname;
+                    if (prefix === undefined) {
+                        prefix = spool.procstep;
+                    }
+                    const sessionName = this.getProfileName();
+                    const spoolNode = new Spool(
+                        `${spool.stepname}:${spool.ddname}(${spool.id})`,
+                        vscode.TreeItemCollapsibleState.None,
+                        this,
+                        this.session,
+                        spool,
+                        this.job,
+                        this
+                    );
+                    const icon = getIconByNode(spoolNode);
+                    if (icon) {
+                        spoolNode.iconPath = icon.path;
+                    }
+                    spoolNode.command = {
+                        command: "zowe.jobs.zosJobsOpenspool",
+                        title: "",
+                        arguments: [sessionName, spool, refreshTimestamp],
+                    };
+                    elementChildren.push(spoolNode);
+                });
             } else {
                 const jobs = await vscode.window.withProgress(
                     {

--- a/packages/zowe-explorer/src/job/ZoweJobNode.ts
+++ b/packages/zowe-explorer/src/job/ZoweJobNode.ts
@@ -103,32 +103,38 @@ export class Job extends ZoweTreeNode implements IZoweJobTreeNode {
                     }
                 );
                 const refreshTimestamp = Date.now();
-                spools.forEach((spool) => {
-                    let prefix = spool.stepname;
-                    if (prefix === undefined) {
-                        prefix = spool.procstep;
-                    }
-                    const sessionName = this.getProfileName();
-                    const spoolNode = new Spool(
-                        `${spool.stepname}:${spool.ddname}(${spool.id})`,
-                        vscode.TreeItemCollapsibleState.None,
-                        this,
-                        this.session,
-                        spool,
-                        this.job,
-                        this
-                    );
-                    const icon = getIconByNode(spoolNode);
-                    if (icon) {
-                        spoolNode.iconPath = icon.path;
-                    }
-                    spoolNode.command = {
-                        command: "zowe.jobs.zosJobsOpenspool",
-                        title: "",
-                        arguments: [sessionName, spool, refreshTimestamp],
-                    };
-                    elementChildren.push(spoolNode);
-                });
+                spools
+                    // filter out all the objects which do not seem to be correct Job File Document types
+                    // see an issue #845 for the details
+                    .filter(
+                        (item) => !(item.id === undefined && item.ddname === undefined && item.stepname === undefined)
+                    )
+                    .forEach((spool) => {
+                        let prefix = spool.stepname;
+                        if (prefix === undefined) {
+                            prefix = spool.procstep;
+                        }
+                        const sessionName = this.getProfileName();
+                        const spoolNode = new Spool(
+                            `${spool.stepname}:${spool.ddname}(${spool.id})`,
+                            vscode.TreeItemCollapsibleState.None,
+                            this,
+                            this.session,
+                            spool,
+                            this.job,
+                            this
+                        );
+                        const icon = getIconByNode(spoolNode);
+                        if (icon) {
+                            spoolNode.iconPath = icon.path;
+                        }
+                        spoolNode.command = {
+                            command: "zowe.jobs.zosJobsOpenspool",
+                            title: "",
+                            arguments: [sessionName, spool, refreshTimestamp],
+                        };
+                        elementChildren.push(spoolNode);
+                    });
             } else {
                 const jobs = await vscode.window.withProgress(
                     {


### PR DESCRIPTION
## Proposed changes

Resolves an issue #845 for the `next` branch.
Skipping all the objects which are returned from `GetSpoolFiles` API call and do not correspond to the proper `zowe.IJobFile` type. As a result there will be no more `undefined:undefined(undefined)` items in the spool files tree.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)
