### PR TITLE
Fix for pull from mainframe bug for spool files

### DIFF
--- a/packages/zowe-explorer/src/job/actions.ts
+++ b/packages/zowe-explorer/src/job/actions.ts
@@ -71,7 +71,7 @@ export async function getSpoolContent(session: string, spool: zowe.IJobFile, ref
         return;
     }
     await profiles.checkCurrentProfile(zosmfProfile);
-    if (profiles.validProfile === ValidProfileEnum.VALID || profiles.validProfile === ValidProfileEnum.UNVERIFIED) {
+    if (profiles.validProfile !== ValidProfileEnum.INVALID) {
         const uri = toUniqueJobFileUri(session, spool)(refreshTimestamp.toString());
         try {
             await vscode.window.showTextDocument(uri);
@@ -100,13 +100,25 @@ export async function getSpoolContentFromMainframe(node: IZoweJobTreeNode) {
         // see an issue #845 for the details
         .filter((item) => !(item.id === undefined && item.ddname === undefined && item.stepname === undefined));
     spools.forEach(async (spool) => {
-        if (`${spool.stepname}:${spool.ddname}(${spool.id})` === node.label.toString()) {
+        if (
+            `${spool.stepname}:${spool.ddname} - ${spool["record-count"]}` === node.label.toString() ||
+            `${spool.stepname}:${spool.ddname} - ${spool.procstep}` === node.label.toString()
+        ) {
             let prefix = spool.stepname;
             if (prefix === undefined) {
                 prefix = spool.procstep;
             }
+
+            const procstep = spool.procstep ? spool.procstep : undefined;
+            let newLabel: string;
+            if (procstep) {
+                newLabel = `${spool.stepname}:${spool.ddname} - ${procstep}`;
+            } else {
+                newLabel = `${spool.stepname}:${spool.ddname} - ${spool["record-count"]}`;
+            }
+
             const spoolNode = new Spool(
-                `${spool.stepname}:${spool.ddname}(${spool.id})`,
+                newLabel,
                 vscode.TreeItemCollapsibleState.None,
                 node.getParent(),
                 node.getSession(),


### PR DESCRIPTION
Signed-off-by: Billie Simmons <49491949+JillieBeanSim@users.noreply.github.com>

## Proposed changes

fix for `Pull from Mainframe` for spool files after label change

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog -->
<!-- If there is a linked issue, it should have the same milestone as this PR -->

Milestone: 2.3.0

Changelog:

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [ ] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
