### PR TITLE
fix: "Show Attributes" feature should adjust colors dependent on VSCode theme

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
+- Fixed issue where "Show Attributes" feature used conflicting colors with light VS Code themes. [#2048](https://github.com/zowe/vscode-extension-for-zowe/issues/2048)
+
 ## `2.5.0`
 
 ### New features and enhancements

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -843,9 +843,11 @@ export async function showAttributes(
             (html, key) =>
                 html.concat(`
                 <tr>
-                    <td align="left" style="color: yellow; font-weight: bold">${key}:</td>
+                    <td align="left" style="color: var(--vscode-editorLink-activeForeground); font-weight: bold">${key}:</td>
                     <td align="right" style="color: ${
-                        typeof attributes[0][key] === "number" ? "dodgerblue" : "white"
+                        isNaN(attributes[0][key])
+                            ? "var(--vscode-settings-textInputForeground)"
+                            : "var(--vscode-problemsWarningIcon-foreground)"
                     }">${attributes[0][key]}</td>
                 </tr>
         `),


### PR DESCRIPTION
Signed-off-by: Trae Yelovich <trae.yelovich@broadcom.com>

## Proposed changes

Previously, the "Show Attributes" feature was using yellow and white as the default color scheme. However, with light themes the text for this feature is unreadable. This fix resolves the issue by falling back to VSCode's colors for the keys and values.

Thanks again to @anaxceron for discovering this issue, and my apologies for the implementation oversight.

**Before:**
![207953222-c79a3ab3-eb28-49bd-a6ea-9cbeba3aab1d](https://user-images.githubusercontent.com/86500639/207958540-9c088759-bfa5-4fac-bc24-5fd66fe0a238.png)

**After:**
| Light Theme | Dark Theme |
| ------ | ------ |
| ![image](https://user-images.githubusercontent.com/86500639/207967757-de34abe7-f682-4d9a-82f1-f29ce55ed96e.png) | ![image](https://user-images.githubusercontent.com/86500639/207967683-d92bfb40-6658-4ba7-b0fc-cfb4d18415d8.png) |


## Release Notes

Milestone: 2.6

Changelog: 
- Fixed issue where "Show Attributes" feature used conflicting colors with light VS Code themes. #2048

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [x] gif or screenshot is included if visual changes are made
- [ ] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
