### PR TITLE
Fix: Clean-up ESLint errors

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -4,15 +4,16 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 ## TBD Release
 
+### Bug fixes
+
+- Added logging in places where errors were being caught and ignored.
+- Fixed all existing ESLint errors within the API logic.
+
 ### New features and enhancements
 
 - New API call `getJobsByParameters` to allow filtering jobs by status.
 - Added `findEquivalentNode` function to IZoweTree to find a corresponding favorited/non-favorited node.
 - Updated `IZoweTree`: changed `IZoweNodeType -> IZoweTreeNode` to prevent incompatibility w/ custom/future Zowe node types
-
-### Bug fixes
-
-- Added logging in places where errors were being caught and ignored.
 
 ## `2.4.1`
 

--- a/packages/zowe-explorer-api/src/logger/IZoweLogger.ts
+++ b/packages/zowe-explorer-api/src/logger/IZoweLogger.ts
@@ -13,6 +13,23 @@ import * as loggerConfig from "../log4jsconfig.json";
 import * as path from "path";
 import { imperative } from "@zowe/cli";
 
+type Appender = {
+    type: string;
+    layout: {
+        type: string;
+        pattern: string;
+    };
+    filename: string;
+};
+
+type Log4JsCfg = {
+    log4jsConfig: {
+        appenders: { [key: string]: Appender };
+    };
+};
+
+const LOGGER_CONFIG: Log4JsCfg = loggerConfig;
+
 export enum MessageSeverityEnum {
     TRACE = 0,
     DEBUG = 1,
@@ -37,9 +54,9 @@ export class IZoweLogger {
      */
     public constructor(extensionName: string, loggingPath: string) {
         for (const appenderName of Object.keys(loggerConfig.log4jsConfig.appenders)) {
-            loggerConfig.log4jsConfig.appenders[appenderName].filename = path.join(
+            LOGGER_CONFIG.log4jsConfig.appenders[appenderName].filename = path.join(
                 loggingPath,
-                loggerConfig.log4jsConfig.appenders[appenderName].filename
+                LOGGER_CONFIG.log4jsConfig.appenders[appenderName].filename
             );
         }
         imperative.Logger.initLogger(loggerConfig);

--- a/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
+++ b/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
@@ -199,7 +199,7 @@ export class ProfilesCache {
                 this.profilesForValidation.pop();
             }
         } catch (error) {
-            this.log.error(error);
+            this.log.error(error as string);
         }
     }
 
@@ -216,7 +216,7 @@ export class ProfilesCache {
         try {
             url = new URL(newUrl);
         } catch (error) {
-            this.log.debug(error);
+            this.log.debug(error as string);
             return validationResult;
         }
 
@@ -492,7 +492,7 @@ export class ProfilesCache {
                 this.profilesByType.set(type, allProfilesByType);
             } catch (error) {
                 // do nothing, skip if profile type is not included in config file
-                this.log.warn(error);
+                this.log.warn(error as string);
             }
         });
         this.allProfiles = [];

--- a/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
+++ b/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
@@ -353,7 +353,7 @@ export class ProfilesCache {
                     type,
                 });
             } catch (error) {
-                this.log.debug(error);
+                this.log.debug(error as string);
             }
             if (profileManager) {
                 this.profileManagerByType.set(type, profileManager);
@@ -392,7 +392,7 @@ export class ProfilesCache {
         try {
             return (await this.getProfileInfo()).isSecured();
         } catch (error) {
-            this.log.error(error);
+            this.log.error(error as string);
         }
     }
 
@@ -418,7 +418,7 @@ export class ProfilesCache {
                     (typeof value2 === "string" && value2.length > 0);
             }
         } catch (error) {
-            this.log.error(error);
+            this.log.error(error as string);
         }
         return imperativeIsSecure;
     }

--- a/packages/zowe-explorer-api/src/profiles/ZoweExplorerZosmfApi.ts
+++ b/packages/zowe-explorer-api/src/profiles/ZoweExplorerZosmfApi.ts
@@ -69,7 +69,7 @@ class ZosmfApiCommon implements ZoweExplorerApi.ICommon {
                 }
             } catch (error) {
                 // todo: initialize and use logging
-                zowe.imperative.Logger.getAppLogger().error(error);
+                zowe.imperative.Logger.getAppLogger().error(error as string);
             }
         }
         return this.session;

