### PR TITLE
Fix: Cannot delete favorited PS, PDS, or member

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -7,8 +7,9 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 ### New features and enhancements
 
 - New API call `getJobsByParameters` to allow filtering jobs by status.
+- Added `findEquivalentNode` function to IZoweTree to find a corresponding favorited/non-favorited node.
 
-## 2.4.1
+## `2.4.1`
 
 ### Bug fixes
 

--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 - New API call `getJobsByParameters` to allow filtering jobs by status.
 - Added `findEquivalentNode` function to IZoweTree to find a corresponding favorited/non-favorited node.
+- Updated `IZoweTree`: changed `IZoweNodeType -> IZoweTreeNode` to prevent incompatibility w/ custom/future Zowe node types
 
 ## `2.4.1`
 

--- a/packages/zowe-explorer-api/src/tree/IZoweTree.ts
+++ b/packages/zowe-explorer-api/src/tree/IZoweTree.ts
@@ -10,7 +10,7 @@
  */
 
 import * as vscode from "vscode";
-import { IZoweNodeType, IZoweUSSTreeNode } from "./IZoweTreeNode";
+import { IZoweTreeNode } from "./IZoweTreeNode";
 import { PersistenceSchemaEnum } from "../profiles/UserSettings";
 
 /**
@@ -26,16 +26,16 @@ export interface IZoweTree<T> extends vscode.TreeDataProvider<T> {
     /**
      * Root session nodes
      */
-    mSessionNodes: IZoweNodeType[];
+    mSessionNodes: IZoweTreeNode[];
     /**
      * Root favorites node
      */
-    mFavoriteSession: IZoweNodeType;
+    mFavoriteSession: IZoweTreeNode;
     /**
      * Array of favorite nodes
      * @deprecated should not be visible outside of class
      */
-    mFavorites: IZoweNodeType[];
+    mFavorites: IZoweTreeNode[];
 
     /**
      * Adds a session to the container
@@ -47,48 +47,48 @@ export interface IZoweTree<T> extends vscode.TreeDataProvider<T> {
      * Edit a session to the container
      * @param node This parameter identifies the node that needs to be called
      */
-    editSession(node: IZoweNodeType, zoweFileProvider: IZoweTree<IZoweNodeType>): Promise<void>;
+    editSession(node: IZoweTreeNode, zoweFileProvider: IZoweTree<IZoweTreeNode>): Promise<void>;
 
     /**
      * Add a new session to the container
      * @param zoweFileProvider The tree to which the profile should be added
      */
-    createZoweSession(zoweFileProvider: IZoweTree<IZoweNodeType>): Promise<void>;
+    createZoweSession(zoweFileProvider: IZoweTree<IZoweTreeNode>): Promise<void>;
 
     /**
      * Create a brand new Schema
      * @param zoweFileProvider The tree from which the schema will be created
      */
-    createZoweSchema(zoweFileProvider: IZoweTree<IZoweNodeType>): Promise<void>;
+    createZoweSchema(zoweFileProvider: IZoweTree<IZoweTreeNode>): Promise<void>;
 
     /**
      * Adds a favorite node
      * @param favorite Adds a favorite node
      */
-    checkCurrentProfile(node: IZoweNodeType);
+    checkCurrentProfile(node: IZoweTreeNode);
 
     /**
      * Log in to authentication service
      * @param node This parameter identifies the node that needs to be called
      */
-    ssoLogin(node: IZoweNodeType);
+    ssoLogin(node: IZoweTreeNode);
 
     /**
      * Log out from authentication service
      * @param node This parameter identifies the node that needs to be called
      */
-    ssoLogout(node: IZoweNodeType);
+    ssoLogout(node: IZoweTreeNode);
 
     /**
      * Adds a favorite node
      * @param favorite Adds a favorite node
      */
-    addFavorite(favorite: IZoweNodeType);
+    addFavorite(favorite: IZoweTreeNode);
     /**
      * Removes a favorite node
      * @param favorite Adds a favorite node
      */
-    removeFavorite(node: IZoweNodeType);
+    removeFavorite(node: IZoweTreeNode);
     /**
      * Removes profile node from Favorites section
      * @param profileName
@@ -102,7 +102,7 @@ export interface IZoweTree<T> extends vscode.TreeDataProvider<T> {
      * Refreshes an element of the tree
      * @param favorite Node to refresh
      */
-    refreshElement(node: IZoweNodeType): void;
+    refreshElement(node: IZoweTreeNode): void;
     /**
      * Event Emitters used to notify subscribers that the refresh event has fired
      */
