### PR TITLE
[fix] Disabling ZE views for web extension

### DIFF
--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -39,7 +39,8 @@
         {
           "id": "zowe",
           "title": "%viewsContainers.activitybar%",
-          "icon": "resources/zowe.svg"
+          "icon": "resources/zowe.svg",
+          "when": "!isWeb"
         }
       ]
     },
@@ -47,15 +48,18 @@
       "zowe": [
         {
           "id": "zowe.ds.explorer",
-          "name": "%zowe.ds.explorer%"
+          "name": "%zowe.ds.explorer%",
+          "when": "!isWeb"
         },
         {
           "id": "zowe.uss.explorer",
-          "name": "%zowe.uss.explorer%"
+          "name": "%zowe.uss.explorer%",
+          "when": "!isWeb"
         },
         {
           "id": "zowe.jobs.explorer",
-          "name": "%zowe.jobs.explorer%"
+          "name": "%zowe.jobs.explorer%",
+          "when": "!isWeb"
         }
       ]
     },


### PR DESCRIPTION
Signed-off-by: Benjamin Santos <Benjamin.Santos@ibm.com>

## Proposed changes
Currently the Zowe Explorer web extension acts only as a stub intended to resolve other web extensions dependencies on it

Despite this, when installing ZE on vscode.dev or any other browser based VS Code instance, the ZE icon is still added to the activity bar, and the tree views are shown. Interacting with these views creates an ugly, unhandled errors (e.g. "command 'zowe.jobs.refreshAllJobs' not found)

The Zowe Explorer views and icon are initialized in the package.json "viewContainers" field. Adding a "when: !isWeb" clause will prevent the views and icon from being loaded in a browser, while not affecting their rendering on desktop or other environments.

To test on your own: 
1. Package the extension as normal, install the .vsix, and make sure the icon and views still shop on desktop.
2. Test in a web browser by running this script from the command line: 
`npx @vscode/test-web --extensionDevelopmentPath=$extensionFolderPath $testDataPath`
Or by following this official Visual Studio Code guide [here](https://code.visualstudio.com/api/extension-guides/web-extensions#test-your-web-extension-in-on-vscode.dev)


Before:
<img width="348" alt="Screen Shot 2022-11-04 at 3 11 12 PM" src="https://user-images.githubusercontent.com/115251181/200061020-ed5ec89d-13b2-4f37-ba8d-9828d931f409.png">
After:
<img width="348" alt="Screen Shot 2022-11-04 at 3 11 55 PM" src="https://user-images.githubusercontent.com/115251181/200061022-5e631746-15b8-450e-982b-0eae306a9911.png">

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog -->
<!-- If there is a linked issue, it should have the same milestone as this PR -->

Milestone:

Changelog:

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [x] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
