### PR TITLE
Update GitHub workflows

### DIFF
--- a/.github/workflows/zowe-explorer-ci.yml
+++ b/.github/workflows/zowe-explorer-ci.yml
@@ -1,10 +1,10 @@
 name: Zowe Explorer CI
 
 on:
-  push:
-    paths:
-      - packages/zowe-explorer/**
-      - packages/zowe-explorer-api/**
+  push:# TODO Restore path filter after testing
+    # paths:
+    #   - packages/zowe-explorer/**
+    #   - packages/zowe-explorer-api/**
   pull_request:
     paths:
       - packages/zowe-explorer/**
@@ -24,7 +24,7 @@ jobs:
       # Continue to run tests on the other systems if one fails
       fail-fast: false
       matrix:
-        node-version: [14, 16]
+        node-version: [14.x, 16.x]
         # order operating systems from best to worst
         os: [windows-latest, ubuntu-latest, macos-latest]
 
@@ -35,14 +35,14 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 
       # install yarn
       - run: npm install -g yarn
 
-      - run: yarn install --frozen-lockfile
+      - run: yarn config set network-timeout 60000 && yarn install --frozen-lockfile
 
       - run: yarn test
         env:
@@ -50,15 +50,25 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=4096
 
       - name: Upload test results
-        uses: actions/upload-artifact@v1
-        # if: matrix.os == 'windows-latest' && matrix.node-version == '12.x'
+        uses: actions/upload-artifact@v2
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '16.x'
         with:
           name: zowe-explorer-results
           path: packages/zowe-explorer/results/
 
-      # Run codecov upload for only one run
-      - name: Upload Results to Codecov from Windows / Node 12.x
-        if: matrix.os == 'windows-latest' && matrix.node-version == '12.x'
-        uses: codecov/codecov-action@v1.0.7
+      - name: Upload Results to Codecov
+        uses: codecov/codecov-action@v3
         with:
           env_vars: OS,NODE
+
+      - name: Package VSIX
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '16.x'
+        run: yarn package
+        working-directory: packages/zowe-explorer
+
+      - name: Archive VSIX artifact
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '16.x'
+        run: actions/upload-artifact@v2
+        with:
+          name: zowe-explorer-vsix
+          path: packages/zowe-explorer/*.vsix

--- a/.github/workflows/zowe-explorer-ci.yml
+++ b/.github/workflows/zowe-explorer-ci.yml
@@ -71,4 +71,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: zowe-explorer-vsix
-          path: packages/zowe-explorer/*.vsix
+          path: dist/*.vsix

--- a/.github/workflows/zowe-explorer-ci.yml
+++ b/.github/workflows/zowe-explorer-ci.yml
@@ -1,7 +1,7 @@
 name: Zowe Explorer CI
 
 on:
-  push:# TODO Restore path filter after testing
+  push: # TODO Restore path filter after testing
     # paths:
     #   - packages/zowe-explorer/**
     #   - packages/zowe-explorer-api/**

--- a/.github/workflows/zowe-explorer-ci.yml
+++ b/.github/workflows/zowe-explorer-ci.yml
@@ -1,10 +1,10 @@
 name: Zowe Explorer CI
 
 on:
-  push: # TODO Restore path filter after testing
-    # paths:
-    #   - packages/zowe-explorer/**
-    #   - packages/zowe-explorer-api/**
+  push:
+    paths:
+      - packages/zowe-explorer/**
+      - packages/zowe-explorer-api/**
   pull_request:
     paths:
       - packages/zowe-explorer/**

--- a/.github/workflows/zowe-explorer-ci.yml
+++ b/.github/workflows/zowe-explorer-ci.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Archive VSIX artifact
         if: matrix.os == 'ubuntu-latest' && matrix.node-version == '16.x'
-        run: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2
         with:
           name: zowe-explorer-vsix
           path: packages/zowe-explorer/*.vsix

--- a/.github/workflows/zowe-explorer-ftp-ci.yml
+++ b/.github/workflows/zowe-explorer-ftp-ci.yml
@@ -71,4 +71,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: zowe-explorer-ftp-extension-vsix
-          path: packages/zowe-explorer-ftp-extension/*.vsix
+          path: dist/*.vsix

--- a/.github/workflows/zowe-explorer-ftp-ci.yml
+++ b/.github/workflows/zowe-explorer-ftp-ci.yml
@@ -1,7 +1,7 @@
 name: Zowe Explorer FTP CI
 
 on:
-  push:# TODO Restore path filter after testing
+  push: # TODO Restore path filter after testing
     # paths:
     #   - packages/zowe-explorer-ftp-extension/**
     #   - packages/zowe-explorer-api/**

--- a/.github/workflows/zowe-explorer-ftp-ci.yml
+++ b/.github/workflows/zowe-explorer-ftp-ci.yml
@@ -1,10 +1,10 @@
 name: Zowe Explorer FTP CI
 
 on:
-  push:
-    paths:
-      - packages/zowe-explorer-ftp-extension/**
-      - packages/zowe-explorer-api/**
+  push:# TODO Restore path filter after testing
+    # paths:
+    #   - packages/zowe-explorer-ftp-extension/**
+    #   - packages/zowe-explorer-api/**
   pull_request:
     paths:
       - packages/zowe-explorer-ftp-extension/**
@@ -24,7 +24,7 @@ jobs:
       # Continue to run tests on the other systems if one fails
       fail-fast: false
       matrix:
-        node-version: [14, 16]
+        node-version: [14.x, 16.x]
         # order operating systems from best to worst
         os: [windows-latest, ubuntu-latest, macos-latest]
 
@@ -35,14 +35,14 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 
       # install yarn
       - run: npm install -g yarn
 
-      - run: yarn install --frozen-lockfile
+      - run: yarn config set network-timeout 60000 && yarn install --frozen-lockfile
 
       - run: yarn workspace zowe-explorer-ftp-extension test
         env:
@@ -60,3 +60,15 @@ jobs:
       #   uses: codecov/codecov-action@v1.0.7
       #   with:
       #     env_vars: OS,NODE
+
+      - name: Package VSIX
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '16.x'
+        run: yarn package
+        working-directory: packages/zowe-explorer-ftp-extension
+
+      - name: Archive VSIX artifact
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '16.x'
+        run: actions/upload-artifact@v2
+        with:
+          name: zowe-explorer-ftp-extension-vsix
+          path: packages/zowe-explorer-ftp-extension/*.vsix

--- a/.github/workflows/zowe-explorer-ftp-ci.yml
+++ b/.github/workflows/zowe-explorer-ftp-ci.yml
@@ -1,10 +1,10 @@
 name: Zowe Explorer FTP CI
 
 on:
-  push: # TODO Restore path filter after testing
-    # paths:
-    #   - packages/zowe-explorer-ftp-extension/**
-    #   - packages/zowe-explorer-api/**
+  push:
+    paths:
+      - packages/zowe-explorer-ftp-extension/**
+      - packages/zowe-explorer-api/**
   pull_request:
     paths:
       - packages/zowe-explorer-ftp-extension/**
@@ -48,12 +48,14 @@ jobs:
         env:
           CI: true
           NODE_OPTIONS: --max_old_space_size=4096
-      # - name: Upload test results
-      #   uses: actions/upload-artifact@v1
-      #   # if: matrix.os == 'windows-latest' && matrix.node-version == '12.x'
-      #   with:
-      #     name: zowe-explorer-ftp-extension-results
-      #     path: packages/zowe-explorer-ftp-extension/results/
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v2
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '16.x'
+        with:
+          name: zowe-explorer-ftp-extension-results
+          path: packages/zowe-explorer-ftp-extension/results/
+
       # Run codecov upload for only one run
       # - name: Upload Results to Codecov from Windows / Node 12.x
       #   if: matrix.os == 'windows-latest' && matrix.node-version == '12.x'

--- a/.github/workflows/zowe-explorer-ftp-ci.yml
+++ b/.github/workflows/zowe-explorer-ftp-ci.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Archive VSIX artifact
         if: matrix.os == 'ubuntu-latest' && matrix.node-version == '16.x'
-        run: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2
         with:
           name: zowe-explorer-ftp-extension-vsix
           path: packages/zowe-explorer-ftp-extension/*.vsix


### PR DESCRIPTION
## Proposed changes

Update workflows for Zowe Explorer and Zowe Explorer FTP extension:
* Increase yarn network timeout from 30s to 60s to reduce build failures
* Fix Codecov uploader not running in ZE workflow
* Fix test results not uploaded in ZE FTP workflow
* Package VSIX in both workflows and upload it as artifact to make testing PRs easier

## Release Notes

N/A

## Types of changes

- [x] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [ ] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [ ] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [ ] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

This commit provides an example of the workflows running successfully: https://github.com/zowe/vscode-extension-for-zowe/commit/4e26a4f14b0f60681f55dee8579df7e5b54076ba