### PR TITLE
[Issue #1560] Fix input cancelling messaging

### DIFF
--- a/packages/zowe-explorer/__tests__/__unit__/command/tsoCommandHandler.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/command/tsoCommandHandler.unit.test.ts
@@ -323,7 +323,7 @@ describe("TsoCommandHandler unit testing", () => {
             placeHolder: "Select the Profile to use to submit the TSO command",
         });
         expect(showInformationMessage.mock.calls.length).toBe(1);
-        expect(showInformationMessage.mock.calls[0][0]).toEqual("No selection made.");
+        expect(showInformationMessage.mock.calls[0][0]).toEqual("No selection made. Operation cancelled.");
     });
 
     it("tests the issueTsoCommand function user escapes the command box", async () => {

--- a/packages/zowe-explorer/i18n/sample/src/command/TsoCommandHandler.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/command/TsoCommandHandler.i18n.json
@@ -7,7 +7,7 @@
   "issueTsoCommand.apiNonExisting": "Not implemented yet for profile of type: ",
   "issueTsoCommand.command.hostname": "Select a TSO command to run immediately against ",
   "issueTsoCommand.command.edit": " (An option to edit will follow)",
-  "issueTsoCommand.options.noselection": "No selection made.",
+  "issueTsoCommand.options.noselection": "No selection made. Operation cancelled.",
   "issueTsoCommand.command.hostnameAlt": "Select a TSO command to run against ",
   "issueTsoCommand.command": "Enter or update the TSO command",
   "issueTsoCommand.enter.command": "No command entered.",

--- a/packages/zowe-explorer/src/command/TsoCommandHandler.ts
+++ b/packages/zowe-explorer/src/command/TsoCommandHandler.ts
@@ -208,7 +208,7 @@ export class TsoCommandHandler extends ZoweCommandProvider {
                 quickpick.hide();
                 if (!choice) {
                     vscode.window.showInformationMessage(
-                        localize("issueTsoCommand.options.noselection", "No selection made.")
+                        localize("issueTsoCommand.options.noselection", "No selection made. Operation cancelled.")
                     );
                     return;
                 }

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -148,9 +148,10 @@ export const syncSessionNode = (profiles: Profiles) => (getSessionForProfile: Se
 export async function resolveQuickPickHelper(
     quickpick: vscode.QuickPick<vscode.QuickPickItem>
 ): Promise<vscode.QuickPickItem | undefined> {
-    return new Promise<vscode.QuickPickItem | undefined>((c) =>
-        quickpick.onDidAccept(() => c(quickpick.activeItems[0]))
-    );
+    return new Promise<vscode.QuickPickItem | undefined>((c) => {
+        quickpick.onDidAccept(() => c(quickpick.activeItems[0]));
+        quickpick.onDidHide(() => c(undefined));
+    });
 }
 
 // tslint:disable-next-line: max-classes-per-file


### PR DESCRIPTION
## Proposed changes

This one fixes #1560. 
_(The issue itself is opened for TSO command execution feature initially, but this bugfix affects a helper function, which is used in many places, and as a result it also fixes the cancelling cases for other commands (e.g. Issue MVS command, filter selections and etc.)_

Added an `onDidHide` handler for `resolveQuickPickHelper`, which always return `undefined` result. 

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog -->
<!-- If there is a linked issue, it should have the same milestone as this PR -->

Milestone:

Changelog:

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Reminder

After a PR is merged into the `master` branch, create a PR from `master` to the `next` branch resolving any conflicts.

## Further comments

The API doc says:
> There are several reasons why this UI might have to be hidden and the extension will be notified through QuickInput.onDidHide. (Examples include: an explicit call to QuickInput.hide, the user pressing Esc, some other input UI opening, etc.)

This means the informational message will be shown in the cases above, including if some other input will appear in the middle of TSO command issuing.

Also, a current implementation already contains `No selection made.` message, which appears when a choice from the picker is falsy (`undefined` in a case of cancelling through `Esc`). The issue however specifies that `Operation cancelled.` is expected.
Should the message be changed or even, should the cancelling event itself be distinguished from others somehow to show operation cancelled message exactly in this case?