@@ -112,65 +112,60 @@ export interface IZoweTree<T> extends vscode.TreeDataProvider<T> {
      * @param element the node being flipped
      * @param isOpen the intended state of the the tree view provider, true or false
      */
-    flipState(element: IZoweNodeType, isOpen: boolean);
+    flipState(element: IZoweTreeNode, isOpen: boolean);
 
     /**
      * Rename the node. Begins a dialog.
      * @param the node to be renamed
      */
-    rename(node: IZoweNodeType);
+    rename(node: IZoweTreeNode);
     /**
      * Opens the node. Begins a dialog.
      * @param node: the node to be opened
      * @param preview: open in preview of edit mode
      */
-    open(node: IZoweNodeType, preview: boolean);
+    open(node: IZoweTreeNode, preview: boolean);
     /**
      * Begins a copy operation on the node.
      * @param node: the node to be copied
      */
-    copy(node: IZoweNodeType);
+    copy(node: IZoweTreeNode);
     /**
      * Concludes a copy/paste operation on the node.
      * @param node: the node to be pasted
      */
-    paste(node: IZoweNodeType);
+    paste(node: IZoweTreeNode);
     /**
      * Deletes a node.
      * @param node: the node to be deleted
      */
-    delete(node: IZoweNodeType);
+    delete(node: IZoweTreeNode);
     /**
      * Reveals and selects a node within the tree.
      * @param treeView: the vscode tree container
      * @param node: the node to be selected
      */
-    setItem(treeView: vscode.TreeView<IZoweNodeType>, node: IZoweNodeType);
+    setItem(treeView: vscode.TreeView<IZoweTreeNode>, node: IZoweTreeNode);
     /**
      * Saves the currently employed filter as a favorite.
      * @param node: A root node representing a session
      */
-    saveSearch(node: IZoweNodeType);
+    saveSearch(node: IZoweTreeNode);
     /**
      * Saves an edited file.
      * @param node: the node to be saved
      */
     saveFile(document: vscode.TextDocument);
 
-    // TODO
-    refreshPS(node: IZoweNodeType);
+    refreshPS(node: IZoweTreeNode);
 
-    uploadDialog(node: IZoweNodeType): any;
+    uploadDialog(node: IZoweTreeNode): any;
 
-    // TODO replace with filterPrompt
-    // datasetFilterPrompt(node: IZoweNodeType): any;
-    // filterPrompt(node: IZoweUSSTreeNode): any;
-    // searchPrompt(node: IZoweJobTreeNode): any;
     /**
-     * Begins a filter/serach operation on a node.
+     * Begins a filter/search operation on a node.
      * @param node: the root node to be searched from
      */
-    filterPrompt(node: IZoweNodeType);
+    filterPrompt(node: IZoweTreeNode);
 
     /**
      * Adds a search history element to persisted settings.
@@ -190,35 +185,35 @@ export interface IZoweTree<T> extends vscode.TreeDataProvider<T> {
      * Deletes a root node from the tree.
      * @param node: A root node representing a session
      */
-    deleteSession(node: IZoweNodeType): any;
+    deleteSession(node: IZoweTreeNode): any;
     /**
      * Lets the user open a dataset by filtering the currently-loaded list
      */
-    getAllLoadedItems?(): Promise<IZoweUSSTreeNode[]>;
+    getAllLoadedItems?(): Promise<IZoweTreeNode[]>;
     /**
      * Retrieves the vscode tree container
      */
-    getTreeView(): vscode.TreeView<IZoweNodeType>;
+    getTreeView(): vscode.TreeView<IZoweTreeNode>;
 
     /**
      * Finds an equivalent node but not as a favorite
      *
-     * @param {IZoweNodeType} node
+     * @param {IZoweTreeNode} node
      * @deprecated should not be visible outside of class
      */
-    findFavoritedNode(node: IZoweNodeType): IZoweNodeType;
+    findFavoritedNode(node: IZoweTreeNode): IZoweTreeNode;
     /**
      * Finds the equivalent node but not as a favorite
      *
-     * @param {IZoweNodeType} node
+     * @param {IZoweTreeNode} node
      * @deprecated should not be visible outside of class
      */
-    findNonFavoritedNode(node: IZoweNodeType): IZoweNodeType;
+    findNonFavoritedNode(node: IZoweTreeNode): IZoweTreeNode;
     /**
      * Finds the equivalent node, based on isFavorite
-     * @param {IZoweNodeType} node
+     * @param {IZoweTreeNode} node
      */
-    findEquivalentNode(node: IZoweNodeType, isFavorite: boolean): IZoweNodeType;
+    findEquivalentNode(node: IZoweTreeNode, isFavorite: boolean): IZoweTreeNode;
     /**
      * Updates favorite
      *
@@ -228,10 +223,10 @@ export interface IZoweTree<T> extends vscode.TreeDataProvider<T> {
     /**
      * Renames a node from the favorites list
      *
-     * @param {IZoweNodeType} node
+     * @param {IZoweTreeNode} node
      * @deprecated should not be visible outside of class
      */
-    renameFavorite(node: IZoweNodeType, newLabel: string);
+    renameFavorite(node: IZoweTreeNode, newLabel: string);
     /**
      * Renames a node based on the profile and it's label
      * @deprecated should not be visible outside of class
@@ -255,9 +250,9 @@ export interface IZoweTree<T> extends vscode.TreeDataProvider<T> {
      * Returns a new dataset filter string, from an old filter and a new string
      *
      * @param {string} newFilter the new filter to add
-     * @param {IZoweNodeType} node the node with the old filter
+     * @param {IZoweTreeNode} node the node with the old filter
      */
-    createFilterString?(newFilter: string, node: IZoweNodeType);
+    createFilterString?(newFilter: string, node: IZoweTreeNode);
     /**
      * @param {string} profileLabel
      * @param {string} beforeLabel
@@ -268,7 +263,7 @@ export interface IZoweTree<T> extends vscode.TreeDataProvider<T> {
      * Opens an item & reveals it in the tree
      *
      * @param {string} path the path of the item
-     * @param {IZoweNodeType} sessionNode the session to use
+     * @param {IZoweTreeNode} sessionNode the session to use
      */
-    openItemFromPath?(path: string, sessionNode: IZoweNodeType);
+    openItemFromPath?(path: string, sessionNode: IZoweTreeNode);
 }

