### PR TITLE
Fix errorHandling utility method throwing an error

### DIFF
--- a/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
@@ -3169,7 +3169,7 @@ describe("Dataset Actions Unit Tests - Function openPS", () => {
         }
 
         expect(showErrorMessageSpy).toBeCalledWith("openPS() called from invalid node.");
-        expect(logErrorSpy).toBeCalledTimes(4);
+        expect(logErrorSpy).toBeCalledTimes(2);
     });
 });
 

--- a/packages/zowe-explorer/__tests__/__unit__/utils/ProfileUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/ProfileUtils.unit.test.ts
@@ -11,7 +11,8 @@
 
 import * as fs from "fs";
 import * as path from "path";
-import { writeOverridesFile } from "../../../src/utils/ProfilesUtils";
+import { errorHandling, writeOverridesFile } from "../../../src/utils/ProfilesUtils";
+import * as globals from "../../../src/globals";
 
 jest.mock("fs");
 
@@ -35,6 +36,8 @@ describe("ProfileUtils.writeOverridesFile Unit Tests", () => {
             },
             configurable: true,
         });
+        Object.defineProperty(globals, "LOG", { value: jest.fn(), configurable: true });
+        Object.defineProperty(globals.LOG, "error", { value: jest.fn(), configurable: true });
 
         return newMocks;
     }
@@ -74,5 +77,15 @@ describe("ProfileUtils.writeOverridesFile Unit Tests", () => {
         expect(spyRead).toBeCalledTimes(0);
         spy.mockClear();
         spyRead.mockClear();
+    });
+    it("should log error details", async () => {
+        createBlockMocks();
+        const errorDetails = new Error("i haz error");
+        const label = "test";
+        const moreInfo = "Task failed successfully";
+        await errorHandling(errorDetails, label, moreInfo);
+        expect(globals.LOG.error).toBeCalledWith(
+            `Error: ${errorDetails.message}\n` + JSON.stringify({ errorDetails, label, moreInfo })
+        );
     });
 });

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -19,7 +19,6 @@ import { getSecurityModules, IZoweTreeNode, ZoweTreeNode, getZoweDir, getFullPat
 import { Profiles } from "../Profiles";
 import * as nls from "vscode-nls";
 import { imperative, getImperativeConfig } from "@zowe/cli";
-import { UIViews } from "../shared/ui-views";
 
 // Set up localization
 nls.config({
@@ -45,7 +44,7 @@ export async function errorHandling(errorDetails: any, label?: string, moreInfo?
         "errorHandling.invalid.token",
         "Your connection is no longer active. Please log in to an authentication service to restore the connection."
     );
-    [errorDetails, errorDetails.mDetails, label, moreInfo].filter(Boolean).forEach(globals.LOG.error);
+    globals.LOG.error(`${errorDetails}\n` + JSON.stringify({ errorDetails, label, moreInfo }));
 
     if (errorDetails.mDetails !== undefined) {
         httpErrCode = errorDetails.mDetails.errorCode;


### PR DESCRIPTION
## Proposed changes

Fixes regression introduced in #2006, which failed to log errors causing the `errorHandling` method to throw an error and skip showing a message to the user.

## Release Notes

Milestone: 2.5.0

Changelog: n/a

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [ ] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [ ] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
