### PR TITLE
Fix: Added missing localization for strings in info/warning/error messages

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the "vscode-extension-for-zowe" extension will be documented in this file.
 
+## TBD Release
+
+### Bug fixes
+
+- Fixed missing localization for certain VScode error/info/warning messages. [#1722](https://github.com/zowe/vscode-extension-for-zowe/issues/1722)
+
 ## `2.4.1`
 
 ### Bug fixes

--- a/packages/zowe-explorer/i18n/sample/src/Profiles.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/Profiles.i18n.json
@@ -30,6 +30,7 @@
   "createNewConnection.booleanValue": "Operation Cancelled",
   "createNewConnection.default": "Operation Cancelled",
   "createNewConnection.duplicateProfileName": "Profile name already exists. Please create a profile using a different name",
+  "createProfile.success.info": "Profile {0} was created.",
   "createNewConnection.option.prompt.username.placeholder": "User Name",
   "createNewConnection.option.prompt.username": "Enter the user name for the connection. Leave blank to not store.",
   "createNewConnection.option.prompt.password.placeholder": "Password",

--- a/packages/zowe-explorer/i18n/sample/src/shared/utils.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/shared/utils.i18n.json
@@ -5,5 +5,6 @@
   "saveFile.error.theiaDetected": "A merge conflict has been detected. Since you are running inside Theia editor, a merge conflict resolution is not available yet.",
   "saveFile.info.confirmUpload": "Would you like to overwrite the remote file?",
   "saveFile.overwriteConfirmation.yes": "Yes",
-  "saveFile.overwriteConfirmation.no": "No"
+  "saveFile.overwriteConfirmation.no": "No",
+  "uploadContent.cancelled": "Upload cancelled."
 }

--- a/packages/zowe-explorer/i18n/sample/src/utils/ProfilesUtils.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/utils/ProfilesUtils.i18n.json
@@ -1,9 +1,10 @@
 {
   "errorHandling.invalid.credentials": "Invalid Credentials. Please ensure the username and password for {0} are valid or this may lead to a lock-out.",
   "errorHandling.invalid.token": "Your connection is no longer active. Please log in to an authentication service to restore the connection.",
-  "ErrorHandling.authentication.login": "Log in to Authentication Service",
-  "ErrorHandling.checkCredentials.button": "Check Credentials",
-  "ErrorHandling.checkCredentials.cancelled": "Operation Cancelled",
+  "errorHandling.invalid.host": "Required parameter 'host' must not be blank.",
+  "errorHandling.authentication.login": "Log in to Authentication Service",
+  "errorHandling.checkCredentials.button": "Check Credentials",
+  "errorHandling.checkCredentials.cancelled": "Operation Cancelled",
   "getProfile.notTreeItem": "Tree Item is not a Zowe Explorer item.",
   "zowe.promptCredentials.notSupported": "\"Update Credentials\" operation not supported when \"autoStore\" is false",
   "createNewConnection.option.prompt.profileName.placeholder": "Connection Name",

--- a/packages/zowe-explorer/src/Profiles.ts
+++ b/packages/zowe-explorer/src/Profiles.ts
@@ -917,7 +917,9 @@ export class Profiles extends ProfilesCache {
                 }
             }
             await this.saveProfile(schemaValues, schemaValues.name, profileType);
-            vscode.window.showInformationMessage("Profile " + newProfileName + " was created.");
+            vscode.window.showInformationMessage(
+                localize("createProfile.success.info", "Profile {0} was created.", newProfileName)
+            );
             // Trigger a ProfilesCache.createConfigInstance with a fresh Config.load
             // This shall capture any profiles created (v1 or v2)
             await readConfigFromDisk();

--- a/packages/zowe-explorer/src/shared/utils.ts
+++ b/packages/zowe-explorer/src/shared/utils.ts
@@ -299,7 +299,7 @@ export async function willForceUpload(
                     }
                 });
             } else {
-                vscode.window.showInformationMessage("Upload cancelled.");
+                vscode.window.showInformationMessage(localize("uploadContent.cancelled", "Upload cancelled."));
                 await markFileAsDirty(doc);
             }
         });

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -53,7 +53,9 @@ export async function errorHandling(errorDetails: any, label?: string, moreInfo?
         if (msg.includes("hostname")) {
             const mProfileInfo = await Profiles.getInstance().getProfileInfo();
             if (mProfileInfo.usingTeamConfig) {
-                vscode.window.showErrorMessage("Required parameter 'host' must not be blank");
+                vscode.window.showErrorMessage(
+                    localize("errorHandling.invalid.host", "Required parameter 'host' must not be blank.")
+                );
                 const profAllAttrs = mProfileInfo.getAllProfiles();
                 for (const prof of profAllAttrs) {
                     if (prof.profName === label.trim()) {
@@ -82,7 +84,7 @@ export async function errorHandling(errorDetails: any, label?: string, moreInfo?
                         });
                     } else {
                         const message = localize(
-                            "ErrorHandling.authentication.login",
+                            "errorHandling.authentication.login",
                             "Log in to Authentication Service"
                         );
                         vscode.window.showErrorMessage(errToken, message).then(async (selection) => {
@@ -98,7 +100,7 @@ export async function errorHandling(errorDetails: any, label?: string, moreInfo?
             if (isTheia()) {
                 vscode.window.showErrorMessage(errMsg);
             } else {
-                const checkCredsButton = localize("ErrorHandling.checkCredentials.button", "Check Credentials");
+                const checkCredsButton = localize("errorHandling.checkCredentials.button", "Check Credentials");
                 await vscode.window
                     .showErrorMessage(errMsg, { modal: true }, ...[checkCredsButton])
                     .then(async (selection) => {
@@ -106,7 +108,7 @@ export async function errorHandling(errorDetails: any, label?: string, moreInfo?
                             await Profiles.getInstance().promptCredentials(label.trim(), true);
                         } else {
                             vscode.window.showInformationMessage(
-                                localize("ErrorHandling.checkCredentials.cancelled", "Operation Cancelled")
+                                localize("errorHandling.checkCredentials.cancelled", "Operation Cancelled")
                             );
                         }
                     });


### PR DESCRIPTION
## Proposed changes

Added localization that was missing for certain strings in VScode error/info/warning messages.
_Note:_ I searched for missing localization using the regular expression `window.show(Information|Error|Warning)Message\("`, so all of the `window.show*` calls should now be localized.

## Release Notes

Milestone: 2.5.0

Changelog: Fixed (added) localization that was missing for certain strings in VScode error/info/warning messages.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found