### PR TITLE
Bugfix: Refresh of Zowe Explorer

### DIFF
--- a/packages/zowe-explorer-api/src/security/KeytarApi.ts
+++ b/packages/zowe-explorer-api/src/security/KeytarApi.ts
@@ -18,6 +18,7 @@ import * as globals from "../globals";
 export class KeytarApi {
     public constructor(protected log: imperative.Logger) {}
 
+    // v1 specific
     public async activateKeytar(initialized: boolean, isTheia: boolean): Promise<void> {
         const log = imperative.Logger.getAppLogger();
         const profiles = new ProfilesCache(log);

--- a/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
@@ -420,44 +420,6 @@ describe("Extension Unit Tests", () => {
         expect(actualCommands).toEqual(globalMocks.expectedCommands);
     });
 
-    it("Tests that activate correctly executes if no configuration is set", async () => {
-        const globalMocks = await createGlobalMocks();
-
-        globalMocks.mockExistsSync.mockReturnValueOnce(false);
-        globalMocks.mockGetConfiguration.mockReturnValueOnce({
-            get: (setting: string) => "",
-            // tslint:disable-next-line: no-empty
-            update: jest.fn(() => {
-                {
-                }
-            }),
-            inspect: (configuration: string) => {
-                return {
-                    workspaceValue: undefined,
-                    globalValue: undefined,
-                };
-            },
-        });
-        globalMocks.mockGetConfiguration.mockReturnValueOnce({
-            get: (setting: string) => "files",
-            // tslint:disable-next-line: no-empty
-            update: jest.fn(() => {
-                {
-                }
-            }),
-            inspect: (configuration: string) => {
-                return {
-                    workspaceValue: undefined,
-                    globalValue: undefined,
-                };
-            },
-        });
-
-        await extension.activate(globalMocks.mockExtension);
-
-        expect(globalMocks.mockExistsSync.mock.calls.length).toBe(2);
-    });
-
     it("Tests that activate() works correctly for Theia", async () => {
         const globalMocks = await createGlobalMocks();
 

--- a/packages/zowe-explorer/src/extension.ts
+++ b/packages/zowe-explorer/src/extension.ts
@@ -25,14 +25,13 @@ import {
     IZoweUSSTreeNode,
     IZoweTreeNode,
     IZoweTree,
-    KeytarApi,
     getZoweDir,
 } from "@zowe/zowe-explorer-api";
 import { ZoweExplorerApiRegister } from "./ZoweExplorerApiRegister";
 import { ZoweExplorerExtender } from "./ZoweExplorerExtender";
 import { Profiles } from "./Profiles";
 import { errorHandling, readConfigFromDisk } from "./utils/ProfilesUtils";
-import { ImperativeError, CliProfileManager, ImperativeConfig } from "@zowe/imperative";
+import { CliProfileManager, ImperativeConfig } from "@zowe/imperative";
 import { getImperativeConfig } from "@zowe/cli";
 import { createDatasetTree } from "./dataset/DatasetTree";
 import { createJobsTree } from "./job/ZosJobsProvider";
@@ -89,13 +88,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<ZoweEx
     try {
         globals.initLogger(context);
         globals.LOG.debug(localize("initialize.log.debug", "Initialized logger from VSCode extension"));
-
-        try {
-            const keytarApi = new KeytarApi(globals.LOG);
-            await keytarApi.activateKeytar(false, globals.ISTHEIA);
-        } catch (err) {
-            throw new ImperativeError({ msg: err.toString() });
-        }
 
         // Ensure that ~/.zowe folder exists
         if (!ImperativeConfig.instance.config?.exists) {


### PR DESCRIPTION
## Proposed changes

some changes where made on imperative and with our call to activateKeytar() line 33 call to CredentialManagerFactory() during activation and the API seems to be v1 specific with this check in it ` const scsActive = profiles.isSecureCredentialPluginActive();`  was breaking our new Refresh Zowe Explorer command pallete and quick-key options. Also the removed test was checking that vscode.workspaces.getConfiguration was called 2 times but the 2nd time was within activateKeytar.

On this note I will propose to remove the Keytar API requirement for extenders in the V2 Conformance.

It may be good to remove the code from ZE API completely as well for v2 since it is v1 specific.

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog -->
<!-- If there is a linked issue, it should have the same milestone as this PR -->

Milestone: vNext

Changelog:

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Reminder

After a PR is merged into the `master` branch, create a PR from `master` to the `next` branch resolving any conflicts.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
