### PR TITLE
Make Zowe Explorer independent of Zowe CLI installation

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the "vscode-extension-for-zowe" extension will be documented in this file.
 
+## TBD Release
+
+### New features and enhancements
+
+- Added independence from Zowe CLI installation by creating the `~/.zowe/settings/imperative.json` file during activation if it doesn't already exist. This file is for Zowe Explorer to know the Security Credential Manager used for secure profile information.
+
+### Bug fixes
+
+- Fixed the `Secure Credentials Enabled` setting to update the `~/.zowe/settings/imperative.json` file upon change of the setting without overwriting other data in the file.
+
 ## `2.4.0`
 
 ### New features and enhancements

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### New features and enhancements
 
-- Added independence from Zowe CLI installation by creating the `~/.zowe/settings/imperative.json` file during activation if it doesn't already exist. This file is for Zowe Explorer to know the Security Credential Manager used for secure profile information.
+- Added independence from Zowe CLI installation by creating the `~/.zowe/settings/imperative.json` file during activation if it doesn't already exist. This file is for Zowe Explorer to know the Security Credential Manager used for secure profile information. [#1850](https://github.com/zowe/vscode-extension-for-zowe/issues/1850)
 
 ### Bug fixes
 

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ## TBD Release
 
-### New features and enhancements
-
 ### Bug fixes
 
 - Fixed the `Secure Credentials Enabled` setting to update the `~/.zowe/settings/imperative.json` file upon change of the setting without overwriting other data in the file.

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -6,11 +6,10 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### New features and enhancements
 
-- Added independence from Zowe CLI installation by creating the `~/.zowe/settings/imperative.json` file during activation if it doesn't already exist. This file is for Zowe Explorer to know the Security Credential Manager used for secure profile information. [#1850](https://github.com/zowe/vscode-extension-for-zowe/issues/1850)
-
 ### Bug fixes
 
 - Fixed the `Secure Credentials Enabled` setting to update the `~/.zowe/settings/imperative.json` file upon change of the setting without overwriting other data in the file.
+- Fixed errors encountered from not having Zowe CLI installed by creating the `~/.zowe/settings/imperative.json` file during activation if it doesn't already exist. This file is for Zowe Explorer to know the Security Credential Manager used for secure profile information and removes the Zowe CLI installation prerequisite. [#1850](https://github.com/zowe/vscode-extension-for-zowe/issues/1850)
 
 ## `2.4.0`
 

--- a/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
@@ -22,7 +22,6 @@ import { Profiles } from "../../src/Profiles";
 import { ZoweDatasetNode } from "../../src/dataset/ZoweDatasetNode";
 import { createInstanceOfProfileInfo, createIProfile, createTreeView } from "../../__mocks__/mockCreators/shared";
 import { PersistentFilters } from "../../src/PersistentFilters";
-import { initializeZoweFolder, writeOverridesFile } from "../../src/utils/ProfilesUtils";
 
 jest.mock("vscode");
 jest.mock("fs");

--- a/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
@@ -80,6 +80,8 @@ async function createGlobalMocks() {
                 readProfilesFromDisk: jest.fn(),
             };
         }),
+        mockSetGlobalSecurityValue: jest.fn(),
+        mockWriteOverridesFile: jest.fn(),
         mockProfCacheProfileInfo: createInstanceOfProfileInfo(),
         mockProfilesCache: new ProfilesCache(zowe.imperative.Logger.getAppLogger()),
         testTreeView: null,
@@ -259,6 +261,10 @@ async function createGlobalMocks() {
     });
     Object.defineProperty(vscode.workspace, "onDidChangeConfiguration", {
         value: globalMocks.mockOnDidChangeConfiguration,
+        configurable: true,
+    });
+    Object.defineProperty(globals, "setGlobalSecurityValue", {
+        value: globalMocks.mockSetGlobalSecurityValue,
         configurable: true,
     });
     Object.defineProperty(fs, "readdirSync", { value: globalMocks.mockReaddirSync, configurable: true });

--- a/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
@@ -22,6 +22,7 @@ import { Profiles } from "../../src/Profiles";
 import { ZoweDatasetNode } from "../../src/dataset/ZoweDatasetNode";
 import { createInstanceOfProfileInfo, createIProfile, createTreeView } from "../../__mocks__/mockCreators/shared";
 import { PersistentFilters } from "../../src/PersistentFilters";
