### PR TITLE
fix(validate profile) Extra space in the dialog box text

### DIFF
--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -67,7 +67,7 @@ export async function errorHandling(errorDetails: any, label?: string, moreInfo?
         // tslint:disable-next-line: no-magic-numbers
         case 401:
             if (label.includes("[")) {
-                label = label.substring(0, label.indexOf(" ["));
+                label = label.substring(0, label.indexOf(" [")).trim();
             }
 
             if (errorDetails.mDetails.additionalDetails) {


### PR DESCRIPTION
Signed-off-by: KutluOzel-b <kutlu.ozel@broadcom.com>

## Proposed changes

Fixed extra space in the Invalid Credentials dialog, at profile validation `profilename`

## Release Notes

#1494 

Changelog:

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

- [ x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [ x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [ x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x ] There is coverage for the code that I have added
- [ x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

