### PR TITLE
Bug/refresh job/status

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "vscode-extension-for-zowe" extension will be documented in this file.
 
+## `2.3.1`
+
+- Bugfix: Fix refresh job & spool file pull from mainframe doesn't update job status [#1936](https://github.com/zowe/vscode-extension-for-zowe/pull/1936)
+
 ## `2.3.0`
 
 - Added option to edit team configuration file via the + button for easy access. [#1896](https://github.com/zowe/vscode-extension-for-zowe/issues/1896)

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the "vscode-extension-for-zowe" extension will be documented in this file.
 
-## `2.3.1`
+## TBD Release
 
 - Bugfix: Fix refresh job & spool file pull from mainframe doesn't update job status [#1936](https://github.com/zowe/vscode-extension-for-zowe/pull/1936)
 

--- a/packages/zowe-explorer/src/extension.ts
+++ b/packages/zowe-explorer/src/extension.ts
@@ -763,7 +763,6 @@ function initJobsProvider(context: vscode.ExtensionContext, jobsProvider: IZoweT
     );
     context.subscriptions.push(
         vscode.commands.registerCommand("zowe.jobs.refreshJob", async (job) => {
-            await jobActions.refreshJob(job, jobsProvider);
             jobActions.refreshJob(job.mParent, jobsProvider);
         })
     );

--- a/packages/zowe-explorer/src/extension.ts
+++ b/packages/zowe-explorer/src/extension.ts
@@ -697,9 +697,10 @@ function initJobsProvider(context: vscode.ExtensionContext, jobsProvider: IZoweT
         vscode.commands.registerCommand("zowe.jobs.refreshJob", async (job) => jobActions.refreshJob(job, jobsProvider))
     );
     context.subscriptions.push(
-        vscode.commands.registerCommand("zowe.jobs.refreshSpool", (node) =>
-            jobActions.getSpoolContentFromMainframe(node)
-        )
+        vscode.commands.registerCommand("zowe.jobs.refreshSpool", async (node) => {
+            await jobActions.getSpoolContentFromMainframe(node);
+            jobActions.refreshJob(node.mParent, jobsProvider);
+        })
     );
     context.subscriptions.push(
         vscode.commands.registerCommand("zowe.jobs.addJobsSession", () => jobsProvider.createZoweSession(jobsProvider))

--- a/packages/zowe-explorer/src/extension.ts
+++ b/packages/zowe-explorer/src/extension.ts
@@ -44,6 +44,7 @@ import { handleSaving } from "./utils/workspace";
 import { ZoweDatasetNode } from "./dataset/ZoweDatasetNode";
 import * as contextuals from "../src/shared/context";
 import { Job } from "./job/ZoweJobNode";
+import { labelRefresh } from "./shared/utils";
 
 // Set up localization
 nls.config({
@@ -762,12 +763,15 @@ function initJobsProvider(context: vscode.ExtensionContext, jobsProvider: IZoweT
         })
     );
     context.subscriptions.push(
-        vscode.commands.registerCommand("zowe.jobs.refreshJob", async (job) => jobActions.refreshJob(job, jobsProvider))
+        vscode.commands.registerCommand("zowe.jobs.refreshJob", async (job) => {
+            await jobActions.refreshJob(job, jobsProvider);
+            jobActions.refreshJob(job.mParent, jobsProvider);
+        })
     );
     context.subscriptions.push(
         vscode.commands.registerCommand("zowe.jobs.refreshSpool", async (node) => {
             await jobActions.getSpoolContentFromMainframe(node);
-            jobActions.refreshJob(node.mParent, jobsProvider);
+            jobActions.refreshJob(node.mParent.mParent, jobsProvider);
         })
     );
     context.subscriptions.push(

--- a/packages/zowe-explorer/src/extension.ts
+++ b/packages/zowe-explorer/src/extension.ts
@@ -44,7 +44,6 @@ import { handleSaving } from "./utils/workspace";
 import { ZoweDatasetNode } from "./dataset/ZoweDatasetNode";
 import * as contextuals from "../src/shared/context";
 import { Job } from "./job/ZoweJobNode";
-import { labelRefresh } from "./shared/utils";
 
 // Set up localization
 nls.config({


### PR DESCRIPTION
## Proposed changes

Fix refresh job & spool file pull from mainframe doesn't update job status by refreshing parent node.

## Release Notes


Milestone:
https://github.com/zowe/vscode-extension-for-zowe/issues/1857

Changelog:

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

The Bug is solved by refreshing parent node method which leads to refreshing unnecessary nodes as well. Since we are populating nodes into belonging trees in a singular way this maybe not the best option but good for consistency.