--- a/packages/zowe-explorer-api/src/tree/IZoweTree.ts
+++ b/packages/zowe-explorer-api/src/tree/IZoweTree.ts
@@ -10,7 +10,7 @@
  */
 
 import * as vscode from "vscode";
-import { IZoweNodeType, IZoweDatasetTreeNode, IZoweUSSTreeNode } from "./IZoweTreeNode";
+import { IZoweNodeType, IZoweUSSTreeNode } from "./IZoweTreeNode";
 import { PersistenceSchemaEnum } from "../profiles/UserSettings";
 
 /**
@@ -160,7 +160,7 @@ export interface IZoweTree<T> extends vscode.TreeDataProvider<T> {
     // TODO
     refreshPS(node: IZoweNodeType);
 
-    uploadDialog(node: IZoweDatasetTreeNode): any;
+    uploadDialog(node: IZoweNodeType): any;
 
     // TODO replace with filterPrompt
     // datasetFilterPrompt(node: IZoweNodeType): any;
@@ -203,17 +203,22 @@ export interface IZoweTree<T> extends vscode.TreeDataProvider<T> {
     /**
      * Finds an equivalent node but not as a favorite
      *
-     * @param {IZoweDatasetTreeNode} node
+     * @param {IZoweNodeType} node
      * @deprecated should not be visible outside of class
      */
     findFavoritedNode(node: IZoweNodeType): IZoweNodeType;
     /**
      * Finds the equivalent node but not as a favorite
      *
-     * @param {IZoweDatasetTreeNode} node
+     * @param {IZoweNodeType} node
      * @deprecated should not be visible outside of class
      */
     findNonFavoritedNode(node: IZoweNodeType): IZoweNodeType;
+    /**
+     * Finds the equivalent node, based on isFavorite
+     * @param {IZoweNodeType} node
+     */
+    findEquivalentNode(node: IZoweNodeType, isFavorite: boolean): IZoweNodeType;
     /**
      * Updates favorite
      *
@@ -223,10 +228,10 @@ export interface IZoweTree<T> extends vscode.TreeDataProvider<T> {
     /**
      * Renames a node from the favorites list
      *
-     * @param {IZoweDatasetTreeNode} node
+     * @param {IZoweNodeType} node
      * @deprecated should not be visible outside of class
      */
