### PR TITLE
Fix: Parent node auto-closes after single/multiple job deletion

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed "Allocate Like" error that prevented proper execution. [#1973](https://github.com/zowe/vscode-extension-for-zowe/issues/1973)
 - Fixed de-sync issue between Data Set and Favorites panels when adding or deleting datasets/members that were favorited. [#1488](https://github.com/zowe/vscode-extension-for-zowe/issues/1488)
 - Added logging in places where errors were being caught and ignored.
+- Fixed issue where parent in Jobs list closes after single/multiple job deletion. [#1676](https://github.com/zowe/vscode-extension-for-zowe/issues/1676)
 
 ## `2.4.1`
 

--- a/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
@@ -37,6 +37,7 @@ async function createGlobalMocks() {
         mockGetAllProfileNames: jest.fn(),
         mockReveal: jest.fn(),
         mockCreateTreeView: jest.fn(),
+        mockExecuteCommand: jest.fn(),
         mockRegisterCommand: jest.fn(),
         mockOnDidSaveTextDocument: jest.fn(),
         mockOnDidChangeSelection: jest.fn(),
@@ -244,6 +245,10 @@ async function createGlobalMocks() {
         value: globalMocks.mockRegisterCommand,
         configurable: true,
     });
+    Object.defineProperty(vscode.commands, "executeCommand", {
+        value: globalMocks.mockExecuteCommand,
+        configurable: true,
+    });
     Object.defineProperty(vscode.workspace, "onDidSaveTextDocument", {
         value: globalMocks.mockOnDidSaveTextDocument,
         configurable: true,
@@ -421,7 +426,8 @@ describe("Extension Unit Tests", () => {
         // Checking if commands are registered properly
         expect(globalMocks.mockRegisterCommand.mock.calls.length).toBe(globals.COMMAND_COUNT);
         globalMocks.mockRegisterCommand.mock.calls.forEach((call, i) => {
-            expect(globalMocks.mockRegisterCommand.mock.calls[i][1]).toBeInstanceOf(Function);
+            expect(call[0]).toStrictEqual(globalMocks.expectedCommands[i]);
+            expect(call[1]).toBeInstanceOf(Function);
         });
         const actualCommands = [];
         globalMocks.mockRegisterCommand.mock.calls.forEach((call) => {
@@ -474,7 +480,8 @@ describe("Extension Unit Tests", () => {
         expect(globalMocks.mockMkdirSync.mock.calls.length).toBe(6);
         expect(globalMocks.mockRegisterCommand.mock.calls.length).toBe(globals.COMMAND_COUNT);
         globalMocks.mockRegisterCommand.mock.calls.forEach((call, i) => {
-            expect(globalMocks.mockRegisterCommand.mock.calls[i][1]).toBeInstanceOf(Function);
+            expect(call[0]).toStrictEqual(globalMocks.expectedCommands[i]);
+            expect(call[1]).toBeInstanceOf(Function);
         });
         const actualCommands = [];
         globalMocks.mockRegisterCommand.mock.calls.forEach((call) => {

--- a/packages/zowe-explorer/__tests__/__unit__/job/ZosJobsProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/ZosJobsProvider.unit.test.ts
@@ -631,6 +631,36 @@ describe("ZosJobsProvider unit tests - Function removeFavProfile", () => {
     });
 });
 
+describe("ZosJobsProvider unit tests - Function delete", () => {
+    const createTestJob = async (globalMocks) => {
+        globalMocks.testJobsProvider.mFavorites = [];
+        const testJobNode = new Job(
+            "IEFBR14(JOB1234) - CC 0000",
+            vscode.TreeItemCollapsibleState.Collapsed,
+            globalMocks.testJobsProvider.mSessionNodes[1],
+            globalMocks.testJobsProvider.mSessionNodes[1].getSession(),
+            globalMocks.testIJob,
+            globalMocks.testProfile
+        );
+        return testJobNode;
+    };
+
+    it("Removes a job node from session parent and refreshes job provider", async () => {
+        const globalMocks = await createGlobalMocks();
+        const testJob = await createTestJob(globalMocks);
+
+        const deleteSpy = jest.spyOn(globalMocks.testJobsProvider, "delete");
+        const removeFavoriteSpy = jest.spyOn(globalMocks.testJobsProvider, "removeFavorite");
+        const refreshSpy = jest.spyOn(globalMocks.testJobsProvider, "refresh");
+
+        await globalMocks.testJobsProvider.delete(testJob);
+        expect(deleteSpy).toHaveBeenCalledWith(testJob);
+        expect(removeFavoriteSpy).toHaveBeenCalledWith(testJob);
+        expect(globalMocks.testJobsProvider.mSessionNodes[1]).not.toContain(testJob);
+        expect(refreshSpy).toHaveBeenCalled();
+    });
+});
+
 describe("ZosJobsProvider Unit Tests - Function findEquivalentNode()", () => {
     it("Testing that findEquivalentNode() returns the corresponding nodes", async () => {
         const globalMocks = await createGlobalMocks();

--- a/packages/zowe-explorer/__tests__/__unit__/job/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/actions.unit.test.ts
@@ -1048,6 +1048,7 @@ describe("job deletion command", () => {
         await jobActions.deleteCommand(jobsProvider, jobNode);
 
         expect(mocked(jobsProvider.delete)).toBeCalledWith(jobNode);
+        expect(jobsProvider.refreshElement).toHaveBeenCalledWith(null);
     });
 
     it("should delete multiple jobs from the jobs provider", async () => {
@@ -1103,5 +1104,6 @@ describe("job deletion command", () => {
 
         // assert
         expect(mocked(jobsProvider.delete)).toBeCalledWith(jobNode);
+        expect(jobsProvider.refreshElement).toHaveBeenCalledWith(null);
     });
 });

--- a/packages/zowe-explorer/__tests__/__unit__/job/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/actions.unit.test.ts
@@ -1048,7 +1048,6 @@ describe("job deletion command", () => {
         await jobActions.deleteCommand(jobsProvider, jobNode);
 
         expect(mocked(jobsProvider.delete)).toBeCalledWith(jobNode);
-        expect(jobsProvider.refreshElement).toHaveBeenCalledWith(null);
     });
 
     it("should delete multiple jobs from the jobs provider", async () => {
@@ -1104,6 +1103,5 @@ describe("job deletion command", () => {
 
         // assert
         expect(mocked(jobsProvider.delete)).toBeCalledWith(jobNode);
-        expect(jobsProvider.refreshElement).toHaveBeenCalledWith(null);
     });
 });

--- a/packages/zowe-explorer/i18n/sample/src/job/actions.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/job/actions.i18n.json
@@ -11,6 +11,6 @@
   "deleteJobPrompt.confirmation.delete": "Delete",
   "deleteJobPrompt.confirmation.cancel.log.debug": "Delete action was canceled.",
   "deleteJobPrompt.deleteCancelled": "Delete action was cancelled.",
-  "deleteCommand.job": "Job {0} deleted.",
+  "deleteCommand.job": "Job {0} was deleted.",
   "deleteCommand.multipleJobs": "The following jobs were deleted: {0}"
 }

--- a/packages/zowe-explorer/src/extension.ts
+++ b/packages/zowe-explorer/src/extension.ts
@@ -726,9 +726,9 @@ function initJobsProvider(context: vscode.ExtensionContext) {
         )
     );
     context.subscriptions.push(
-        vscode.commands.registerCommand("zowe.jobs.deleteJob", async (job, jobs) =>
-            jobActions.deleteCommand(jobsProvider, job, jobs)
-        )
+        vscode.commands.registerCommand("zowe.jobs.deleteJob", async (job, jobs) => {
+            await jobActions.deleteCommand(jobsProvider, job, jobs);
+        })
     );
     context.subscriptions.push(
         vscode.commands.registerCommand("zowe.jobs.runModifyCommand", (job) => jobActions.modifyCommand(job))

--- a/packages/zowe-explorer/src/job/ZosJobsProvider.ts
+++ b/packages/zowe-explorer/src/job/ZosJobsProvider.ts
@@ -272,6 +272,8 @@ export class ZosJobsProvider extends ZoweTreeProvider implements IZoweTree<IZowe
         try {
             await ZoweExplorerApiRegister.getJesApi(node.getProfile()).deleteJob(node.job.jobname, node.job.jobid);
             await this.removeFavorite(this.createJobsFavorite(node));
+            node.getSessionNode().children = node.getSessionNode().children.filter((n) => n !== node);
+            this.refresh();
         } catch (error) {
             await errorHandling(error, node.getProfileName(), error.message);
         }

--- a/packages/zowe-explorer/src/job/actions.ts
+++ b/packages/zowe-explorer/src/job/actions.ts
@@ -355,7 +355,7 @@ async function deleteSingleJob(job: IZoweJobTreeNode, jobsProvider: IZoweTree<IZ
         await errorHandling(error.toString(), job.getProfile().name, error.message.toString());
         return;
     }
-    await refreshAllJobs(jobsProvider);
+    jobsProvider.refreshElement(job.getParent());
     vscode.window.showInformationMessage(localize("deleteCommand.job", "Job {0} deleted.", jobName));
 }
 
@@ -395,11 +395,11 @@ async function deleteMultipleJobs(
             if (result instanceof Error) {
                 return undefined;
             }
+            jobsProvider.refreshElement(result.getParent());
             return result;
         })
         .filter((result) => result !== undefined);
     if (deletedJobs.length) {
-        await refreshAllJobs(jobsProvider);
         vscode.window.showInformationMessage(
             localize(
                 "deleteCommand.multipleJobs",

--- a/packages/zowe-explorer/src/job/actions.ts
+++ b/packages/zowe-explorer/src/job/actions.ts
@@ -349,14 +349,15 @@ async function deleteSingleJob(job: IZoweJobTreeNode, jobsProvider: IZoweTree<IZ
         );
         return;
     }
+
     try {
         await jobsProvider.delete(job);
     } catch (error) {
         await errorHandling(error.toString(), job.getProfile().name, error.message.toString());
         return;
     }
-    jobsProvider.refreshElement(job.getParent());
-    vscode.window.showInformationMessage(localize("deleteCommand.job", "Job {0} deleted.", jobName));
+
+    vscode.window.showInformationMessage(localize("deleteCommand.job", "Job {0} was deleted.", jobName));
 }
 
 async function deleteMultipleJobs(
@@ -395,7 +396,6 @@ async function deleteMultipleJobs(
             if (result instanceof Error) {
                 return undefined;
             }
-            jobsProvider.refreshElement(result.getParent());
             return result;
         })
         .filter((result) => result !== undefined);


### PR DESCRIPTION
## Proposed changes

- Fixes issue where the parent node (in job tree) automatically closes after 1+ job(s) are deleted from that parent node.

## Release Notes

Milestone: 2.5.0

Changelog: Fixed issue where parent job node closes after deleting 1+ job(s) belonging to that parent.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
