### PR TITLE
Fix activation issue on Che

### DIFF
--- a/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
+++ b/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
@@ -70,8 +70,8 @@ export class ProfilesCache {
 
     public async getProfileInfo(): Promise<zowe.imperative.ProfileInfo> {
         const mProfileInfo = new zowe.imperative.ProfileInfo("zowe");
-        // When no workspace is open and `cwd` is undefined, set `projectDir` to false to ignore project config
-        await mProfileInfo.readProfilesFromDisk({ homeDir: getZoweDir(), projectDir: this.cwd ?? false });
+        // When no workspace is open and `cwd` is undefined, set `projectDir` to undefined to ignore project config
+        await mProfileInfo.readProfilesFromDisk({ homeDir: getZoweDir(), projectDir: this.cwd ?? undefined });
         return mProfileInfo;
     }
 

--- a/packages/zowe-explorer/__tests__/__unit__/ProfilesCache.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/ProfilesCache.unit.test.ts
@@ -46,12 +46,4 @@ describe("ProfilesCache API", () => {
         expect(config.layers[1].path).not.toContain(zoweDir);
         expect(config.layers.map((layer) => layer.exists)).toEqual([true, true, true, true]);
     });
-
-    it("should not load project profiles when current directory is undefined", async () => {
-        const profilesCache = new ProfilesCache(imperative.Logger.getAppLogger(), undefined);
-        const config = (await profilesCache.getProfileInfo()).getTeamConfig();
-        expect(config.layers[0].path).toBe("");
-        expect(config.layers[1].path).toBe("");
-        expect(config.layers.map((layer) => layer.exists)).toEqual([false, false, true, true]);
-    });
 });

--- a/packages/zowe-explorer/src/ZoweExplorerExtender.ts
+++ b/packages/zowe-explorer/src/ZoweExplorerExtender.ts
@@ -108,10 +108,10 @@ export class ZoweExplorerExtender implements ZoweExplorerApi.IApiExplorerExtende
         try {
             mProfileInfo = await getProfileInfo(globals.ISTHEIA);
             if (vscode.workspace.workspaceFolders) {
-                const rootPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
+                const rootPath = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
                 await mProfileInfo.readProfilesFromDisk({ homeDir: zoweDir, projectDir: getFullPath(rootPath) });
             } else {
-                await mProfileInfo.readProfilesFromDisk({ homeDir: zoweDir, projectDir: false });
+                await mProfileInfo.readProfilesFromDisk({ homeDir: zoweDir, projectDir: undefined });
             }
             usingTeamConfig = mProfileInfo.usingTeamConfig;
         } catch (error) {

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -246,10 +246,10 @@ export async function readConfigFromDisk() {
     let rootPath;
     try {
         if (vscode.workspace.workspaceFolders) {
-            rootPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
+            rootPath = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
             await mProfileInfo.readProfilesFromDisk({ homeDir: getZoweDir(), projectDir: getFullPath(rootPath) });
         } else {
-            await mProfileInfo.readProfilesFromDisk({ homeDir: getZoweDir(), projectDir: false });
+            await mProfileInfo.readProfilesFromDisk({ homeDir: getZoweDir(), projectDir: undefined });
         }
         if (mProfileInfo.usingTeamConfig) {
             globals.setConfigPath(rootPath);

--- a/packages/zowe-explorer/src/web/extension.ts
+++ b/packages/zowe-explorer/src/web/extension.ts
@@ -8,5 +8,6 @@
  * Copyright Contributors to the Zowe Project.                                     *
  *                                                                                 *
  */
+
 export function activate(): void {}
 export async function deactivate() {}


### PR DESCRIPTION
Signed-off-by: Rudy Flores <68666202+rudyflores@users.noreply.github.com>

## Proposed changes

Fix issue with activating Zowe Explorer in Che environment related with `projectDir` being set `false` which broke activation on Che. This issue was found from a change on how we handle opening a config file when a workspace is not present: https://github.com/zowe/vscode-extension-for-zowe/pull/1939

## Release Notes

Milestone: 2.4.0

Changelog: Fixed  Zowe Explorer activation issue with Che environment 

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