-    renameFavorite(node: IZoweDatasetTreeNode, newLabel: string);
+    renameFavorite(node: IZoweNodeType, newLabel: string);
     /**
      * Renames a node based on the profile and it's label
      * @deprecated should not be visible outside of class
@@ -250,7 +255,7 @@ export interface IZoweTree<T> extends vscode.TreeDataProvider<T> {
      * Returns a new dataset filter string, from an old filter and a new string
      *
      * @param {string} newFilter the new filter to add
-     * @param {IZoweDatasetTreeNode} node the node with the old filter
+     * @param {IZoweNodeType} node the node with the old filter
      */
     createFilterString?(newFilter: string, node: IZoweNodeType);
     /**

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 - Fixed missing localization for certain VScode error/info/warning messages. [#1722](https://github.com/zowe/vscode-extension-for-zowe/issues/1722)
 - Fixed "Allocate Like" error that prevented proper execution. [#1973](https://github.com/zowe/vscode-extension-for-zowe/issues/1973)
+- Fixed de-sync issue between Data Set and Favorites panels when adding or deleting datasets/members that were favorited. [#1488](https://github.com/zowe/vscode-extension-for-zowe/issues/1488)
 
 ## `2.4.1`
 

--- a/packages/zowe-explorer/__mocks__/mockCreators/datasets.ts
+++ b/packages/zowe-explorer/__mocks__/mockCreators/datasets.ts
@@ -74,6 +74,7 @@ export function createDatasetTree(sessionNode: ZoweDatasetNode, treeView: any, f
         renameNode: jest.fn(),
         findFavoritedNode: jest.fn(),
         findNonFavoritedNode: jest.fn(),
+        findEquivalentNode: jest.fn(),
         getProfileName: jest.fn(),
         getSession: jest.fn(),
         getProfiles: jest.fn(),

--- a/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
@@ -618,7 +618,7 @@ describe("Dataset Actions Unit Tests - Function deleteDatasetPrompt", () => {
         );
     });
 
-    it("Should not delete a favorited dataset", async () => {
+    it("Should delete a favorited data set", async () => {
         const globalMocks = createGlobalMocks();
         const blockMocks = createBlockMocks(globalMocks);
 
@@ -629,12 +629,14 @@ describe("Dataset Actions Unit Tests - Function deleteDatasetPrompt", () => {
 
         await dsActions.deleteDatasetPrompt(blockMocks.testDatasetTree);
 
-        expect(mocked(vscode.window.showInformationMessage)).toBeCalledWith(
-            "Deleting data sets and members from the Favorites section is currently not supported."
+        expect(mocked(vscode.window.showWarningMessage)).toBeCalledWith(
+            `Are you sure you want to delete the following 1 item(s)?\nThis will permanently remove these data sets and/or members from your system.\n\n ${blockMocks.testFavoritedNode.getLabel()}`,
+            { modal: true },
+            "Delete"
         );
     });
 
-    it("Should not delete a favorited member", async () => {
+    it("Should delete a favorited member", async () => {
         const globalMocks = createGlobalMocks();
         const blockMocks = createBlockMocks(globalMocks);
 
@@ -645,12 +647,14 @@ describe("Dataset Actions Unit Tests - Function deleteDatasetPrompt", () => {
 
         await dsActions.deleteDatasetPrompt(blockMocks.testDatasetTree);
 
-        expect(mocked(vscode.window.showInformationMessage)).toBeCalledWith(
-            "Deleting data sets and members from the Favorites section is currently not supported."
+        expect(mocked(vscode.window.showWarningMessage)).toBeCalledWith(
+            `Are you sure you want to delete the following 1 item(s)?\nThis will permanently remove these data sets and/or members from your system.\n\n ${blockMocks.testFavoritedNode.getLabel()}(${blockMocks.testFavMemberNode.getLabel()})`,
+            { modal: true },
+            "Delete"
         );
     });
 
-    it("Should not delete a session", async () => {
+    it("Should not consider a session for deletion", async () => {
         const globalMocks = createGlobalMocks();
         const blockMocks = createBlockMocks(globalMocks);
 
@@ -662,11 +666,11 @@ describe("Dataset Actions Unit Tests - Function deleteDatasetPrompt", () => {
         await dsActions.deleteDatasetPrompt(blockMocks.testDatasetTree);
 
         expect(mocked(vscode.window.showInformationMessage)).toBeCalledWith(
-            "Deleting data sets and members from the Favorites section is currently not supported."
+            "No data sets selected for deletion, cancelling..."
         );
     });
 
-    it("Should fail to delete first dataset and succeed in deleting second dataset", async () => {
+    it("Should account for favorited data sets during deletion", async () => {
         const globalMocks = createGlobalMocks();
         const blockMocks = createBlockMocks(globalMocks);
 
@@ -678,7 +682,7 @@ describe("Dataset Actions Unit Tests - Function deleteDatasetPrompt", () => {
         await dsActions.deleteDatasetPrompt(blockMocks.testDatasetTree);
 
         expect(mocked(vscode.window.showInformationMessage)).toBeCalledWith(
-            `The following 1 item(s) were deleted: ${blockMocks.testDatasetNode.getLabel()}`
+            `The following 2 item(s) were deleted: ${blockMocks.testDatasetNode.getLabel()}, ${blockMocks.testFavoritedNode.getLabel()}`
         );
     });
 

--- a/packages/zowe-explorer/__tests__/__unit__/job/ZosJobsProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/ZosJobsProvider.unit.test.ts
@@ -630,6 +630,71 @@ describe("ZosJobsProvider unit tests - Function removeFavProfile", () => {
     });
 });
 
+describe("ZosJobsProvider Unit Tests - Function findEquivalentNode()", () => {
+    it("Testing that findEquivalentNode() returns the corresponding nodes", async () => {
+        const globalMocks = await createGlobalMocks();
+        const favNodeParent = new Job(
+            "sestest",
+            vscode.TreeItemCollapsibleState.Expanded,
+            globalMocks.testJobsProvider.mSessionNodes[0],
+            globalMocks.testJobsProvider.mSessionNodes[0].getSession(),
+            null,
+            globalMocks.testProfile
+        );
+        const favNode = new Job(
+            "exampleName",
+            vscode.TreeItemCollapsibleState.Expanded,
+            null,
+            favNodeParent.getSession(),
+            globalMocks.testIJob,
+            globalMocks.testProfile
+        );
+        favNode.contextValue = globals.JOBS_JOB_CONTEXT + globals.FAV_SUFFIX;
+        favNodeParent.children.push(favNode);
+        // Create a copy of the above job object to designate as a non-favorited node
+        const nonFavNode = new Job(
+            "exampleName",
+            vscode.TreeItemCollapsibleState.Expanded,
+            null,
+            globalMocks.testSession,
+            globalMocks.testIJob,
+            globalMocks.testProfile
+        );
+        nonFavNode.contextValue = globals.JOBS_JOB_CONTEXT;
+
+        globalMocks.testJobsProvider.mFavorites.push(favNodeParent);
+        globalMocks.testJobsProvider.mSessionNodes[0].children.push(favNodeParent);
+        globalMocks.testJobsProvider.mSessionNodes[1].children.push(nonFavNode);
+
+        expect(globalMocks.testJobsProvider.findEquivalentNode(favNode, true)).toStrictEqual(nonFavNode);
+        expect(globalMocks.testJobsProvider.findEquivalentNode(nonFavNode, false)).toStrictEqual(favNode);
+    });
+});
+
+describe("ZosJobsProvider Unit Tests - unimplemented functions", () => {
+    it("Testing that each unimplemented function throws an error", async () => {
+        const globalMocks = await createGlobalMocks();
+
+        const unimplementedFns = [
+            globalMocks.testJobsProvider.rename,
+            globalMocks.testJobsProvider.open,
+            globalMocks.testJobsProvider.copy,
+            globalMocks.testJobsProvider.paste,
+            globalMocks.testJobsProvider.saveFile,
+            globalMocks.testJobsProvider.refreshPS,
+            globalMocks.testJobsProvider.uploadDialog,
+        ];
+
+        for (const fn of unimplementedFns) {
+            try {
+                fn(undefined);
+            } catch (e) {
+                expect(e.message).toEqual("Method not implemented.");
+            }
+        }
+    });
+});
+
 describe("ZosJobsProvider unit tests - Function getUserJobsMenuChoice", () => {
     let showInformationMessage;
     let globalMocks;

--- a/packages/zowe-explorer/__tests__/__unit__/shared/context.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/shared/context.unit.test.ts
@@ -178,7 +178,7 @@ describe("Context helper tests", () => {
         }
     });
 
-    it("PDS (regardless of favorite status)", async () => {
+    it("Test PDS (regardless of favorite)", async () => {
         for (const ctx of testList) {
             treeItem.contextValue = ctx;
             expect(contextually.isPds(treeItem)).toBe(treeItem.contextValue.indexOf(DS_PDS_CONTEXT) >= 0);

--- a/packages/zowe-explorer/__tests__/__unit__/uss/USSTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/USSTree.unit.test.ts
@@ -820,23 +820,29 @@ describe("USSTree Unit Tests - Function USSTree.getAllLoadedItems()", () => {
     });
 });
 
+const setupUssFavNode = (globalMocks): ZoweUSSNode => {
+    const ussFavNode = createFavoriteUSSNode(globalMocks.testSession, globalMocks.testProfile);
+    const ussFavNodeParent = new ZoweUSSNode(
+        "sestest",
+        vscode.TreeItemCollapsibleState.Expanded,
+        null,
+        globalMocks.testSession,
+        null,
+        false,
+        globalMocks.testProfile.name
+    );
+    ussFavNodeParent.children.push(ussFavNode);
+    globalMocks.testTree.mFavorites.push(ussFavNodeParent);
+
+    return ussFavNode;
+};
+
 describe("USSTree Unit Tests - Function USSTree.findFavoritedNode()", () => {
     it("Testing that findFavoritedNode() returns the favorite of a non-favorited node", async () => {
         const globalMocks = await createGlobalMocks();
         globalMocks.testUSSNode.contextValue = globals.DS_TEXT_FILE_CONTEXT;
 
-        const ussFavNode = createFavoriteUSSNode(globalMocks.testSession, globalMocks.testProfile);
-        const ussFavNodeParent = new ZoweUSSNode(
-            "sestest",
-            vscode.TreeItemCollapsibleState.Expanded,
-            null,
-            globalMocks.testSession,
-            null,
-            false,
-            globalMocks.testProfile.name
-        );
-        ussFavNodeParent.children.push(ussFavNode);
-        globalMocks.testTree.mFavorites.push(ussFavNodeParent);
+        const ussFavNode = setupUssFavNode(globalMocks);
 
         const foundNode = await globalMocks.testTree.findFavoritedNode(globalMocks.testUSSNode);
 
@@ -857,21 +863,23 @@ describe("USSTree Unit Tests - Function USSTree.findFavoritedNode()", () => {
 describe("USSTree Unit Tests - Function USSTree.findNonFavoritedNode()", () => {
     it("Testing that findNonFavoritedNode() returns the non-favorite from a favorite node", async () => {
         const globalMocks = await createGlobalMocks();
-        const ussFavNode = createFavoriteUSSNode(globalMocks.testSession, globalMocks.testProfile);
-        const ussFavNodeParent = new ZoweUSSNode(
-            "sestest",
-            vscode.TreeItemCollapsibleState.Expanded,
-            null,
-            globalMocks.testSession,
-            null,
-            false,
-            globalMocks.testProfile.name
-        );
-        ussFavNodeParent.children.push(ussFavNode);
-        globalMocks.testTree.mFavorites.push(ussFavNodeParent);
+        const ussFavNode = setupUssFavNode(globalMocks);
+
         globalMocks.testTree.mSessionNodes[1].children.push(globalMocks.testUSSNode);
 
         const nonFaveNode = await globalMocks.testTree.findNonFavoritedNode(ussFavNode);
+        expect(nonFaveNode).toStrictEqual(globalMocks.testUSSNode);
+    });
+});
+
+describe("USSTree Unit Tests - Function USSTree.findEquivalentNode()", () => {
+    it("Testing that findEquivalentNode() returns the corresponding node for a favorite node", async () => {
+        const globalMocks = await createGlobalMocks();
+        const ussFavNode = setupUssFavNode(globalMocks);
+
+        globalMocks.testTree.mSessionNodes[1].children.push(globalMocks.testUSSNode);
+
+        const nonFaveNode = await globalMocks.testTree.findEquivalentNode(ussFavNode, true);
         expect(nonFaveNode).toStrictEqual(globalMocks.testUSSNode);
     });
 });

--- a/packages/zowe-explorer/i18n/sample/src/dataset/actions.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/dataset/actions.i18n.json
@@ -7,7 +7,7 @@
   "createDataSet.log.error": "Error encountered when creating data set! ",
   "createDataSet.error": "Error encountered when creating data set! ",
   "enterPattern.pattern": "You must enter a pattern.",
-  "deleteDatasetPrompt.nodesToDelete.empty": "Deleting data sets and members from the Favorites section is currently not supported.",
+  "deleteDatasetPrompt.nodesToDelete.empty": "No data sets selected for deletion, cancelled.",
   "deleteDatasetPrompt.log.debug": "Deleting data set(s): ",
   "deleteDatasetPrompt.confirmation.delete": "Delete",
   "deleteDatasetPrompt.confirmation.message": "Are you sure you want to delete the following {0} item(s)?\nThis will permanently remove these data sets and/or members from your system.\n\n{1}",

--- a/packages/zowe-explorer/i18n/sample/src/dataset/actions.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/dataset/actions.i18n.json
@@ -7,7 +7,7 @@
   "createDataSet.log.error": "Error encountered when creating data set! ",
   "createDataSet.error": "Error encountered when creating data set! ",
   "enterPattern.pattern": "You must enter a pattern.",
-  "deleteDatasetPrompt.nodesToDelete.empty": "No data sets selected for deletion, cancelled.",
+  "deleteDatasetPrompt.nodesToDelete.empty": "No data sets selected for deletion, cancelling...",
   "deleteDatasetPrompt.log.debug": "Deleting data set(s): ",
   "deleteDatasetPrompt.confirmation.delete": "Delete",
   "deleteDatasetPrompt.confirmation.message": "Are you sure you want to delete the following {0} item(s)?\nThis will permanently remove these data sets and/or members from your system.\n\n{1}",

--- a/packages/zowe-explorer/src/dataset/DatasetTree.ts
+++ b/packages/zowe-explorer/src/dataset/DatasetTree.ts
@@ -644,8 +644,12 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
      */
     public findNonFavoritedNode(node: IZoweDatasetTreeNode) {
         const profileName = node.getProfileName();
-        const sessionNode = this.mSessionNodes.find((session) => session.label.toString() === profileName);
+        const sessionNode = this.mSessionNodes.find((session) => session.label.toString().trim() === profileName);
         return sessionNode.children.find((temp) => temp.label === node.label);
+    }
+
+    public findEquivalentNode(node: IZoweDatasetTreeNode, isFavorite: boolean) {
+        return isFavorite ? this.findNonFavoritedNode(node) : this.findFavoritedNode(node);
     }
 
     /**
@@ -1201,12 +1205,7 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
                 );
                 throw err;
             }
-            let otherParent;
-            if (contextually.isFavorite(node.getParent())) {
-                otherParent = this.findNonFavoritedNode(node.getParent());
-            } else {
-                otherParent = this.findFavoritedNode(node.getParent());
-            }
+            const otherParent = this.findEquivalentNode(node.getParent(), contextually.isFavorite(node.getParent()));
             if (otherParent) {
                 const otherMember = otherParent.children.find((child) => child.label === beforeMemberName);
                 if (otherMember) {

--- a/packages/zowe-explorer/src/dataset/DatasetTree.ts
+++ b/packages/zowe-explorer/src/dataset/DatasetTree.ts
@@ -628,10 +628,7 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
         // Get node's profile node in favorites
         const profileName = node.getProfileName();
         const profileNodeInFavorites = this.findMatchingProfileInArray(this.mFavorites, profileName);
-        if (!profileNodeInFavorites) {
-            return;
-        }
-        return profileNodeInFavorites.children.find(
+        return profileNodeInFavorites?.children.find(
             (temp) => temp.label === node.getLabel().toString() && temp.contextValue.includes(node.contextValue)
         );
     }
@@ -645,7 +642,7 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
     public findNonFavoritedNode(node: IZoweDatasetTreeNode) {
         const profileName = node.getProfileName();
         const sessionNode = this.mSessionNodes.find((session) => session.label.toString().trim() === profileName);
-        return sessionNode.children.find((temp) => temp.label === node.label);
+        return sessionNode?.children.find((temp) => temp.label === node.label);
     }
 
     /**

--- a/packages/zowe-explorer/src/dataset/DatasetTree.ts
+++ b/packages/zowe-explorer/src/dataset/DatasetTree.ts
@@ -648,6 +648,10 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
         return sessionNode.children.find((temp) => temp.label === node.label);
     }
 
+    /**
+     * Finds the equivalent node depending on whether the passed node is a favorite.
+     * @param node
+     */
     public findEquivalentNode(node: IZoweDatasetTreeNode, isFavorite: boolean) {
         return isFavorite ? this.findNonFavoritedNode(node) : this.findFavoritedNode(node);
     }

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -247,35 +247,24 @@ export async function deleteDatasetPrompt(
     selectedNodes = selectedNodes.filter((val) => !childArray.includes(val));
 
     if (includedSelection || !node) {
-        // Filter out sessions, favorite nodes, or information messages
+        // Filter out sessions and information messages
         nodes = selectedNodes.filter(
             (selectedNode) =>
                 selectedNode.getParent() &&
-                !contextually.isFavorite(selectedNode) &&
-                !contextually.isFavorite(selectedNode.getParent()) &&
                 !contextually.isSession(selectedNode) &&
                 !contextually.isInformation(selectedNode)
         );
     } else {
-        if (
-            node.getParent() &&
-            !contextually.isFavorite(node) &&
-            !contextually.isFavorite(node.getParent()) &&
-            !contextually.isSession(node) &&
-            !contextually.isInformation(node)
-        ) {
+        if (node.getParent() && !contextually.isSession(node) && !contextually.isInformation(node)) {
             nodes = [];
             nodes.push(node);
         }
     }
 
-    // Check that there are items to be deleted, this can be caused by trying to delete favorites right now
+    // Check that there are items to be deleted
     if (!nodes || nodes.length === 0) {
         vscode.window.showInformationMessage(
-            localize(
-                "deleteDatasetPrompt.nodesToDelete.empty",
-                "Deleting data sets and members from the Favorites section is currently not supported."
-            )
+            localize("deleteDatasetPrompt.nodesToDelete.empty", "No data sets selected for deletion, cancelling...")
         );
         return;
     }

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -1067,16 +1067,18 @@ export async function deleteDataset(node: api.IZoweTreeNode, datasetProvider: ap
 
     const isMember = contextually.isDsMember(node);
 
-    // TODO(Trae): Change favorites impl. to avoid searching through favorites array for every action
-    // Perhaps 1:1 mapping e.g. custom Map class?
+    // If the node is a dataset member, go up a level in the node tree
+    // to find the relevant, matching node
+    const nodeOfInterest = isMember ? node.getParent() : node;
+    const parentNode = fav
+        ? datasetProvider.findNonFavoritedNode(nodeOfInterest)
+        : datasetProvider.findFavoritedNode(nodeOfInterest);
 
-    // Refresh corresponding tree parent to reflect deletion
-    const dsFavParent = fav
-        ? datasetProvider.findNonFavoritedNode(isMember ? node.getParent() : node)
-        : datasetProvider.findFavoritedNode(isMember ? node.getParent() : node);
-    if (dsFavParent != null) {
-        datasetProvider.refreshElement(isMember ? dsFavParent : dsFavParent.getParent());
+    if (parentNode != null) {
+        // Refresh the correct node (parent of node to delete) to reflect changes
+        datasetProvider.refreshElement(isMember ? parentNode : parentNode.getParent());
     }
+
     datasetProvider.refreshElement(node.getSessionNode());
 
     // remove local copy of file

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -431,11 +431,7 @@ export async function createMember(
         );
 
         // Refresh corresponding tree parent to reflect addition
-        const findCorrespondingNode = contextually.isFavorite(parent)
-            ? datasetProvider.findNonFavoritedNode.bind(datasetProvider)
-            : datasetProvider.findFavoritedNode.bind(datasetProvider);
-
-        const otherTreeParent = findCorrespondingNode(parent);
+        const otherTreeParent = datasetProvider.findEquivalentNode(parent, contextually.isFavorite(parent));
         if (otherTreeParent != null) {
             datasetProvider.refreshElement(otherTreeParent);
         }
@@ -1070,9 +1066,7 @@ export async function deleteDataset(node: api.IZoweTreeNode, datasetProvider: ap
     // If the node is a dataset member, go up a level in the node tree
     // to find the relevant, matching node
     const nodeOfInterest = isMember ? node.getParent() : node;
-    const parentNode = fav
-        ? datasetProvider.findNonFavoritedNode(nodeOfInterest)
-        : datasetProvider.findFavoritedNode(nodeOfInterest);
+    const parentNode = datasetProvider.findEquivalentNode(nodeOfInterest, fav);
 
     if (parentNode != null) {
         // Refresh the correct node (parent of node to delete) to reflect changes

--- a/packages/zowe-explorer/src/job/ZosJobsProvider.ts
+++ b/packages/zowe-explorer/src/job/ZosJobsProvider.ts
@@ -291,6 +291,14 @@ export class ZosJobsProvider extends ZoweTreeProvider implements IZoweTree<IZowe
     }
 
     /**
+     * Finds the equivalent node based on whether the passed node is a favorite.
+     * @param node
+     */
+    public findEquivalentNode(node: IZoweJobTreeNode, isFavorite: boolean): IZoweJobTreeNode {
+        return isFavorite ? this.findNonFavoritedNode(node) : this.findFavoritedNode(node);
+    }
+
+    /**
      * Creates and returns new profile node, and pushes it to mFavorites
      * @param profileName Name of profile
      * @returns {Job}

--- a/packages/zowe-explorer/src/job/ZosJobsProvider.ts
+++ b/packages/zowe-explorer/src/job/ZosJobsProvider.ts
@@ -291,6 +291,27 @@ export class ZosJobsProvider extends ZoweTreeProvider implements IZoweTree<IZowe
     }
 
     /**
+     * Finds the equivalent, favorited node.
+     * @param node
+     */
+    public findFavoritedNode(node: IZoweJobTreeNode): IZoweJobTreeNode {
+        const profileNodeInFavorites = this.findMatchingProfileInArray(this.mFavorites, node.getProfileName());
+        return profileNodeInFavorites?.children.find(
+            (temp) => temp.label === node.getLabel().toString() && temp.contextValue.includes(node.contextValue)
+        );
+    }
+
+    /**
+     * Finds the equivalent, non-favorited node.
+     * @param node
+     */
+    public findNonFavoritedNode(node: IZoweJobTreeNode): IZoweJobTreeNode {
+        const profileName = node.getProfileName();
+        const sessionNode = this.mSessionNodes.find((session) => session.label.toString().trim() === profileName);
+        return sessionNode?.children.find((temp) => temp.label === node.label);
+    }
+
+    /**
      * Finds the equivalent node based on whether the passed node is a favorite.
      * @param node
      */

--- a/packages/zowe-explorer/src/shared/context.ts
+++ b/packages/zowe-explorer/src/shared/context.ts
@@ -227,12 +227,21 @@ export function isDsSession(node: TreeItem): boolean {
 }
 
 /**
+ * Helper function which identifies if the node is a partitioned, unfavorited dataset
+ * @param node
+ * @return true if a partitioned and unfavorited dataset, false otherwise
+ */
+export function isPdsNotFav(node: TreeItem): boolean {
+    return new RegExp("^(?!.*" + globals.FAV_SUFFIX + ")" + globals.DS_PDS_CONTEXT).test(node.contextValue);
+}
+
+/**
  * Helper function which identifies if the node is a partitioned dataset
  * @param node
  * @return true if a partitioned dataset, false otherwise
  */
-export function isPdsNotFav(node: TreeItem): boolean {
-    return new RegExp("^(?!.*" + globals.FAV_SUFFIX + ")" + globals.DS_PDS_CONTEXT).test(node.contextValue);
+export function isPds(node: TreeItem): boolean {
+    return new RegExp("^(" + globals.DS_PDS_CONTEXT + ")").test(node.contextValue);
 }
 
 /**

--- a/packages/zowe-explorer/src/shared/context.ts
+++ b/packages/zowe-explorer/src/shared/context.ts
@@ -245,15 +245,6 @@ export function isPds(node: TreeItem): boolean {
 }
 
 /**
- * Helper function which identifies if the node is a partitioned dataset
- * @param node
- * @return true if a partitioned dataset, false otherwise
- */
-export function isPds(node: TreeItem): boolean {
-    return new RegExp("^(" + globals.DS_PDS_CONTEXT + ")").test(node.contextValue);
-}
-
-/**
  * Helper function which identifies if the node is a USS Directory
  * @param node
  * @return true if a USS Directory, false otherwise

--- a/packages/zowe-explorer/src/uss/USSTree.ts
+++ b/packages/zowe-explorer/src/uss/USSTree.ts
@@ -244,6 +244,14 @@ export class USSTree extends ZoweTreeProvider implements IZoweTree<IZoweUSSTreeN
     }
 
     /**
+     * Finds the equivalent node based on whether the passed node is a favorite.
+     * @param node
+     */
+    public findEquivalentNode(node: IZoweUSSTreeNode, isFavorite: boolean): IZoweUSSTreeNode {
+        return isFavorite ? this.findNonFavoritedNode(node) : this.findFavoritedNode(node);
+    }
+
+    /**
      * This function is for renaming the non-favorited equivalent of a favorited node for a given profile.
      * @param profileLabel
      * @param oldNamePath


### PR DESCRIPTION
## Proposed changes

- Sync tree nodes in favorites list with their actual state under "Data Sets" panel

## Release Notes

Milestone: 2.5.0

Changelog: Fixed issue where Favorites section was not refreshing after changes were made to data sets or their members.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [x] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found

## Further comments

- **Future Proposal:** Change method of storing favorites such that the nodes can be mapped 1:1; this should shorten lookup time for corresponding nodes and make logic more straightforward for adding/removing favorites. Since we are searching based on labels, we could assign the node labels as keys for a map-based structure.
- **For next standup:** The `findFavoritedNode` and `findNonFavoritedNode` functions are marked deprecated, but they're being used in the codebase. Reimplement (as suggested above) or keep the same data structure? 