+import { initializeZoweFolder, writeOverridesFile } from "../../src/utils/ProfilesUtils";
 
 jest.mock("vscode");
 jest.mock("fs");
@@ -470,7 +471,7 @@ describe("Extension Unit Tests", () => {
 
         expect(globals.ISTHEIA).toEqual(true);
         // tslint:disable-next-line: no-magic-numbers
-        expect(globalMocks.mockMkdirSync.mock.calls.length).toBe(4);
+        expect(globalMocks.mockMkdirSync.mock.calls.length).toBe(6);
         expect(globalMocks.mockRegisterCommand.mock.calls.length).toBe(globals.COMMAND_COUNT);
         globalMocks.mockRegisterCommand.mock.calls.forEach((call, i) => {
             expect(globalMocks.mockRegisterCommand.mock.calls[i][1]).toBeInstanceOf(Function);

--- a/packages/zowe-explorer/__tests__/__unit__/utils/ProfileUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/ProfileUtils.unit.test.ts
@@ -50,9 +50,7 @@ describe("ProfileUtils Unit Tests", () => {
         spy.mockClear();
     });
     it("should have no change to global variable PROFILE_SECURITY and returns", async () => {
-        const globalMocks = await createGlobalMocks();
         const fileJson = { overrides: { CredentialManager: "@zowe/cli", testValue: true } };
-        const content = JSON.stringify(fileJson, null, 2);
         jest.spyOn(fs, "readFileSync").mockReturnValueOnce(JSON.stringify(fileJson, null, 2));
         const spy = jest.spyOn(fs, "writeFileSync");
         writeOverridesFile();

--- a/packages/zowe-explorer/__tests__/__unit__/utils/ProfileUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/ProfileUtils.unit.test.ts
@@ -19,6 +19,8 @@ async function createGlobalMocks() {
         mockReadFileSync: jest.fn(),
         mockWriteFileSync: jest.fn(),
         mockFileRead: { overrides: { CredentialManager: "@zowe/cli" } },
+        zoweDir: "__tests__/.zowe/settings/imperative.json",
+        encoding: "utf8",
     };
     Object.defineProperty(fs, "writeFileSync", { value: globalMocks.mockWriteFileSync, configurable: true });
     Object.defineProperty(fs, "existsSync", {
@@ -36,23 +38,21 @@ afterEach(() => {
 
 describe("ProfileUtils Unit Tests", () => {
     it("should have file exist", async () => {
+        const globalMocks = await createGlobalMocks();
         const fileJson = { overrides: { CredentialManager: "@zowe/cli", testValue: true } };
-        const path = "__tests__/.zowe/settings/imperative.json";
         const content = JSON.stringify(fileJson, null, 2);
-        const encoding = "utf8";
         jest.spyOn(fs, "readFileSync").mockReturnValueOnce(
             JSON.stringify({ overrides: { CredentialManager: false, testValue: true } }, null, 2)
         );
         const spy = jest.spyOn(fs, "writeFileSync");
         writeOverridesFile();
-        expect(spy).toBeCalledWith(path, content, encoding);
+        expect(spy).toBeCalledWith(globalMocks.zoweDir, content, globalMocks.encoding);
         spy.mockClear();
     });
     it("should have no change to global variable PROFILE_SECURITY and returns", async () => {
+        const globalMocks = await createGlobalMocks();
         const fileJson = { overrides: { CredentialManager: "@zowe/cli", testValue: true } };
-        const path = "__tests__/.zowe/settings/imperative.json";
         const content = JSON.stringify(fileJson, null, 2);
-        const encoding = "utf8";
         jest.spyOn(fs, "readFileSync").mockReturnValueOnce(JSON.stringify(fileJson, null, 2));
         const spy = jest.spyOn(fs, "writeFileSync");
         writeOverridesFile();
@@ -67,14 +67,11 @@ describe("ProfileUtils Unit Tests", () => {
             },
             configurable: true,
         });
-        const fileJson = { overrides: { CredentialManager: "@zowe/cli" } };
-        const path = "__tests__/.zowe/settings/imperative.json";
-        const content = JSON.stringify(fileJson, null, 2);
-        const encoding = "utf8";
+        const content = JSON.stringify(globalMocks.mockFileRead, null, 2);
         const spyRead = jest.spyOn(fs, "readFileSync");
         const spy = jest.spyOn(fs, "writeFileSync");
         writeOverridesFile();
-        expect(spy).toBeCalledWith(path, content, encoding);
+        expect(spy).toBeCalledWith(globalMocks.zoweDir, content, globalMocks.encoding);
         expect(spyRead).toBeCalledTimes(0);
         spy.mockClear();
         spyRead.mockClear();

--- a/packages/zowe-explorer/__tests__/__unit__/utils/ProfileUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/ProfileUtils.unit.test.ts
@@ -10,6 +10,7 @@
  */
 
 import * as fs from "fs";
+import * as path from "path";
 import { writeOverridesFile } from "../../../src/utils/ProfilesUtils";
 
 jest.mock("fs");
@@ -19,7 +20,7 @@ async function createGlobalMocks() {
         mockReadFileSync: jest.fn(),
         mockWriteFileSync: jest.fn(),
         mockFileRead: { overrides: { CredentialManager: "@zowe/cli" } },
-        zoweDir: "__tests__/.zowe/settings/imperative.json",
+        zoweDir: path.normalize("__tests__/.zowe/settings/imperative.json"),
         encoding: "utf8",
     };
     Object.defineProperty(fs, "writeFileSync", { value: globalMocks.mockWriteFileSync, configurable: true });

--- a/packages/zowe-explorer/__tests__/__unit__/utils/ProfileUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/ProfileUtils.unit.test.ts
@@ -1,0 +1,82 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the *
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+ * https://www.eclipse.org/legal/epl-v20.html                                      *
+ *                                                                                 *
+ * SPDX-License-Identifier: EPL-2.0                                                *
+ *                                                                                 *
+ * Copyright Contributors to the Zowe Project.                                     *
+ *                                                                                 *
+ */
+
+import * as fs from "fs";
+import { writeOverridesFile } from "../../../src/utils/ProfilesUtils";
+
+jest.mock("fs");
+
+async function createGlobalMocks() {
+    const globalMocks = {
+        mockReadFileSync: jest.fn(),
+        mockWriteFileSync: jest.fn(),
+        mockFileRead: { overrides: { CredentialManager: "@zowe/cli" } },
+    };
+    Object.defineProperty(fs, "writeFileSync", { value: globalMocks.mockWriteFileSync, configurable: true });
+    Object.defineProperty(fs, "existsSync", {
+        value: () => {
+            return true;
+        },
+        configurable: true,
+    });
+    return globalMocks;
+}
+
+afterEach(() => {
+    jest.clearAllMocks();
+});
+
+describe("ProfileUtils Unit Tests", () => {
+    it("should have file exist", async () => {
+        const fileJson = { overrides: { CredentialManager: "@zowe/cli", testValue: true } };
+        const path = "__tests__/.zowe/settings/imperative.json";
+        const content = JSON.stringify(fileJson, null, 2);
+        const encoding = "utf8";
+        jest.spyOn(fs, "readFileSync").mockReturnValueOnce(
+            JSON.stringify({ overrides: { CredentialManager: false, testValue: true } }, null, 2)
+        );
+        const spy = jest.spyOn(fs, "writeFileSync");
+        writeOverridesFile();
+        expect(spy).toBeCalledWith(path, content, encoding);
+        spy.mockClear();
+    });
+    it("should have no change to global variable PROFILE_SECURITY and returns", async () => {
+        const fileJson = { overrides: { CredentialManager: "@zowe/cli", testValue: true } };
+        const path = "__tests__/.zowe/settings/imperative.json";
+        const content = JSON.stringify(fileJson, null, 2);
+        const encoding = "utf8";
+        jest.spyOn(fs, "readFileSync").mockReturnValueOnce(JSON.stringify(fileJson, null, 2));
+        const spy = jest.spyOn(fs, "writeFileSync");
+        writeOverridesFile();
+        expect(spy).toBeCalledTimes(0);
+        spy.mockClear();
+    });
+    it("should have not exist and create default file", async () => {
+        const globalMocks = await createGlobalMocks();
+        Object.defineProperty(fs, "existsSync", {
+            value: () => {
+                return false;
+            },
+            configurable: true,
+        });
+        const fileJson = { overrides: { CredentialManager: "@zowe/cli" } };
+        const path = "__tests__/.zowe/settings/imperative.json";
+        const content = JSON.stringify(fileJson, null, 2);
+        const encoding = "utf8";
+        const spyRead = jest.spyOn(fs, "readFileSync");
+        const spy = jest.spyOn(fs, "writeFileSync");
+        writeOverridesFile();
+        expect(spy).toBeCalledWith(path, content, encoding);
+        expect(spyRead).toBeCalledTimes(0);
+        spy.mockClear();
+        spyRead.mockClear();
+    });
+});

--- a/packages/zowe-explorer/src/Profiles.ts
+++ b/packages/zowe-explorer/src/Profiles.ts
@@ -717,24 +717,6 @@ export class Profiles extends ProfilesCache {
         }
     }
 
-    public updateImperativeSettings() {
-        try {
-            const fileName = path.join(getZoweDir(), "settings", "imperative.json");
-            const updatedSettings = {
-                overrides: {
-                    CredentialManager: false,
-                },
-            };
-            fs.writeFile(fileName, JSON.stringify(updatedSettings), "utf8", (err) => {
-                if (err) {
-                    this.log.error("Could not update imperative.json settings file", err);
-                }
-            });
-        } catch (error) {
-            this.log.error(error);
-        }
-    }
-
     public async editZoweConfigFile() {
         const existingLayers = await this.getConfigLayers();
         if (existingLayers.length === 1) {
@@ -1917,7 +1899,6 @@ export class Profiles extends ProfilesCache {
             for (const profile of Object.entries(newConfig.profiles)) {
                 delete newConfig.profiles[profile[0]].secure;
             }
-            this.updateImperativeSettings();
             newConfig.autoStore = false;
         }
     }

--- a/packages/zowe-explorer/src/extension.ts
+++ b/packages/zowe-explorer/src/extension.ts
@@ -176,9 +176,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<ZoweEx
         })
     );
 
-    // Update imperative.json to false if VS Code setting is set to false
-    await vscode.commands.executeCommand("zowe.updateSecureCredentials");
-
     if (datasetProvider) {
         initDatasetProvider(context, datasetProvider);
     }

--- a/packages/zowe-explorer/src/extension.ts
+++ b/packages/zowe-explorer/src/extension.ts
@@ -28,7 +28,7 @@ import {
 import { ZoweExplorerApiRegister } from "./ZoweExplorerApiRegister";
 import { ZoweExplorerExtender } from "./ZoweExplorerExtender";
 import { Profiles } from "./Profiles";
-import { initializeZoweFolder, promptCredentials, readConfigFromDisk } from "./utils/ProfilesUtils";
+import { initializeZoweFolder, promptCredentials, readConfigFromDisk, writeOverridesFile } from "./utils/ProfilesUtils";
 import { createDatasetTree } from "./dataset/DatasetTree";
 import { createJobsTree } from "./job/ZosJobsProvider";
 import { createUSSTree } from "./uss/USSTree";
@@ -131,14 +131,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<ZoweEx
 
     // Update imperative.json to false only when VS Code setting is set to false
     context.subscriptions.push(
-        vscode.commands.registerCommand("zowe.updateSecureCredentials", () => {
-            const isSettingEnabled: boolean = vscode.workspace
-                .getConfiguration()
-                .get(globals.SETTINGS_SECURE_CREDENTIALS_ENABLED);
-
-            if (!isSettingEnabled) {
-                Profiles.getInstance().updateImperativeSettings();
-            }
+        vscode.commands.registerCommand("zowe.updateSecureCredentials", async () => {
+            await globals.setGlobalSecurityValue();
+            writeOverridesFile();
         })
     );
 

--- a/packages/zowe-explorer/src/extension.ts
+++ b/packages/zowe-explorer/src/extension.ts
@@ -10,7 +10,6 @@
  */
 
 import * as fs from "fs";
-import * as path from "path";
 import * as globals from "./globals";
 import * as vscode from "vscode";
 import * as ussActions from "./uss/actions";
@@ -29,8 +28,7 @@ import {
 import { ZoweExplorerApiRegister } from "./ZoweExplorerApiRegister";
 import { ZoweExplorerExtender } from "./ZoweExplorerExtender";
 import { Profiles } from "./Profiles";
-import { promptCredentials, readConfigFromDisk } from "./utils/ProfilesUtils";
-import { getImperativeConfig, imperative } from "@zowe/cli";
+import { initializeZoweFolder, promptCredentials, readConfigFromDisk } from "./utils/ProfilesUtils";
 import { createDatasetTree } from "./dataset/DatasetTree";
 import { createJobsTree } from "./job/ZosJobsProvider";
 import { createUSSTree } from "./uss/USSTree";
@@ -88,32 +86,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<ZoweEx
     }
 
     try {
-        // Ensure that ~/.zowe folder exists
-        if (!imperative.ImperativeConfig.instance.config?.exists) {
-            const zoweDir = getZoweDir();
-            // Should we replace the instance.config above with (await getProfileInfo(globals.ISTHEIA)).exists
-            await imperative.CliProfileManager.initialize({
-                configuration: getImperativeConfig().profiles,
-                profileRootDirectory: path.join(zoweDir, "profiles"),
-            });
-
-            // TODO(zFernand0): Will address the commented code below once this imperative issue is resolved.
-            // https://github.com/zowe/imperative/issues/840
-
-            // const settingsPath = path.join(zoweDir, "settings");
-            // if (!fs.existsSync(settingsPath)) {
-            //     fs.mkdirSync(settingsPath);
-            // }
-            // const imperativeSettings = path.join(settingsPath, "imperative.json");
-            // if (!fs.existsSync(imperativeSettings)) {
-            //     fs.writeFileSync(imperativeSettings, JSON.stringify({
-            //         overrides: {
-            //             CredentialManager: "@zowe/cli"
-            //         }
-            //     }));
-            // }
-        }
-
+        await initializeZoweFolder();
         await readConfigFromDisk();
     } catch (err) {
         const errorMessage = localize("initialize.profiles.error", "Error reading or initializing Zowe CLI profiles.");

--- a/packages/zowe-explorer/src/globals.ts
+++ b/packages/zowe-explorer/src/globals.ts
@@ -88,6 +88,7 @@ export const SETTINGS_JOBS_HISTORY = "zowe.jobs.history";
 export const SETTINGS_SECURE_CREDENTIALS_ENABLED = "zowe.security.secureCredentialsEnabled";
 export const EXTENDER_CONFIG: imperative.ICommandProfileTypeConfiguration[] = [];
 export let ACTIVATED = false;
+export let PROFILE_SECURITY: string | boolean = "@zowe/cli";
 
 export enum CreateDataSetTypeWithKeysEnum {
     DATA_SET_BINARY = 0,
@@ -251,4 +252,12 @@ export function initLogger(context: vscode.ExtensionContext) {
 
 export function setActivated(value: boolean) {
     ACTIVATED = value;
+}
+
+export function setGlobalSecurityValue() {
+    const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
+    const secureCredsEnabled: boolean = configuration.get(SETTINGS_SECURE_CREDENTIALS_ENABLED);
+    if (!secureCredsEnabled) {
+        PROFILE_SECURITY = false;
+    }
 }

--- a/packages/zowe-explorer/src/globals.ts
+++ b/packages/zowe-explorer/src/globals.ts
@@ -87,8 +87,9 @@ export const SETTINGS_USS_HISTORY = "zowe.uss.history";
 export const SETTINGS_JOBS_HISTORY = "zowe.jobs.history";
 export const SETTINGS_SECURE_CREDENTIALS_ENABLED = "zowe.security.secureCredentialsEnabled";
 export const EXTENDER_CONFIG: imperative.ICommandProfileTypeConfiguration[] = [];
+export const ZOWE_CLI_SCM = "@zowe/cli";
 export let ACTIVATED = false;
-export let PROFILE_SECURITY: string | boolean = "@zowe/cli";
+export let PROFILE_SECURITY: string | boolean = ZOWE_CLI_SCM;
 
 export enum CreateDataSetTypeWithKeysEnum {
     DATA_SET_BINARY = 0,
@@ -254,10 +255,13 @@ export function setActivated(value: boolean) {
     ACTIVATED = value;
 }
 
-export function setGlobalSecurityValue() {
-    const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
-    const secureCredsEnabled: boolean = configuration.get(SETTINGS_SECURE_CREDENTIALS_ENABLED);
-    if (!secureCredsEnabled) {
+export async function setGlobalSecurityValue() {
+    const isSettingEnabled: boolean = await vscode.workspace
+        .getConfiguration()
+        .get(SETTINGS_SECURE_CREDENTIALS_ENABLED);
+    if (!isSettingEnabled) {
         PROFILE_SECURITY = false;
+    } else {
+        PROFILE_SECURITY = ZOWE_CLI_SCM;
     }
 }

--- a/packages/zowe-explorer/src/globals.ts
+++ b/packages/zowe-explorer/src/globals.ts
@@ -256,10 +256,8 @@ export function setActivated(value: boolean) {
 }
 
 export async function setGlobalSecurityValue() {
-    const isSettingEnabled: boolean = await vscode.workspace
-        .getConfiguration()
-        .get(SETTINGS_SECURE_CREDENTIALS_ENABLED);
-    if (!isSettingEnabled) {
+    const settingEnabled: boolean = await vscode.workspace.getConfiguration().get(SETTINGS_SECURE_CREDENTIALS_ENABLED);
+    if (!settingEnabled) {
         PROFILE_SECURITY = false;
     } else {
         PROFILE_SECURITY = ZOWE_CLI_SCM;

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -368,14 +368,14 @@ export function writeOverridesFile() {
     const settingsFile = path.join(getZoweDir(), "settings", "imperative.json");
     if (fs.existsSync(settingsFile)) {
         content = JSON.parse(fs.readFileSync(settingsFile).toString());
-    }
-    if (content && content?.overrides) {
-        if (content?.overrides?.CredentialManager === globals.PROFILE_SECURITY) {
-            return;
+        if (content && content?.overrides) {
+            if (content?.overrides?.CredentialManager === globals.PROFILE_SECURITY) {
+                return;
+            }
+            content.overrides.CredentialManager = globals.PROFILE_SECURITY;
+            fileContent = JSON.stringify(content, null, 2);
+            fs.writeFileSync(settingsFile, fileContent, "utf8");
         }
-        content.overrides.CredentialManager = globals.PROFILE_SECURITY;
-        fileContent = JSON.stringify(content, null, 2);
-        fs.writeFileSync(settingsFile, fileContent, "utf8");
     } else {
         fileContent = JSON.stringify({ overrides: { CredentialManager: globals.PROFILE_SECURITY } }, null, 2);
         fs.writeFileSync(settingsFile, fileContent, "utf8");

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -333,11 +333,17 @@ export async function promptCredentials(node: IZoweTreeNode) {
 }
 
 export async function initializeZoweFolder(): Promise<void> {
+    // ensure the Secure Credentials Enabled value is read
+    // set globals.PROFILE_SECURITY value accordingly
+    globals.setGlobalSecurityValue();
     // Ensure that ~/.zowe folder exists
-    const zoweDir = getZoweDir();
     // Ensure that the ~/.zowe/settings/imperative.json exists
     // TODO: update code below once this imperative issue is resolved.
     // https://github.com/zowe/imperative/issues/840
+    const zoweDir = getZoweDir();
+    if (!fs.existsSync(zoweDir)) {
+        fs.mkdirSync(zoweDir);
+    }
     const settingsPath = path.join(zoweDir, "settings");
     if (!fs.existsSync(settingsPath)) {
         fs.mkdirSync(settingsPath);
@@ -353,17 +359,12 @@ export async function initializeZoweFolder(): Promise<void> {
     }
 }
 
-function writeOverridesFile() {
-    globals.setGlobalSecurityValue();
+export function writeOverridesFile() {
     const settingsFile = path.join(getZoweDir(), "settings", "imperative.json");
-    if (!fs.existsSync(settingsFile)) {
-        fs.writeFileSync(
-            settingsFile,
-            JSON.stringify({
-                overrides: {
-                    CredentialManager: globals.PROFILE_SECURITY,
-                },
-            })
-        );
-    }
+    const file = JSON.stringify({
+        overrides: {
+            CredentialManager: globals.PROFILE_SECURITY,
+        },
+    });
+    fs.writeFileSync(settingsFile, file);
 }

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -363,15 +363,22 @@ export async function initializeZoweFolder(): Promise<void> {
 }
 
 export function writeOverridesFile() {
+    let content;
+    let fileContent: string;
     const settingsFile = path.join(getZoweDir(), "settings", "imperative.json");
-    const fileContent = JSON.stringify(
-        {
-            overrides: {
-                CredentialManager: globals.PROFILE_SECURITY,
-            },
-        },
-        null,
-        2
-    );
-    fs.writeFileSync(settingsFile, fileContent);
+    if (fs.existsSync(settingsFile)) {
+        content = JSON.parse(fs.readFileSync(settingsFile).toString());
+    }
+    if (content && content?.overrides) {
+        if (content?.overrides?.CredentialManager === globals.PROFILE_SECURITY) {
+            return;
+        }
+        content.overrides.CredentialManager = globals.PROFILE_SECURITY;
+        console.log(content.overrides.CredentialManager);
+        fileContent = JSON.stringify(content, null, 2);
+        fs.writeFileSync(settingsFile, fileContent, "utf8");
+    } else {
+        fileContent = JSON.stringify({ overrides: { CredentialManager: globals.PROFILE_SECURITY } }, null, 2);
+        fs.writeFileSync(settingsFile, fileContent, "utf8");
+    }
 }

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -374,7 +374,6 @@ export function writeOverridesFile() {
             return;
         }
         content.overrides.CredentialManager = globals.PROFILE_SECURITY;
-        console.log(content.overrides.CredentialManager);
         fileContent = JSON.stringify(content, null, 2);
         fs.writeFileSync(settingsFile, fileContent, "utf8");
     } else {

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -348,7 +348,10 @@ export async function initializeZoweFolder(): Promise<void> {
     if (!fs.existsSync(settingsPath)) {
         fs.mkdirSync(settingsPath);
     }
-    writeOverridesFile();
+    const settingsFile = path.join(settingsPath, "imperative.json");
+    if (!fs.existsSync(settingsFile)) {
+        writeOverridesFile();
+    }
     // If not using team config, ensure that the ~/.zowe/profiles directory
     // exists with appropriate types within
     if (!imperative.ImperativeConfig.instance.config?.exists) {

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -364,10 +364,14 @@ export async function initializeZoweFolder(): Promise<void> {
 
 export function writeOverridesFile() {
     const settingsFile = path.join(getZoweDir(), "settings", "imperative.json");
-    const fileContent = JSON.stringify({
-        overrides: {
-            CredentialManager: globals.PROFILE_SECURITY,
+    const fileContent = JSON.stringify(
+        {
+            overrides: {
+                CredentialManager: globals.PROFILE_SECURITY,
+            },
         },
-    });
+        null,
+        2
+    );
     fs.writeFileSync(settingsFile, fileContent);
 }

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -283,8 +283,8 @@ export async function readConfigFromDisk() {
 export async function openConfigOnError(error: Error) {
     if (error.message.toString().includes("Error parsing JSON")) {
         const errorArray = error.message.toString().split("'");
-        const path = errorArray[1];
-        await Profiles.getInstance().openConfigFile(path);
+        const errorPath = errorArray[1];
+        await Profiles.getInstance().openConfigFile(errorPath);
     }
 }
 
@@ -364,10 +364,10 @@ export async function initializeZoweFolder(): Promise<void> {
 
 export function writeOverridesFile() {
     const settingsFile = path.join(getZoweDir(), "settings", "imperative.json");
-    const file = JSON.stringify({
+    const fileContent = JSON.stringify({
         overrides: {
             CredentialManager: globals.PROFILE_SECURITY,
         },
     });
-    fs.writeFileSync(settingsFile, file);
+    fs.writeFileSync(settingsFile, fileContent);
 }


### PR DESCRIPTION
Signed-off-by: Billie Simmons <49491949+JillieBeanSim@users.noreply.github.com>

## Proposed changes

This PR will 
1. check for and create if needed the .zowe/settings/imperative.json file making Zowe Explorer independent of the Zowe CLI installation.  
2. fixes the watcher of the Secure Credentials Enabled setting, to update file when checked or unchecked.  
3. will read and parse the file if existing and changing the CredentialManager value then write back. This is done just incase imperative, zowe cli, or an extender/plugin decide to introduce more values to this file.

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog -->
<!-- If there is a linked issue, it should have the same milestone as this PR -->

Milestone: 2.4.1

Changelog:
- Added independence from Zowe CLI installation by creating the `~/.zowe/settings/imperative.json` file during activation if it doesn't already exist. This file is for Zowe Explorer to know the Security Credential Manager used for secure profile information.
- Fixed the `Secure Credentials Enabled` setting to update the `~/.zowe/settings/imperative.json` file upon change of the setting without overwriting other data in the file.

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [x] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

https://user-images.githubusercontent.com/49491949/198721982-c5ea7a94-b192-41da-b173-c7b4c0c94da4.mov

https://user-images.githubusercontent.com/49491949/198725505-f1504304-2a08-4b19-bfe2-2859860224e8.mov

