### PR TITLE
fix runtime err profileTypeConfiguration iteration

### DIFF
--- a/packages/zowe-explorer/src/ZoweExplorerExtender.ts
+++ b/packages/zowe-explorer/src/ZoweExplorerExtender.ts
@@ -112,7 +112,7 @@ export class ZoweExplorerExtender implements ZoweExplorerApi.IApiExplorerExtende
             }
         }
         // add extender config info to global variable
-        profileTypeConfigurations.forEach((item) => {
+        profileTypeConfigurations?.forEach((item) => {
             globals.EXTENDER_CONFIG.push(item);
         });
         // sequentially reload the internal profiles cache to satisfy all the newly added profile types


### PR DESCRIPTION
Signed-off-by: KutluOzel-b <kutlu.ozel@broadcom.com>

## Proposed changes

fix runtime error profileTypeConfigurations iteration. 

## Release Notes

Milestone:

https://github.com/zowe/vscode-extension-for-zowe/issues/1872

Changelog:

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

- [ x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [ x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [ x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ x] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments
