### PR TITLE
(Fix) registerCustomProfileType for extenders throwing error while v1 profile not in use but v2 in use. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Join our [Slack channel](https://slack.openmainframeproject.org/) to connect wit
 
 Client-side prerequisites:
 
-- Install [Node.js](https://nodejs.org/en/download/) v12.0 or later.
+- Install [Node.js](https://nodejs.org/en/download/) v14.0 or later.
 - Install [Yarn](https://yarnpkg.com/getting-started/install).
 
 Host-side prerequisites:

--- a/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
+++ b/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
@@ -497,13 +497,16 @@ export class ProfilesCache {
     /**
      * Used for extenders to register with Zowe Explorer that do not need their
      * profile type in the existing MVS, USS, and JES
-     * @param {string} profileTypeName Type of Profile, defaults to "zosmf" if nothing passed.
+     * @param {string} profileTypeName Type of Profile
      *
      * @returns {void}
      */
     public async asyncRegisterCustomProfilesType(profileTypeName: string): Promise<void> {
         const existsV1Profile = fs.existsSync(path.posix.join(`${os.homedir()}/.zowe/profiles/${profileTypeName}`));
-        const existsV2Profile = (await this.getProfileInfo()).usingTeamConfig;
+        const profileInfo = await this.getProfileInfo();
+        const existsV2Profile =
+            profileInfo?.usingTeamConfig &&
+            profileInfo.getAllProfiles().find((profile) => profile.profType === profileTypeName);
         if (!existsV1Profile && !existsV2Profile) {
             throw new Error(
                 `Zowe Explorer Profiles Cache error: Tried to register a custom profile type named: ${profileTypeName} that does not yet exist. Extenders must call "zoweExplorerApi.getExplorerExtenderApi().initForZowe()" first.`

--- a/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
+++ b/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
@@ -149,6 +149,7 @@ export class ProfilesCache {
     }
 
     /**
+     * @deprecated Please use {@link asyncRegisterCustomProfilesType}.
      * Used for extenders to register with Zowe Explorer that do not need their
      * profile type in the existing MVS, USS, and JES
      *
@@ -491,5 +492,23 @@ export class ProfilesCache {
             externalTypeArray.filter((exType) => registeredTypes.every((type) => type !== exType))
         );
         return allTypes;
+    }
+
+    /**
+     * Used for extenders to register with Zowe Explorer that do not need their
+     * profile type in the existing MVS, USS, and JES
+     * @param {string} profileTypeName Type of Profile, defaults to "zosmf" if nothing passed.
+     *
+     * @returns {void}
+     */
+    public async asyncRegisterCustomProfilesType(profileTypeName: string): Promise<void> {
+        const existsV1Profile = fs.existsSync(path.posix.join(`${os.homedir()}/.zowe/profiles/${profileTypeName}`));
+        const existsV2Profile = (await this.getProfileInfo()).usingTeamConfig;
+        if (!existsV1Profile && !existsV2Profile) {
+            throw new Error(
+                `Zowe Explorer Profiles Cache error: Tried to register a custom profile type named: ${profileTypeName} that does not yet exist. Extenders must call "zoweExplorerApi.getExplorerExtenderApi().initForZowe()" first.`
+            );
+        }
+        this.allExternalTypes.add(profileTypeName);
     }
 }

--- a/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
+++ b/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
@@ -149,7 +149,6 @@ export class ProfilesCache {
     }
 
     /**
-     * @deprecated Please use {@link asyncRegisterCustomProfilesType}.
      * Used for extenders to register with Zowe Explorer that do not need their
      * profile type in the existing MVS, USS, and JES
      *
@@ -158,12 +157,6 @@ export class ProfilesCache {
      * @returns {void}
      */
     public registerCustomProfilesType(profileTypeName: string): void {
-        const exists = fs.existsSync(path.posix.join(`${os.homedir()}/.zowe/profiles/${profileTypeName}`));
-        if (!exists) {
-            throw new Error(
-                `Zowe Explorer Profiles Cache error: Tried to register a custom profile type named: ${profileTypeName} that does not yet exist. Extenders must call "zoweExplorerApi.getExplorerExtenderApi().initForZowe()" first.`
-            );
-        }
         this.allExternalTypes.add(profileTypeName);
     }
 
@@ -492,26 +485,5 @@ export class ProfilesCache {
             externalTypeArray.filter((exType) => registeredTypes.every((type) => type !== exType))
         );
         return allTypes;
-    }
-
-    /**
-     * Used for extenders to register with Zowe Explorer that do not need their
-     * profile type in the existing MVS, USS, and JES
-     * @param {string} profileTypeName Type of Profile
-     *
-     * @returns {void}
-     */
-    public async asyncRegisterCustomProfilesType(profileTypeName: string): Promise<void> {
-        const existsV1Profile = fs.existsSync(path.posix.join(`${os.homedir()}/.zowe/profiles/${profileTypeName}`));
-        const profileInfo = await this.getProfileInfo();
-        const existsV2Profile =
-            profileInfo?.usingTeamConfig &&
-            profileInfo.getAllProfiles().find((profile) => profile.profType === profileTypeName);
-        if (!existsV1Profile && !existsV2Profile) {
-            throw new Error(
-                `Zowe Explorer Profiles Cache error: Tried to register a custom profile type named: ${profileTypeName} that does not yet exist. Extenders must call "zoweExplorerApi.getExplorerExtenderApi().initForZowe()" first.`
-            );
-        }
-        this.allExternalTypes.add(profileTypeName);
     }
 }


### PR DESCRIPTION
Signed-off-by: KutluOzel-b <kutlu.ozel@broadcom.com>

## Proposed changes

Fix registerCustomProfileType for extenders throwing error while v1 profile not in use but v2 in use. 

Checking if v1 or v2 is used if so then registers profile.

## Release Notes

Milestone:

https://github.com/zowe/vscode-extension-for-zowe/issues/1870

Changelog:

## Types of changes

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

- [ x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x ] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [ x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [ x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ x] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments
