### PR TITLE
fix(tso-cmd): Retrieve team config information for tso commands

### DIFF
--- a/packages/zowe-explorer/__tests__/__unit__/command/tsoCommandHandler.extended.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/command/tsoCommandHandler.extended.unit.test.ts
@@ -1,0 +1,42 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the *
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+ * https://www.eclipse.org/legal/epl-v20.html                                      *
+ *                                                                                 *
+ * SPDX-License-Identifier: EPL-2.0                                                *
+ *                                                                                 *
+ * Copyright Contributors to the Zowe Project.                                     *
+ *                                                                                 *
+ */
+
+import * as vscode from "vscode";
+import { ProfilesCache } from "@zowe/zowe-explorer-api";
+import { Profiles } from "../../../src/Profiles";
+import { TsoCommandHandler } from "../../../src/command/TsoCommandHandler";
+import { ProfileInfo } from "@zowe/imperative";
+
+describe("TsoCommandHandler extended testing", () => {
+    Object.defineProperty(vscode.workspace, "getConfiguration", { value: jest.fn() });
+    Object.defineProperty(vscode.window, "createOutputChannel", { value: jest.fn() });
+    Object.defineProperty(ProfileInfo, "profAttrsToProfLoaded", { value: () => ({ profile: {} }) });
+    Object.defineProperty(Profiles, "selectTsoProfile", { value: () => "dummy" });
+
+    describe("getTsoParms", () => {
+        it("should work with teamConfig", async () => {
+            Object.defineProperty(Profiles, "getInstance", {
+                value: jest.fn(() => ({ getCliProfileManager: () => null })),
+            });
+
+            jest.spyOn(ProfilesCache, "getConfigInstance").mockReturnValue({
+                usingTeamConfig: true,
+                getAllProfiles: jest.fn().mockReturnValue(["dummy"]),
+                mergeArgsForProfile: jest.fn().mockReturnValue({
+                    knownArgs: [{ argName: "account", argValue: "TEST" }],
+                }),
+            } as any);
+
+            const result = await (TsoCommandHandler.getInstance() as any).getTsoParams();
+            expect(result.account).toEqual("TEST");
+        });
+    });
+});

--- a/packages/zowe-explorer/src/command/TsoCommandHandler.ts
+++ b/packages/zowe-explorer/src/command/TsoCommandHandler.ts
@@ -346,7 +346,9 @@ export class TsoCommandHandler extends ZoweCommandProvider {
         }
         if (tsoProfile) {
             iStartTso.forEach((p) => (tsoParms[p] = tsoProfile.profile[p]));
-        } else {
+        }
+
+        if (tsoParms.account == null || tsoParms.account === "") {
             // If there is no tso profile an account number is still required, so ask for one.
             // All other properties of tsoParams will be undefined, so defaults will be utilized.
             const InputBoxOptions = {

--- a/packages/zowe-explorer/src/command/TsoCommandHandler.ts
+++ b/packages/zowe-explorer/src/command/TsoCommandHandler.ts
@@ -158,7 +158,7 @@ export class TsoCommandHandler extends ZoweCommandProvider {
             if (error.toString().includes("non-existing")) {
                 vscode.window.showErrorMessage(
                     localize("issueTsoCommand.apiNonExisting", "Not implemented yet for profile of type: ") +
-                    profile.type
+                        profile.type
                 );
             } else {
                 await errorHandling(error.toString(), profile.name, error.message.toString());
@@ -196,10 +196,10 @@ export class TsoCommandHandler extends ZoweCommandProvider {
                 const quickpick = vscode.window.createQuickPick();
                 quickpick.placeholder = alwaysEdit
                     ? localize("issueTsoCommand.command.hostnameAlt", "Select a TSO command to run against ") +
-                    hostname +
-                    localize("issueTsoCommand.command.edit", " (An option to edit will follow)")
+                      hostname +
+                      localize("issueTsoCommand.command.edit", " (An option to edit will follow)")
                     : localize("issueTsoCommand.command.hostname", "Select a TSO command to run immediately against ") +
-                    hostname;
+                      hostname;
 
                 quickpick.items = [createPick, ...items];
                 quickpick.ignoreFocusOut = true;

--- a/packages/zowe-explorer/src/command/TsoCommandHandler.ts
+++ b/packages/zowe-explorer/src/command/TsoCommandHandler.ts
@@ -13,7 +13,7 @@ import * as vscode from "vscode";
 import * as nls from "vscode-nls";
 import * as globals from "../globals";
 import * as imperative from "@zowe/imperative";
-import { ValidProfileEnum, IZoweTreeNode } from "@zowe/zowe-explorer-api";
+import { ValidProfileEnum, IZoweTreeNode, ProfilesCache, ZoweVsCodeExtension } from "@zowe/zowe-explorer-api";
 import { PersistentFilters } from "../PersistentFilters";
 import { Profiles } from "../Profiles";
 import { ZoweExplorerApiRegister } from "../ZoweExplorerApiRegister";
@@ -158,7 +158,7 @@ export class TsoCommandHandler extends ZoweCommandProvider {
             if (error.toString().includes("non-existing")) {
                 vscode.window.showErrorMessage(
                     localize("issueTsoCommand.apiNonExisting", "Not implemented yet for profile of type: ") +
-                        profile.type
+                    profile.type
                 );
             } else {
                 await errorHandling(error.toString(), profile.name, error.message.toString());
@@ -196,10 +196,10 @@ export class TsoCommandHandler extends ZoweCommandProvider {
                 const quickpick = vscode.window.createQuickPick();
                 quickpick.placeholder = alwaysEdit
                     ? localize("issueTsoCommand.command.hostnameAlt", "Select a TSO command to run against ") +
-                      hostname +
-                      localize("issueTsoCommand.command.edit", " (An option to edit will follow)")
+                    hostname +
+                    localize("issueTsoCommand.command.edit", " (An option to edit will follow)")
                     : localize("issueTsoCommand.command.hostname", "Select a TSO command to run immediately against ") +
-                      hostname;
+                    hostname;
 
                 quickpick.items = [createPick, ...items];
                 quickpick.ignoreFocusOut = true;
@@ -291,10 +291,41 @@ export class TsoCommandHandler extends ZoweCommandProvider {
         }
     }
 
+    private async selectTsoProfile(tsoProfiles: imperative.IProfileLoaded[] = []): Promise<imperative.IProfileLoaded> {
+        let tsoProfile: imperative.IProfileLoaded;
+        if (tsoProfiles.length > 1) {
+            const tsoProfileNamesList = tsoProfiles.map((temprofile) => {
+                return temprofile.name;
+            });
+            if (tsoProfileNamesList.length) {
+                const quickPickOptions: vscode.QuickPickOptions = {
+                    placeHolder: localize(
+                        "issueTsoCommand.tsoProfile.quickPickOption",
+                        "Select the TSO Profile to use for account number."
+                    ),
+                    ignoreFocusOut: true,
+                    canPickMany: false,
+                };
+                const sesName = await vscode.window.showQuickPick(tsoProfileNamesList, quickPickOptions);
+                if (sesName === undefined) {
+                    vscode.window.showInformationMessage(localize("issueTsoCommand.cancelled", "Operation Cancelled"));
+                    return;
+                }
+                tsoProfile = tsoProfiles.filter((temprofile) => temprofile.name === sesName)[0];
+            }
+        } else if (tsoProfiles.length > 0) {
+            tsoProfile = tsoProfiles[0];
+        }
+        return tsoProfile;
+    }
+
     private async getTsoParams(): Promise<IStartTsoParms> {
         const tsoProfiles: imperative.IProfileLoaded[] = [];
         let tsoProfile: imperative.IProfileLoaded;
         const tsoParms: IStartTsoParms = {};
+        // Keys in the IStartTsoParms interface
+        // TODO(zFernand0): Request the CLI squad that all interfaces are also exported as values that we can iterate
+        const iStartTso = ["account", "characterSet", "codePage", "columns", "logonProcedure", "regionSize", "rows"];
         const profileManager = Profiles.getInstance().getCliProfileManager("tso");
         if (profileManager) {
             try {
@@ -304,47 +335,30 @@ export class TsoCommandHandler extends ZoweCommandProvider {
                         tsoProfiles.push(item);
                     }
                 }
-                if (tsoProfiles.length && tsoProfiles.length > 1) {
-                    const tsoProfileNamesList = tsoProfiles.map((temprofile) => {
-                        return temprofile.name;
-                    });
-                    if (tsoProfileNamesList.length) {
-                        const quickPickOptions: vscode.QuickPickOptions = {
-                            placeHolder: localize(
-                                "issueTsoCommand.tsoProfile.quickPickOption",
-                                "Select the TSO Profile to use for account number."
-                            ),
-                            ignoreFocusOut: true,
-                            canPickMany: false,
-                        };
-                        const sesName = await vscode.window.showQuickPick(tsoProfileNamesList, quickPickOptions);
-                        if (sesName === undefined) {
-                            vscode.window.showInformationMessage(
-                                localize("issueTsoCommand.cancelled", "Operation Cancelled")
-                            );
-                            return;
-                        }
-                        tsoProfile = tsoProfiles.filter((temprofile) => temprofile.name === sesName)[0];
-                    }
-                } else {
-                    if (tsoProfiles.length) {
-                        tsoProfile = tsoProfiles[0];
-                    }
-                }
+                tsoProfile = await this.selectTsoProfile(tsoProfiles);
             } catch (error) {
                 if (!error?.message?.includes(`No default profile set for type "tso"`)) {
                     vscode.window.showInformationMessage(error);
                 }
             }
+        } else if (ProfilesCache.getConfigInstance().usingTeamConfig) {
+            const tempProfiles = ProfilesCache.getConfigInstance().getAllProfiles("tso");
+            if (tempProfiles.length > 0) {
+                tsoProfile = await this.selectTsoProfile(
+                    tempProfiles.map((p) => imperative.ProfileInfo.profAttrsToProfLoaded(p))
+                );
+                if (tsoProfile != null) {
+                    const prof = ProfilesCache.getConfigInstance().mergeArgsForProfile(
+                        tsoProfile.profile as imperative.IProfAttrs
+                    );
+                    iStartTso.forEach(
+                        (p) => (tsoProfile.profile[p] = prof.knownArgs.find((a) => a.argName === p)?.argValue)
+                    );
+                }
+            }
         }
         if (tsoProfile) {
-            tsoParms.account = tsoProfile.profile.account;
-            tsoParms.characterSet = tsoProfile.profile.characterSet;
-            tsoParms.codePage = tsoProfile.profile.codePage;
-            tsoParms.columns = tsoProfile.profile.columns;
-            tsoParms.logonProcedure = tsoProfile.profile.logonProcedure;
-            tsoParms.regionSize = tsoProfile.profile.regionSize;
-            tsoParms.rows = tsoProfile.profile.rows;
+            iStartTso.forEach((p) => (tsoParms[p] = tsoProfile.profile[p]));
         } else {
             // If there is no tso profile an account number is still required, so ask for one.
             // All other properties of tsoParams will be undefined, so defaults will be utilized.
@@ -357,7 +371,7 @@ export class TsoCommandHandler extends ZoweCommandProvider {
                 ignoreFocusOut: true,
                 value: tsoParms.account,
             };
-            tsoParms.account = await UIViews.inputBox(InputBoxOptions);
+            tsoParms.account = await ZoweVsCodeExtension.inputBox(InputBoxOptions);
             if (!tsoParms.account) {
                 vscode.window.showInformationMessage(localize("issueTsoCommand.cancelled", "Operation Cancelled."));
                 return;


### PR DESCRIPTION
## Proposed changes

- Retrieve team config information for TSO commands
- Reuse the same TSO profile-selection logic between v1 and v2 profiles.

## Release Notes

- Fix #1515

Milestone: V2

Changelog: Fixed TSO commands in when using teamConfig

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [x] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