--- a/packages/zowe-explorer-api/src/profiles/ZoweExplorerZosmfApi.ts
+++ b/packages/zowe-explorer-api/src/profiles/ZoweExplorerZosmfApi.ts
@@ -43,12 +43,12 @@ class ZosmfApiCommon implements ZoweExplorerApi.ICommon {
                     const cmdArgs: zowe.imperative.ICommandArguments = {
                         $0: "zowe",
                         _: [""],
-                        host: serviceProfile.profile.host,
-                        port: serviceProfile.profile.port,
-                        basePath: serviceProfile.profile.basePath,
-                        rejectUnauthorized: serviceProfile.profile.rejectUnauthorized,
-                        user: serviceProfile.profile.user,
-                        password: serviceProfile.profile.password,
+                        host: serviceProfile.profile.host as string,
+                        port: serviceProfile.profile.port as number,
+                        basePath: serviceProfile.profile.basePath as string,
+                        rejectUnauthorized: serviceProfile.profile.rejectUnauthorized as boolean,
+                        user: serviceProfile.profile.user as string,
+                        password: serviceProfile.profile.password as string,
                     };
 
                     this.session = this.getSessionFromCommandArgument(cmdArgs);
@@ -57,12 +57,12 @@ class ZosmfApiCommon implements ZoweExplorerApi.ICommon {
                     const cmdArgs: zowe.imperative.ICommandArguments = {
                         $0: "zowe",
                         _: [""],
-                        host: serviceProfile.profile.host,
-                        port: serviceProfile.profile.port,
-                        basePath: serviceProfile.profile.basePath,
-                        rejectUnauthorized: serviceProfile.profile.rejectUnauthorized,
-                        tokenType: serviceProfile.profile.tokenType,
-                        tokenValue: serviceProfile.profile.tokenValue,
+                        host: serviceProfile.profile.host as string,
+                        port: serviceProfile.profile.port as number,
+                        basePath: serviceProfile.profile.basePath as string,
+                        rejectUnauthorized: serviceProfile.profile.rejectUnauthorized as boolean,
+                        tokenType: serviceProfile.profile.tokenType as string,
+                        tokenValue: serviceProfile.profile.tokenValue as string,
                     };
 
                     this.session = this.getSessionFromCommandArgument(cmdArgs);
@@ -84,12 +84,12 @@ class ZosmfApiCommon implements ZoweExplorerApi.ICommon {
                 const cmdArgs: zowe.imperative.ICommandArguments = {
                     $0: "zowe",
                     _: [""],
-                    host: serviceProfile.profile.host,
-                    port: serviceProfile.profile.port,
-                    basePath: serviceProfile.profile.basePath,
-                    rejectUnauthorized: serviceProfile.profile.rejectUnauthorized,
-                    tokenType: serviceProfile.profile.tokenType,
-                    tokenValue: serviceProfile.profile.tokenValue,
+                    host: serviceProfile.profile.host as string,
+                    port: serviceProfile.profile.port as number,
+                    basePath: serviceProfile.profile.basePath as string,
+                    rejectUnauthorized: serviceProfile.profile.rejectUnauthorized as boolean,
+                    tokenType: serviceProfile.profile.tokenType as string,
+                    tokenValue: serviceProfile.profile.tokenValue as string,
                 };
 
                 validateSession = this.getSessionFromCommandArgument(cmdArgs);
@@ -98,12 +98,12 @@ class ZosmfApiCommon implements ZoweExplorerApi.ICommon {
                 const cmdArgs: zowe.imperative.ICommandArguments = {
                     $0: "zowe",
                     _: [""],
-                    host: serviceProfile.profile.host,
-                    port: serviceProfile.profile.port,
-                    basePath: serviceProfile.profile.basePath,
-                    rejectUnauthorized: serviceProfile.profile.rejectUnauthorized,
-                    user: serviceProfile.profile.user,
-                    password: serviceProfile.profile.password,
+                    host: serviceProfile.profile.host as string,
+                    port: serviceProfile.profile.port as number,
+                    basePath: serviceProfile.profile.basePath as string,
+                    rejectUnauthorized: serviceProfile.profile.rejectUnauthorized as boolean,
+                    user: serviceProfile.profile.user as string,
+                    password: serviceProfile.profile.password as string,
                 };
 
                 validateSession = this.getSessionFromCommandArgument(cmdArgs);

--- a/packages/zowe-explorer-api/src/security/KeytarCredentialManager.ts
+++ b/packages/zowe-explorer-api/src/security/KeytarCredentialManager.ts
@@ -89,7 +89,7 @@ export class KeytarCredentialManager extends imperative.AbstractCredentialManage
             imperativeIsSecure =
                 (typeof value1 === "string" && value1.length > 0) || (typeof value2 === "string" && value2.length > 0);
         } catch (error) {
-            imperative.Logger.getAppLogger().warn(error);
+            imperative.Logger.getAppLogger().warn(error as string);
             return undefined;
         }
         return imperativeIsSecure ? getSecurityModules(moduleName, isTheia) : undefined;
@@ -223,13 +223,13 @@ export function getSecurityModules(moduleName: string, isTheia: boolean): NodeMo
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return r(`${appRoot}/node_modules/${moduleName}`);
     } catch (err) {
-        imperative.Logger.getAppLogger().warn(err);
+        imperative.Logger.getAppLogger().warn(err as string);
     }
     try {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return r(`${appRoot}/node_modules.asar/${moduleName}`);
     } catch (err) {
-        imperative.Logger.getAppLogger().warn(err);
+        imperative.Logger.getAppLogger().warn(err as string);
     }
     return undefined;
 }

--- a/packages/zowe-explorer-api/src/tree/IZoweTree.ts
+++ b/packages/zowe-explorer-api/src/tree/IZoweTree.ts
@@ -159,7 +159,7 @@ export interface IZoweTree<T> extends vscode.TreeDataProvider<T> {
 
     refreshPS(node: IZoweTreeNode);
 
-    uploadDialog(node: IZoweTreeNode): any;
+    uploadDialog(node: IZoweTreeNode);
 
     /**
      * Begins a filter/search operation on a node.
@@ -185,7 +185,7 @@ export interface IZoweTree<T> extends vscode.TreeDataProvider<T> {
      * Deletes a root node from the tree.
      * @param node: A root node representing a session
      */
-    deleteSession(node: IZoweTreeNode): any;
+    deleteSession(node: IZoweTreeNode);
     /**
      * Lets the user open a dataset by filtering the currently-loaded list
      */

--- a/packages/zowe-explorer-api/src/vscode/ZoweVsCodeExtension.ts
+++ b/packages/zowe-explorer-api/src/vscode/ZoweVsCodeExtension.ts
@@ -52,20 +52,14 @@ export class ZoweVsCodeExtension {
     public static showVsCodeMessage(message: string, severity: MessageSeverityEnum, logger: IZoweLogger): void {
         logger.logImperativeMessage(message, severity);
 
-        let errorMessage;
-        switch (true) {
-            case severity < 3:
-                errorMessage = `${logger.getExtensionName()}: ${message}`;
-                void vscode.window.showInformationMessage(errorMessage);
-                break;
-            case severity === 3:
-                errorMessage = `${logger.getExtensionName()}: ${message}`;
-                void vscode.window.showWarningMessage(errorMessage);
-                break;
-            case severity > 3:
-                errorMessage = `${logger.getExtensionName()}: ${message}`;
-                void vscode.window.showErrorMessage(errorMessage);
-                break;
+        const errorMessage = `${logger.getExtensionName()}: ${message}`;
+
+        if (severity < 3) {
+            void vscode.window.showInformationMessage(errorMessage);
+        } else if (severity === 3) {
+            void vscode.window.showWarningMessage(errorMessage);
+        } else {
+            void vscode.window.showErrorMessage(errorMessage);
         }
     }
 

--- a/packages/zowe-explorer-ftp-extension/CHANGELOG.md
+++ b/packages/zowe-explorer-ftp-extension/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 ### Bug fixes
 
 - Added logging in places where errors were being caught and ignored.
+- Fixed all existing ESLint errors within the API logic.
 
 ## `2.4.1`
 

--- a/packages/zowe-explorer-ftp-extension/__mocks__/vscode.ts
+++ b/packages/zowe-explorer-ftp-extension/__mocks__/vscode.ts
@@ -18,14 +18,17 @@ export namespace window {
      * @param items A set of items that will be rendered as actions in the message.
      * @return A thenable that resolves to the selected item or `undefined` when being dismissed.
      */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     export function showInformationMessage(message: string, ...items: string[]): undefined {
         return undefined;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     export function showErrorMessage(message: string, ...items: string[]): undefined {
         return undefined;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     export function setStatusBarMessage(message: string, ...items: string[]): undefined {
         return undefined;
     }

--- a/packages/zowe-explorer-ftp-extension/src/ZoweExplorerAbstractFtpApi.ts
+++ b/packages/zowe-explorer-ftp-extension/src/ZoweExplorerAbstractFtpApi.ts
@@ -16,6 +16,10 @@ import { MessageSeverityEnum, ZoweExplorerApi, ZoweVsCodeExtension } from "@zowe
 import { sessionMap, ZoweLogger } from "./extension";
 import { FtpSession } from "./ftpSession";
 
+export interface ConnectionType {
+    close(): void;
+}
+
 export abstract class AbstractFtpApi implements ZoweExplorerApi.ICommon {
     private session?: FtpSession;
 
@@ -66,13 +70,13 @@ export abstract class AbstractFtpApi implements ZoweExplorerApi.ICommon {
         return this.profile;
     }
 
-    public async ftpClient(profile: imperative.IProfileLoaded): Promise<any> {
+    public async ftpClient(profile: imperative.IProfileLoaded): Promise<unknown> {
         const ftpProfile = profile.profile as IZosFTPProfile;
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return await FTPConfig.connectFromArguments(ftpProfile);
     }
 
-    public releaseConnection(connection: any): void {
+    public releaseConnection<T extends ConnectionType>(connection: T): void {
         if (connection != null) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
             connection.close();
@@ -80,7 +84,8 @@ export abstract class AbstractFtpApi implements ZoweExplorerApi.ICommon {
         }
     }
 
-    public logout(session: any): Promise<void> {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    public logout(session): Promise<void> {
         const ftpsession = sessionMap.get(this.profile);
         if (ftpsession !== undefined) {
             ftpsession.releaseConnections();
@@ -108,7 +113,7 @@ export abstract class AbstractFtpApi implements ZoweExplorerApi.ICommon {
                     throw new Error();
                 } else {
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                    ZoweVsCodeExtension.showVsCodeMessage(e.message, MessageSeverityEnum.ERROR, ZoweLogger);
+                    ZoweVsCodeExtension.showVsCodeMessage(e.message as string, MessageSeverityEnum.ERROR, ZoweLogger);
                     throw new Error();
                 }
             }

--- a/packages/zowe-explorer-ftp-extension/src/ZoweExplorerFtpJesApi.ts
+++ b/packages/zowe-explorer-ftp-extension/src/ZoweExplorerFtpJesApi.ts
@@ -14,11 +14,22 @@ import { MessageSeverityEnum, ZoweExplorerApi, ZoweVsCodeExtension } from "@zowe
 import { JobUtils, DataSetUtils, TRANSFER_TYPE_ASCII } from "@zowe/zos-ftp-for-zowe-cli";
 import { DownloadJobs, IJobFile } from "@zowe/cli";
 import { IJob, IJobStatus, ISpoolFile } from "@zowe/zos-ftp-for-zowe-cli/lib/api/JobInterface";
-import { AbstractFtpApi } from "./ZoweExplorerAbstractFtpApi";
+import { AbstractFtpApi, ConnectionType } from "./ZoweExplorerAbstractFtpApi";
 import { ZoweLogger } from "./extension";
 // The Zowe FTP CLI plugin is written and uses mostly JavaScript, so relax the rules here.
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
+interface IJobRefactor extends IJob {
+    jobId: string;
+    jobName: string;
+}
+
+interface ISpoolFileRefactor extends ISpoolFile {
+    stepName: string;
+    procStep: string;
+    ddName: string;
+}
 
 export class FtpJesApi extends AbstractFtpApi implements ZoweExplorerApi.IJes {
     public async getJobsByOwnerAndPrefix(owner: string, prefix: string): Promise<zowe.IJob[]> {
@@ -38,8 +49,8 @@ export class FtpJesApi extends AbstractFtpApi implements ZoweExplorerApi.IJes {
                     return {
                         ...result,
                         /* it’s prepared for the potential change in zftp api, renaming jobid to jobId, jobname to jobName. */
-                        jobid: (job as any).jobId || job.jobid,
-                        jobname: (job as any).jobName || job.jobname,
+                        jobid: (job as IJobRefactor).jobId || job.jobid,
+                        jobname: (job as IJobRefactor).jobName || job.jobname,
                         owner: job.owner,
                         class: job.class,
                         status: job.status,
@@ -53,7 +64,7 @@ export class FtpJesApi extends AbstractFtpApi implements ZoweExplorerApi.IJes {
 
     public async getJob(jobid: string): Promise<zowe.IJob> {
         const result = this.getIJobResponse();
-        let connection: any;
+        let connection;
         try {
             connection = await this.ftpClient(this.checkedProfile());
             if (connection) {
@@ -63,8 +74,8 @@ export class FtpJesApi extends AbstractFtpApi implements ZoweExplorerApi.IJes {
                     return {
                         ...result,
                         /* it’s prepared for the potential change in zftp api, renaming jobid to jobId, jobname to jobName. */
-                        jobid: (jobStatus as any).jobId || jobStatus.jobid,
-                        jobname: (jobStatus as any).jobName || jobStatus.jobname,
+                        jobid: (jobStatus as IJobRefactor).jobId || jobStatus.jobid,
+                        jobname: (jobStatus as IJobRefactor).jobName || jobStatus.jobname,
                         owner: jobStatus.owner,
                         class: jobStatus.class,
                         status: jobStatus.status,
@@ -79,7 +90,7 @@ export class FtpJesApi extends AbstractFtpApi implements ZoweExplorerApi.IJes {
 
     public async getSpoolFiles(jobname: string, jobid: string): Promise<zowe.IJobFile[]> {
         const result = this.getIJobFileResponse();
-        let connection: any;
+        let connection: unknown;
         try {
             connection = await this.ftpClient(this.checkedProfile());
             if (connection) {
@@ -94,26 +105,25 @@ export class FtpJesApi extends AbstractFtpApi implements ZoweExplorerApi.IJes {
                             jobname: jobname,
                             "byte-count": file.byteCount,
                             id: file.id,
-                            stepname: (file as any).stepName || file.stepname,
-                            procstep: (file as any).procStep || file.procstep,
+                            stepname: (file as ISpoolFileRefactor).stepName || file.stepname,
+                            procstep: (file as ISpoolFileRefactor).procStep || file.procstep,
                             class: file.class,
-                            ddname: (file as any).ddName || file.ddname,
+                            ddname: (file as ISpoolFileRefactor).ddName || file.ddname,
                         };
                     });
                 }
             }
             return [result];
         } finally {
-            this.releaseConnection(connection);
+            this.releaseConnection(connection as ConnectionType);
         }
     }
     public async downloadSpoolContent(parms: zowe.IDownloadAllSpoolContentParms): Promise<void> {
-        let connection: any;
+        let connection;
         try {
             connection = await this.ftpClient(this.checkedProfile());
             /* it's duplicate code with zftp. We may add new job API in the next zftp to cover spool file downloading. */
             if (connection) {
-                const destination = parms.outDir == null ? "./output/" : parms.outDir;
                 const jobDetails = await JobUtils.findJobByID(connection, parms.jobid);
                 if (jobDetails.spoolFiles == null || jobDetails.spoolFiles.length === 0) {
                     ZoweVsCodeExtension.showVsCodeMessage(
@@ -162,7 +172,7 @@ export class FtpJesApi extends AbstractFtpApi implements ZoweExplorerApi.IJes {
     }
 
     public async getSpoolContentById(jobname: string, jobid: string, spoolId: number): Promise<string> {
-        let connection: any;
+        let connection;
         try {
             connection = await this.ftpClient(this.checkedProfile());
             if (connection) {
@@ -184,6 +194,7 @@ export class FtpJesApi extends AbstractFtpApi implements ZoweExplorerApi.IJes {
         }
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public getJclForJob(job: zowe.IJob): Promise<string> {
         ZoweVsCodeExtension.showVsCodeMessage(
             "Get jcl is not supported in the FTP extension.",
@@ -193,6 +204,7 @@ export class FtpJesApi extends AbstractFtpApi implements ZoweExplorerApi.IJes {
         throw new Error();
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public submitJcl(jcl: string, internalReaderRecfm?: string, internalReaderLrecl?: string): Promise<zowe.IJob> {
         ZoweVsCodeExtension.showVsCodeMessage(
             "Submit jcl is not supported in the FTP extension.",
@@ -204,7 +216,7 @@ export class FtpJesApi extends AbstractFtpApi implements ZoweExplorerApi.IJes {
 
     public async submitJob(jobDataSet: string): Promise<zowe.IJob> {
         const result = this.getIJobResponse();
-        let connection: any;
+        let connection;
         try {
             connection = await this.ftpClient(this.checkedProfile());
             if (connection) {
@@ -224,7 +236,7 @@ export class FtpJesApi extends AbstractFtpApi implements ZoweExplorerApi.IJes {
         }
     }
     public async deleteJob(jobname: string, jobid: string): Promise<void> {
-        let connection: any;
+        let connection;
         try {
             connection = await this.ftpClient(this.checkedProfile());
             if (connection) {

--- a/packages/zowe-explorer-ftp-extension/src/ZoweExplorerFtpMvsApi.ts
+++ b/packages/zowe-explorer-ftp-extension/src/ZoweExplorerFtpMvsApi.ts
@@ -27,6 +27,7 @@ import { ZoweLogger } from "./extension";
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
 export class FtpMvsApi extends AbstractFtpApi implements ZoweExplorerApi.IMvs {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public async dataSet(filter: string, options?: zowe.IListOptions): Promise<zowe.IZosFilesResponse> {
         const result = this.getDefaultResponse();
         const session = this.getSession(this.profile);
@@ -34,7 +35,7 @@ export class FtpMvsApi extends AbstractFtpApi implements ZoweExplorerApi.IMvs {
             session.mvsListConnection = await this.ftpClient(this.checkedProfile());
         }
         if (session.mvsListConnection.connected === true) {
-            const response: any[] = await DataSetUtils.listDataSets(session.mvsListConnection, filter);
+            const response = await DataSetUtils.listDataSets(session.mvsListConnection, filter);
             if (response) {
                 result.success = true;
                 result.apiResponse.items = response.map((element) => ({
@@ -52,13 +53,14 @@ export class FtpMvsApi extends AbstractFtpApi implements ZoweExplorerApi.IMvs {
         return result;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public async allMembers(dataSetName: string, options?: zowe.IListOptions): Promise<zowe.IZosFilesResponse> {
         const result = this.getDefaultResponse();
-        let connection: any;
+        let connection;
         try {
             connection = await this.ftpClient(this.checkedProfile());
             if (connection) {
-                const response: any[] = await DataSetUtils.listMembers(connection, dataSetName);
+                const response = await DataSetUtils.listMembers(connection, dataSetName);
                 if (response) {
                     result.success = true;
                     result.apiResponse.items = response.map((element) => ({
@@ -83,7 +85,7 @@ export class FtpMvsApi extends AbstractFtpApi implements ZoweExplorerApi.IMvs {
             localFile: targetFile,
             encoding: options.encoding,
         };
-        let connection: any;
+        let connection;
         try {
             connection = await this.ftpClient(this.checkedProfile());
             if (connection && targetFile) {
@@ -131,7 +133,7 @@ export class FtpMvsApi extends AbstractFtpApi implements ZoweExplorerApi.IMvs {
             targetDataset = dataSetName + "(" + member + ")";
         }
         const result = this.getDefaultResponse();
-        let connection: any;
+        let connection;
         try {
             connection = await this.ftpClient(this.checkedProfile());
             if (!connection) {
@@ -224,7 +226,7 @@ export class FtpMvsApi extends AbstractFtpApi implements ZoweExplorerApi.IMvs {
         const allocateOptions = {
             dcb: dcb,
         };
-        let connection: any;
+        let connection;
         try {
             connection = await this.ftpClient(this.checkedProfile());
             if (connection) {
@@ -248,7 +250,7 @@ export class FtpMvsApi extends AbstractFtpApi implements ZoweExplorerApi.IMvs {
             encoding: options.encoding,
         };
         const result = this.getDefaultResponse();
-        let connection: any;
+        let connection;
         try {
             connection = await this.ftpClient(this.checkedProfile());
             if (!connection) {
@@ -265,6 +267,7 @@ export class FtpMvsApi extends AbstractFtpApi implements ZoweExplorerApi.IMvs {
         }
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public allocateLikeDataSet(dataSetName: string, likeDataSetName: string): Promise<zowe.IZosFilesResponse> {
         ZoweVsCodeExtension.showVsCodeMessage(
             "Allocate like dataset is not supported in ftp extension.",
@@ -275,8 +278,11 @@ export class FtpMvsApi extends AbstractFtpApi implements ZoweExplorerApi.IMvs {
     }
 
     public copyDataSetMember(
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         { dsn: fromDataSetName, member: fromMemberName }: zowe.IDataSet,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         { dsn: toDataSetName, member: toMemberName }: zowe.IDataSet,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         options?: { replace?: boolean }
     ): Promise<zowe.IZosFilesResponse> {
         ZoweVsCodeExtension.showVsCodeMessage(
@@ -289,7 +295,7 @@ export class FtpMvsApi extends AbstractFtpApi implements ZoweExplorerApi.IMvs {
 
     public async renameDataSet(currentDataSetName: string, newDataSetName: string): Promise<zowe.IZosFilesResponse> {
         const result = this.getDefaultResponse();
-        let connection: any;
+        let connection;
         try {
             connection = await this.ftpClient(this.checkedProfile());
             if (connection) {
@@ -314,7 +320,7 @@ export class FtpMvsApi extends AbstractFtpApi implements ZoweExplorerApi.IMvs {
         const result = this.getDefaultResponse();
         const currentName = dataSetName + "(" + currentMemberName + ")";
         const newName = dataSetName + "(" + newMemberName + ")";
-        let connection: any;
+        let connection;
         try {
             connection = await this.ftpClient(this.checkedProfile());
             if (connection) {
@@ -331,6 +337,7 @@ export class FtpMvsApi extends AbstractFtpApi implements ZoweExplorerApi.IMvs {
         }
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public hMigrateDataSet(dataSetName: string): Promise<zowe.IZosFilesResponse> {
         ZoweVsCodeExtension.showVsCodeMessage(
             "Migrate dataset is not supported in ftp extension.",
@@ -340,6 +347,7 @@ export class FtpMvsApi extends AbstractFtpApi implements ZoweExplorerApi.IMvs {
         throw new Error();
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public hRecallDataSet(dataSetName: string): Promise<zowe.IZosFilesResponse> {
         ZoweVsCodeExtension.showVsCodeMessage(
             "Recall dataset is not supported in ftp extension.",
@@ -350,10 +358,11 @@ export class FtpMvsApi extends AbstractFtpApi implements ZoweExplorerApi.IMvs {
     }
     public async deleteDataSet(
         dataSetName: string,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         options?: zowe.IDeleteDatasetOptions
     ): Promise<zowe.IZosFilesResponse> {
         const result = this.getDefaultResponse();
-        let connection: any;
+        let connection;
         try {
             connection = await this.ftpClient(this.checkedProfile());
             if (connection) {

--- a/packages/zowe-explorer-ftp-extension/src/ZoweExplorerFtpUssApi.ts
+++ b/packages/zowe-explorer-ftp-extension/src/ZoweExplorerFtpUssApi.ts
@@ -35,7 +35,7 @@ export class FtpUssApi extends AbstractFtpApi implements ZoweExplorerApi.IUss {
         }
 
         if (session.ussListConnection.connected === true) {
-            const response: any[] = await UssUtils.listFiles(session.ussListConnection, ussFilePath);
+            const response = await UssUtils.listFiles(session.ussListConnection, ussFilePath);
             if (response) {
                 result.success = true;
                 result.apiResponse.items = response.map((element) => ({
@@ -62,7 +62,7 @@ export class FtpUssApi extends AbstractFtpApi implements ZoweExplorerApi.IUss {
             localFile: targetFile,
             size: 1,
         };
-        let connection: any;
+        let connection;
         try {
             connection = await this.ftpClient(this.checkedProfile());
             if (connection && targetFile) {
@@ -94,7 +94,7 @@ export class FtpUssApi extends AbstractFtpApi implements ZoweExplorerApi.IUss {
             localFile: inputFilePath,
         };
         const result = this.getDefaultResponse();
-        let connection: any;
+        let connection;
         try {
             connection = await this.ftpClient(this.checkedProfile());
             if (!connection) {
@@ -162,7 +162,7 @@ export class FtpUssApi extends AbstractFtpApi implements ZoweExplorerApi.IUss {
         mode?: string
     ): Promise<zowe.IZosFilesResponse> {
         const result = this.getDefaultResponse();
-        let connection: any;
+        let connection;
         try {
             connection = await this.ftpClient(this.checkedProfile());
             if (connection) {
@@ -190,7 +190,7 @@ export class FtpUssApi extends AbstractFtpApi implements ZoweExplorerApi.IUss {
 
     public async delete(ussPath: string, recursive?: boolean): Promise<zowe.IZosFilesResponse> {
         const result = this.getDefaultResponse();
-        let connection: any;
+        let connection;
         try {
             connection = await this.ftpClient(this.checkedProfile());
             if (connection) {
@@ -213,7 +213,7 @@ export class FtpUssApi extends AbstractFtpApi implements ZoweExplorerApi.IUss {
 
     public async rename(currentUssPath: string, newUssPath: string): Promise<zowe.IZosFilesResponse> {
         const result = this.getDefaultResponse();
-        let connection: any;
+        let connection;
         try {
             connection = await this.ftpClient(this.checkedProfile());
             if (connection) {
@@ -230,15 +230,13 @@ export class FtpUssApi extends AbstractFtpApi implements ZoweExplorerApi.IUss {
         }
     }
 
-    private async deleteDirectory(ussPath: string, connection: any): Promise<any> {
+    private async deleteDirectory(ussPath: string, connection): Promise<void> {
         const result = this.getDefaultResponse();
         try {
             connection = await this.ftpClient(this.checkedProfile());
-            const response: any = await UssUtils.deleteDirectory(connection, ussPath);
-            if (response) {
-                result.success = true;
-                result.commandResponse = "Delete Completed";
-            }
+            await UssUtils.deleteDirectory(connection, ussPath);
+            result.success = true;
+            result.commandResponse = "Delete Completed";
         } finally {
             this.releaseConnection(connection);
         }

--- a/packages/zowe-explorer-ftp-extension/src/extension.ts
+++ b/packages/zowe-explorer-ftp-extension/src/extension.ts
@@ -26,6 +26,7 @@ export function activate(context: vscode.ExtensionContext): void {
     void registerFtpApis();
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function deactivate(context: vscode.ExtensionContext): void {
     sessionMap.forEach((session) => session.releaseConnections());
     sessionMap.clear();

--- a/packages/zowe-explorer-ftp-extension/src/ftpSession.ts
+++ b/packages/zowe-explorer-ftp-extension/src/ftpSession.ts
@@ -11,9 +11,9 @@
 
 import { imperative } from "@zowe/cli";
 export class FtpSession extends imperative.Session {
-    public ussListConnection: any;
-    public mvsListConnection: any;
-    public jesListConnection: any;
+    public ussListConnection;
+    public mvsListConnection;
+    public jesListConnection;
     public constructor(newSession: imperative.ISession) {
         super(newSession);
     }


### PR DESCRIPTION
Signed-off-by: Trae Yelovich <trae.yelovich@broadcom.com>

## Proposed changes

- All ESLint errors in `zowe-explorer-api` are now fixed
- Significantly reduced ESLint errors in `zowe-explorer-ftp-extension`

## Release Notes

Milestone:

Changelog:

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found

## Further comments

- Reduced amount of warnings down to 4; those warnings require a refactor of other packages (namely `zowe-cli-ftp-plugin`) to be merged before the warnings can be properly fixed.