### PR TITLE
Fix some zftp profile properties being ignored

### DIFF
--- a/packages/zowe-explorer-ftp-extension/CHANGELOG.md
+++ b/packages/zowe-explorer-ftp-extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 All notable changes to the "vscode-extension-for-zowe" extension will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed some profile properties like "rejectUnauthorized" being ignored.
+
 ## `2.0.2`
 
 - Bugfix: Fixed eTag related issue when saving USS files. [#1813](https://github.com/zowe/vscode-extension-for-zowe/pull/1813)

--- a/packages/zowe-explorer-ftp-extension/__tests__/__unit__/FtpApi/ZoweExplorerAbstractFtpApi.unit.test.ts
+++ b/packages/zowe-explorer-ftp-extension/__tests__/__unit__/FtpApi/ZoweExplorerAbstractFtpApi.unit.test.ts
@@ -12,6 +12,9 @@
 import { sessionMap } from "../../../src/extension";
 import { AbstractFtpApi } from "../../../src/ZoweExplorerAbstractFtpApi";
 import { FtpSession } from "../../../src/ftpSession";
+import { FTPConfig, IZosFTPProfile } from "@zowe/zos-ftp-for-zowe-cli";
+
+jest.mock("zos-node-accessor");
 
 class Dummy extends AbstractFtpApi {}
 
@@ -21,6 +24,7 @@ const profile = {
     type: "zftp",
     profile: { host: "1.1.1.1", user: "user", password: "password", port: "21", rejectUnauthorized: false },
 };
+
 describe("AbstractFtpApi", () => {
     it("should add a record in sessionMap when call getSession function.", () => {
         const instance = new Dummy();
@@ -42,5 +46,24 @@ describe("AbstractFtpApi", () => {
         // eslint-disable-next-line @typescript-eslint/unbound-method
         expect(session.releaseConnections).toBeCalledTimes(1);
         expect(sessionMap.size).toBe(0);
+    });
+
+    it("should load all properties from zftp profile", async () => {
+        const ftpProfile: IZosFTPProfile = {
+            host: "example.com",
+            port: 21,
+            user: "fakeUser",
+            password: "fakePass",
+            secureFtp: true,
+            connectionTimeout: 60000,
+            rejectUnauthorized: false,
+            serverName: "example2.com",
+        };
+        const createConfigFromArgsSpy = jest.spyOn(FTPConfig, "createConfigFromArguments");
+        const instance = new Dummy();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        await instance.ftpClient({ ...profile, profile: ftpProfile });
+
+        expect(createConfigFromArgsSpy).toHaveBeenLastCalledWith(ftpProfile);
     });
 });

--- a/packages/zowe-explorer-ftp-extension/src/ZoweExplorerAbstractFtpApi.ts
+++ b/packages/zowe-explorer-ftp-extension/src/ZoweExplorerAbstractFtpApi.ts
@@ -69,13 +69,7 @@ export abstract class AbstractFtpApi implements ZoweExplorerApi.ICommon {
     public async ftpClient(profile: imperative.IProfileLoaded): Promise<any> {
         const ftpProfile = profile.profile as IZosFTPProfile;
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        return await FTPConfig.connectFromArguments({
-            host: ftpProfile.host,
-            user: ftpProfile.user,
-            password: ftpProfile.password,
-            port: ftpProfile.port,
-            secureFtp: ftpProfile.secureFtp,
-        });
+        return await FTPConfig.connectFromArguments(ftpProfile);
     }
 
     public releaseConnection(connection: any): void {


### PR DESCRIPTION
## Proposed changes

Fixes some zftp profile properties like "connectionTimeout", "rejectUnauthorized", and "serverName" being ignored.

## Release Notes

Updated the changelog in the PR.

## Types of changes

Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [ ] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [ ] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [ ] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
