### PR TITLE
[Next][Issue #1338] Add progress bar for multi-deletion of jobs

### DIFF
--- a/packages/zowe-explorer/i18n/sample/src/job/actions.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/job/actions.i18n.json
@@ -11,6 +11,7 @@
   "deleteJobPrompt.confirmation.message": "Are you sure you want to delete the following {0} item(s)?\nThis will permanently remove the following job(s) from your system.\n\n{1}",
   "deleteJobPrompt.confirmation.cancel.log.debug": "Delete action was canceled.",
   "deleteJobPrompt.deleteCancelled": "Delete action was cancelled.",
+  "deleteJobPrompt.deleteCounter": "Deleting nodes",
   "deleteCommand.multipleJobs": "The following jobs were deleted: {0}",
   "deleteCommand.job": "Job {0} deleted."
 }

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -341,7 +341,7 @@ export async function deleteDatasetPrompt(
                     }
                     progress.report({
                         message: `Deleting ${index + 1} of ${nodes.length}`,
-                        increment: (index / nodes.length) * total,
+                        increment: total / nodes.length,
                     });
                     try {
                         await deleteDataset(currNode, datasetProvider);
@@ -350,7 +350,7 @@ export async function deleteDatasetPrompt(
                             : ` ${currNode.getLabel()}`;
                         nodesDeleted.push(deleteItemName);
                     } catch (err) {
-                        // do nothing; delete next
+                        globals.LOG.error(err);
                     }
                 }
             }


### PR DESCRIPTION
## Proposed changes

Resolves issue #1338 by introducing progress bar during multi-delete for jobs.
## Release Notes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

