### PR TITLE
Fix: "Allocate Like" execution stops due to error

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the "vscode-extension-for-zowe" extension will be documented in this file.
 
+## TBD Release
+
+### Bug fixes
+
+- Fixed "Allocate Like" feature failing to respect original dataset params and pattern (if specified). [#1974](https://github.com/zowe/vscode-extension-for-zowe/issues/1974)
+
 ## `2.4.1`
 
 ### Bug fixes

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 ### Bug fixes
 
 - Fixed missing localization for certain VScode error/info/warning messages. [#1722](https://github.com/zowe/vscode-extension-for-zowe/issues/1722)
-- Fixed "Allocate Like" feature failing to respect original dataset params and pattern (if specified). [#1974](https://github.com/zowe/vscode-extension-for-zowe/issues/1974)
+- Fixed "Allocate Like" error that prevented proper execution. [#1973](https://github.com/zowe/vscode-extension-for-zowe/issues/1973)
 
 ## `2.4.1`
 

--- a/packages/zowe-explorer/__tests__/__unit__/dataset/DatasetTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/dataset/DatasetTree.unit.test.ts
@@ -1158,6 +1158,28 @@ describe("Dataset Tree Unit Tests - Function removeFavorite", () => {
         expect(removeFavProfileSpy).toHaveBeenCalledWith(profileNodeInFavs.label, false);
         expect(testTree.mFavorites.length).toBe(0);
     });
+
+    it("Checking removeFavorite when calling with a node that is not favorited", async () => {
+        createGlobalMocks();
+        const blockMocks = createBlockMocks();
+
+        mocked(vscode.window.createTreeView).mockReturnValueOnce(blockMocks.treeView);
+        const testTree = new DatasetTree();
+        testTree.mSessionNodes.push(blockMocks.datasetSessionNode);
+        const node = new ZoweDatasetNode(
+            "Dataset",
+            vscode.TreeItemCollapsibleState.None,
+            testTree.mSessionNodes[1],
+            null
+        );
+
+        const updateFavoritesSpy = jest.spyOn(testTree, "updateFavorites");
+        const removeFavoriteSpy = jest.spyOn(testTree, "removeFavorite");
+
+        await testTree.removeFavorite(node);
+        expect(removeFavoriteSpy).toHaveReturned();
+        expect(updateFavoritesSpy).not.toHaveBeenCalled();
+    });
 });
 describe("Dataset Tree Unit Tests - Function  - Function removeFavProfile", () => {
     function createBlockMocks() {

--- a/packages/zowe-explorer/src/dataset/DatasetTree.ts
+++ b/packages/zowe-explorer/src/dataset/DatasetTree.ts
@@ -657,6 +657,11 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
         // Get node's profile node in favorites
         const profileName = node.getProfileName();
         const profileNodeInFavorites = this.findMatchingProfileInArray(this.mFavorites, profileName);
+
+        if (profileNodeInFavorites === undefined) {
+            return;
+        }
+
         profileNodeInFavorites.children = profileNodeInFavorites.children.filter(
             (temp) => !(temp.label === node.label && temp.contextValue.startsWith(node.contextValue))
         );
@@ -773,7 +778,7 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
         let theFilter = this.getSearchHistory()[0] || null;
 
         // Check if filter is currently applied
-        if (node.pattern !== "" && theFilter) {
+        if (node.pattern != null && node.pattern !== "" && theFilter) {
             const currentFilters = node.pattern.split(",");
 
             // Check if current filter includes the new node

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -142,9 +142,10 @@ export async function allocateLike(
     // Refresh tree and open new node, if applicable
     if (!currSession) {
         currSession = datasetProvider.mSessionNodes.find(
-            (thisSession) => thisSession.label.toString() === profile.name
+            (thisSession) => thisSession.label.toString().trim() === profile.name
         );
     }
+
     const theFilter = await datasetProvider.createFilterString(newDSName, currSession);
     currSession.tooltip = currSession.pattern = theFilter.toUpperCase();
     datasetProvider.addSearchHistory(theFilter);


### PR DESCRIPTION
## Proposed changes

- Fixes bug described in #1973 to allow `allocateLike` to continue execution
- **Update:** Originally #1974 was factored into this issue, but the block size problem appears to be an issue with z/OSMF REST client.
- Also updated logic in `removeFavorite` to skip `undefined` nodes

## Release Notes

Milestone: 2.5.0

Changelog: Fixed issue where "Allocate Like" feature fails to grab dataset node during execution

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [x] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found