### PR TITLE
fix(uss-tree) Quick-key Delete not working in USS tree #1510

### DIFF
--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -80,6 +80,11 @@
         "when": "focusedView == zowe.ds.explorer && listSupportsMultiselect"
       },
       {
+        "command": "zowe.uss.deleteNode",
+        "key": "delete",
+        "when": "focusedView == zowe.uss.explorer"
+      },
+      {
         "command": "zowe.extRefresh",
         "key": "alt+z"
       }

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -72,7 +72,7 @@
       {
         "command": "zowe.jobs.deleteJob",
         "key": "delete",
-        "when": "focusedView == zowe.jobs.explorer && listSupportsMultiselect"
+        "when": "focusedView == zowe.jobs.explorer"
       },
       {
         "command": "zowe.ds.deleteDataset",
@@ -1520,6 +1520,10 @@
         },
         {
           "command": "zowe.jobs.refreshJob",
+          "when": "never"
+        },
+        {
+          "command": "zowe.jobs.deleteJob",
           "when": "never"
         }
       ]

--- a/packages/zowe-explorer/src/extension.ts
+++ b/packages/zowe-explorer/src/extension.ts
@@ -518,7 +518,7 @@ function initUSSProvider(context: vscode.ExtensionContext, ussFileProvider: IZow
     );
     context.subscriptions.push(
         vscode.commands.registerCommand("zowe.uss.deleteNode", (node: IZoweUSSTreeNode) => {
-            let tempNode = ussFileProvider.getTreeView().selection[0] as IZoweUSSTreeNode;
+            const tempNode = ussFileProvider.getTreeView().selection[0] as IZoweUSSTreeNode;
             tempNode.deleteUSSNode(ussFileProvider, tempNode.getUSSDocumentFilePath());
         })
     );

--- a/packages/zowe-explorer/src/extension.ts
+++ b/packages/zowe-explorer/src/extension.ts
@@ -517,9 +517,10 @@ function initUSSProvider(context: vscode.ExtensionContext, ussFileProvider: IZow
         )
     );
     context.subscriptions.push(
-        vscode.commands.registerCommand("zowe.uss.deleteNode", async (node: IZoweUSSTreeNode) =>
-            node.deleteUSSNode(ussFileProvider, node.getUSSDocumentFilePath())
-        )
+        vscode.commands.registerCommand("zowe.uss.deleteNode", (node: IZoweUSSTreeNode) => {
+            let tempNode = ussFileProvider.getTreeView().selection[0] as IZoweUSSTreeNode;
+            tempNode.deleteUSSNode(ussFileProvider, tempNode.getUSSDocumentFilePath());
+        })
     );
     context.subscriptions.push(
         vscode.commands.registerCommand("zowe.uss.binary", async (node: IZoweUSSTreeNode) =>

--- a/packages/zowe-explorer/src/job/actions.ts
+++ b/packages/zowe-explorer/src/job/actions.ts
@@ -277,7 +277,7 @@ export async function deleteCommand(
         return;
     } else {
         const treeView = jobsProvider.getTreeView();
-        let selectedNodes = treeView.selection;
+        const selectedNodes = treeView.selection;
         if (selectedNodes) {
             await deleteMultipleJobs(selectedNodes, jobsProvider);
         }

--- a/packages/zowe-explorer/src/job/actions.ts
+++ b/packages/zowe-explorer/src/job/actions.ts
@@ -272,10 +272,15 @@ export async function deleteCommand(
             jobsProvider
         );
         return;
-    }
-    if (job) {
+    } else if (job) {
         await deleteSingleJob(job, jobsProvider);
         return;
+    } else {
+        const treeView = jobsProvider.getTreeView();
+        let selectedNodes = treeView.selection;
+        if (selectedNodes) {
+            await deleteMultipleJobs(selectedNodes, jobsProvider);
+        }
     }
 }
 


### PR DESCRIPTION
## Proposed changes

Fixed 'Delete' key not working in USS tree.
Added 'Delete' keybinding to Jobs.

## Release Notes

Changelog: #1510 Fixed Quick-key Delete not working in USS tree

## Types of changes

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

- [ x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x ] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [ x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [ x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ x] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ x] There is coverage for the code that I have added
- [ x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

