### PR TITLE
Fix failure to activate in empty workspace

### DIFF
--- a/packages/zowe-explorer-api/src/security/KeytarApi.ts
+++ b/packages/zowe-explorer-api/src/security/KeytarApi.ts
@@ -21,7 +21,7 @@ export class KeytarApi {
     // v1 specific
     public async activateKeytar(initialized: boolean, isTheia: boolean): Promise<void> {
         const log = imperative.Logger.getAppLogger();
-        const profiles = new ProfilesCache(log, vscode.workspace.workspaceFolders?.[0].uri.fsPath);
+        const profiles = new ProfilesCache(log, vscode.workspace.workspaceFolders?.[0]?.uri.fsPath);
         const scsActive = profiles.isSecureCredentialPluginActive();
         if (scsActive) {
             const keytar: NodeRequire | undefined = KeytarCredentialManager.getSecurityModules("keytar", isTheia);

--- a/packages/zowe-explorer-api/src/vscode/ZoweVsCodeExtension.ts
+++ b/packages/zowe-explorer-api/src/vscode/ZoweVsCodeExtension.ts
@@ -20,6 +20,11 @@ import { IPromptCredentialsOptions, IPromptUserPassOptions } from "./doc/IPrompt
  * Collection of utility functions for writing Zowe Explorer VS Code extensions.
  */
 export class ZoweVsCodeExtension {
+    private static profilesCache = new ProfilesCache(
+        imperative.Logger.getAppLogger(),
+        vscode.workspace.workspaceFolders?.[0]?.uri.fsPath
+    );
+
     /**
      * @param {string} [requiredVersion] Optional semver string specifying the minimal required version
      *           of Zowe Explorer that needs to be installed for the API to be usable to the client.
@@ -27,10 +32,6 @@ export class ZoweVsCodeExtension {
      *          to access the Zowe Explorer APIs or `undefined`. Also `undefined` if requiredVersion
      *          is larger than the version of Zowe Explorer found.
      */
-    private static profilesCache = new ProfilesCache(
-        imperative.Logger.getAppLogger(),
-        vscode.workspace.workspaceFolders?.[0].uri.fsPath
-    );
     public static getZoweExplorerApi(requiredVersion?: string): ZoweExplorerApi.IApiRegisterClient {
         const zoweExplorerApi = vscode.extensions.getExtension("Zowe.vscode-extension-for-zowe");
         if (zoweExplorerApi?.exports) {

--- a/packages/zowe-explorer/src/Profiles.ts
+++ b/packages/zowe-explorer/src/Profiles.ts
@@ -54,7 +54,7 @@ let InputBoxOptions: vscode.InputBoxOptions;
 export class Profiles extends ProfilesCache {
     // Processing stops if there are no profiles detected
     public static async createInstance(log: zowe.imperative.Logger): Promise<Profiles> {
-        Profiles.loader = new Profiles(log, vscode.workspace.workspaceFolders?.[0].uri.fsPath);
+        Profiles.loader = new Profiles(log, vscode.workspace.workspaceFolders?.[0]?.uri.fsPath);
         await Profiles.loader.refresh(ZoweExplorerApiRegister.getInstance());
         return Profiles.loader;
     }
@@ -640,7 +640,7 @@ export class Profiles extends ProfilesCache {
             let user = false;
             let global = true;
             let rootPath = getZoweDir();
-            if (vscode.workspace.workspaceFolders) {
+            if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0]) {
                 const choice = await this.getConfigLocationPrompt("create");
                 if (choice === undefined) {
                     vscode.window.showInformationMessage(
@@ -649,7 +649,7 @@ export class Profiles extends ProfilesCache {
                     return;
                 }
                 if (choice === "project") {
-                    rootPath = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
+                    rootPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
                     user = true;
                     global = false;
                 }
@@ -672,7 +672,7 @@ export class Profiles extends ProfilesCache {
                 homeDir: getZoweDir(),
                 projectDir: getFullPath(rootPath),
             });
-            if (vscode.workspace.workspaceFolders) {
+            if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0]) {
                 config.api.layers.activate(user, global, rootPath);
             }
 
@@ -1463,7 +1463,7 @@ export class Profiles extends ProfilesCache {
         const existingLayers: zowe.imperative.IConfigLayer[] = [];
         const config = await zowe.imperative.Config.load("zowe", {
             homeDir: getZoweDir(),
-            projectDir: vscode.workspace.workspaceFolders?.[0].uri.fsPath,
+            projectDir: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
         });
         const layers = config.layers;
         layers.forEach((layer) => {

--- a/packages/zowe-explorer/src/ZoweExplorerExtender.ts
+++ b/packages/zowe-explorer/src/ZoweExplorerExtender.ts
@@ -107,7 +107,7 @@ export class ZoweExplorerExtender implements ZoweExplorerApi.IApiExplorerExtende
         let mProfileInfo: zowe.imperative.ProfileInfo;
         try {
             mProfileInfo = await getProfileInfo(globals.ISTHEIA);
-            if (vscode.workspace.workspaceFolders) {
+            if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0]) {
                 const rootPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
                 await mProfileInfo.readProfilesFromDisk({ homeDir: zoweDir, projectDir: getFullPath(rootPath) });
             } else {

--- a/packages/zowe-explorer/src/extension.ts
+++ b/packages/zowe-explorer/src/extension.ts
@@ -328,7 +328,7 @@ async function watchConfigProfile(context: vscode.ExtensionContext) {
     );
 
     const workspaceProfileWatcher =
-        vscode.workspace.workspaceFolders &&
+        vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0] &&
         vscode.workspace.createFileSystemWatcher(
             new vscode.RelativePattern(
                 vscode.workspace.workspaceFolders[0].uri.fsPath,

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -245,7 +245,7 @@ export async function readConfigFromDisk() {
     let rootPath: string;
     try {
         const mProfileInfo = await getProfileInfo(globals.ISTHEIA);
-        if (vscode.workspace.workspaceFolders) {
+        if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0]) {
             rootPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
             await mProfileInfo.readProfilesFromDisk({ homeDir: getZoweDir(), projectDir: getFullPath(rootPath) });
         } else {


### PR DESCRIPTION
## Proposed changes

Fixes #1994 which is related to https://github.com/microsoft/vscode/issues/96111. When an empty workspace is open in VS Code, then `vscode.workspace.workspaceFolders = [undefined]` which we weren't handling correctly.

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog -->
<!-- If there is a linked issue, it should have the same milestone as this PR -->

Milestone: 2.4.1

Changelog:

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [ ] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [ ] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [ ] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
