### PR TITLE
Automatically detect team config files as jsonc

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "vscode": "^1.53.2"
   },
   "dependencies": {
-    "@zowe/cli": "7.9.0",
+    "@zowe/cli": "7.9.3",
     "vscode-nls": "4.1.2"
   },
   "devDependencies": {

--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 ### Bug fixes
 
+- Updated Imperative to fix failure to load schema when there is no profile of that type. [zowe/imperative#916](https://github.com/zowe/imperative/pull/916)
+
 ## `2.5.0`
 
 - Copy and Paste added to IZoweTree API for files and directories on USS tree.

--- a/packages/zowe-explorer-api/package.json
+++ b/packages/zowe-explorer-api/package.json
@@ -16,7 +16,7 @@
     "@types/semver": "^7.3.6"
   },
   "dependencies": {
-    "@zowe/cli": "7.9.0",
+    "@zowe/cli": "7.9.3",
     "semver": "^7.3.5"
   },
   "scripts": {

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### New features and enhancements
 
+- Added file association for `zowe.config.json` and `zowe.config.user.json` to automatically detect them as JSON with Comments. [#1997](https://github.com/zowe/vscode-extension-for-zowe/issues/1997)
+
 ### Bug fixes
 
 - Fixed issue where "Show Attributes" feature used conflicting colors with light VS Code themes. [#2048](https://github.com/zowe/vscode-extension-for-zowe/issues/2048)

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -1742,7 +1742,15 @@
           "scope": "window"
         }
       }
-    }
+    },
+    "languages": [
+      {
+        "id": "jsonc",
+        "filenamePatterns": [
+          "zowe.config*.json"
+        ]
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "yarn createTestProfileData && gulp build && yarn license && yarn lint && webpack --mode production && yarn updateStrings && yarn run compile-web",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2444,23 +2444,23 @@
   resolved "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-"@zowe/cli@7.9.0":
-  version "7.9.0"
-  resolved "https://registry.npmjs.org/@zowe/cli/-/cli-7.9.0.tgz#80ce7c12a964421c70149c94555f9d8700adc96f"
-  integrity sha512-bZZle5700QpvVn5smaAAtScUxvHmcPb0ANJSk9D0S/ctNet2EQDiD3wLU6gd7hwGD1XwbLjxGdqoTrRJK1JO4w==
+"@zowe/cli@7.9.3":
+  version "7.9.3"
+  resolved "https://registry.npmjs.org/@zowe/cli/-/cli-7.9.3.tgz#c13d232a88544c10b8cd31e13cca5d5db1915c05"
+  integrity sha512-NvbSNE4CClJLcx0wADtTs7YZ1P1o+UnJL24AmeTu6vttZ4THqR2Tur//HeANSqR7FH3BhIzDcX3ufhb8CHIGWw==
   dependencies:
-    "@zowe/core-for-zowe-sdk" "7.9.0"
-    "@zowe/imperative" "5.7.2"
+    "@zowe/core-for-zowe-sdk" "7.9.3"
+    "@zowe/imperative" "5.7.5"
     "@zowe/perf-timing" "1.0.7"
-    "@zowe/provisioning-for-zowe-sdk" "7.9.0"
-    "@zowe/zos-console-for-zowe-sdk" "7.9.0"
-    "@zowe/zos-files-for-zowe-sdk" "7.9.0"
-    "@zowe/zos-jobs-for-zowe-sdk" "7.9.0"
-    "@zowe/zos-logs-for-zowe-sdk" "7.9.0"
-    "@zowe/zos-tso-for-zowe-sdk" "7.9.0"
-    "@zowe/zos-uss-for-zowe-sdk" "7.9.0"
-    "@zowe/zos-workflows-for-zowe-sdk" "7.9.0"
-    "@zowe/zosmf-for-zowe-sdk" "7.9.0"
+    "@zowe/provisioning-for-zowe-sdk" "7.9.3"
+    "@zowe/zos-console-for-zowe-sdk" "7.9.3"
+    "@zowe/zos-files-for-zowe-sdk" "7.9.3"
+    "@zowe/zos-jobs-for-zowe-sdk" "7.9.3"
+    "@zowe/zos-logs-for-zowe-sdk" "7.9.3"
+    "@zowe/zos-tso-for-zowe-sdk" "7.9.3"
+    "@zowe/zos-uss-for-zowe-sdk" "7.9.3"
+    "@zowe/zos-workflows-for-zowe-sdk" "7.9.3"
+    "@zowe/zosmf-for-zowe-sdk" "7.9.3"
     find-process "1.4.7"
     get-stream "6.0.1"
     lodash "4.17.21"
@@ -2469,18 +2469,18 @@
   optionalDependencies:
     keytar "7.9.0"
 
-"@zowe/core-for-zowe-sdk@7.9.0":
-  version "7.9.0"
-  resolved "https://registry.npmjs.org/@zowe/core-for-zowe-sdk/-/core-for-zowe-sdk-7.9.0.tgz#44a80d5ec2d25d718cd3fe1b98e05500dec25c86"
-  integrity sha512-OvkNURLhAfxlyU+goqCQEGszoEKpDQi7aTi4aOXM2p9R/Lb24r48O5lURrIsKxajivyX9x8IWk1AnECr22SKWA==
+"@zowe/core-for-zowe-sdk@7.9.3":
+  version "7.9.3"
+  resolved "https://registry.npmjs.org/@zowe/core-for-zowe-sdk/-/core-for-zowe-sdk-7.9.3.tgz#6ec78ad16c638b86e0f05eae07d47914cb082996"
+  integrity sha512-zmxFbQXpoAJYW/nB84QRTTGt4xRC982bPzifeGG+WhkSa04mT18ollDVYk+fbf1ZDxOOrusbUiebGygDPXWY9Q==
   dependencies:
     comment-json "4.1.1"
     string-width "4.2.3"
 
-"@zowe/imperative@5.7.2":
-  version "5.7.2"
-  resolved "https://registry.npmjs.org/@zowe/imperative/-/imperative-5.7.2.tgz#b02cb0903c3acb85fe7a973aa426ce3054a71220"
-  integrity sha512-7cJ81KA08qdkAZbUGjjCliSetUXE9VFx3gCUrsLob+uyJTzuePVwvG4xoC+67TLrzaCLacMzmmG2tI2KshpdUw==
+"@zowe/imperative@5.7.5":
+  version "5.7.5"
+  resolved "https://registry.npmjs.org/@zowe/imperative/-/imperative-5.7.5.tgz#3f5fe3b3191ae75726ba90fce7fd2a6ebf566018"
+  integrity sha512-5ijI3o6bZ/SnU0pPTUNLEG5QiW0sNHQDLioZKqyaxe9+ghGBsTZ8rZ/4c9czBtEqSG0hRm7BcoEQ5zooCeJvIw==
   dependencies:
     "@types/yargs" "13.0.4"
     "@zowe/perf-timing" "1.0.7"
@@ -2528,22 +2528,22 @@
     fs-extra "8.1.0"
     pkg-up "2.0.0"
 
-"@zowe/provisioning-for-zowe-sdk@7.9.0":
-  version "7.9.0"
-  resolved "https://registry.npmjs.org/@zowe/provisioning-for-zowe-sdk/-/provisioning-for-zowe-sdk-7.9.0.tgz#e7e5e49a7ac90a30b3a8d049d030bda5083fe716"
-  integrity sha512-wtJlMRpmN45mARxL3CTK2zFCjbFsBJIQnVDIoYYOsJNESRTcwcHcREMHMxw6LGaWPanHfpgs/tL0QMjNQHYQuQ==
+"@zowe/provisioning-for-zowe-sdk@7.9.3":
+  version "7.9.3"
+  resolved "https://registry.npmjs.org/@zowe/provisioning-for-zowe-sdk/-/provisioning-for-zowe-sdk-7.9.3.tgz#1bd27b7f2519e2689709ca749830b6cbd294726e"
+  integrity sha512-E1liTvVl1ZBVy/clZ9dSmSOA3HziMDdY1Xp3xg44Ylrv8QhEAbYUkCUgOsP66uYWFyTSomcCmaO/2qp2LJnO5g==
   dependencies:
     js-yaml "4.1.0"
 
-"@zowe/zos-console-for-zowe-sdk@7.9.0":
-  version "7.9.0"
-  resolved "https://registry.npmjs.org/@zowe/zos-console-for-zowe-sdk/-/zos-console-for-zowe-sdk-7.9.0.tgz#02eb7ee34bb05951308804122f5722a4fbcbfdf8"
-  integrity sha512-usNOX1sqLS8rWKbRZyjWBdXgkOZ4l8BvwM9H5vi9ji0PwtFGDXWNZ+GCEDVpHcWZ+7USReP8EEiVrnTA3GZUoA==
+"@zowe/zos-console-for-zowe-sdk@7.9.3":
+  version "7.9.3"
+  resolved "https://registry.npmjs.org/@zowe/zos-console-for-zowe-sdk/-/zos-console-for-zowe-sdk-7.9.3.tgz#b5e816937b7d4f33711cb07571d0d7c7ebc93ea8"
+  integrity sha512-W+XmwBMXzxtmHV5cK9OEPoPT+iPr5tugxerJ85kycGhPBU8zKrinHbGrsjw/VGTH/6j6X8oTd+V5NKkIfzmceA==
 
-"@zowe/zos-files-for-zowe-sdk@7.9.0":
-  version "7.9.0"
-  resolved "https://registry.npmjs.org/@zowe/zos-files-for-zowe-sdk/-/zos-files-for-zowe-sdk-7.9.0.tgz#79e83a8d167d93be694cbe8050956d78cb41e314"
-  integrity sha512-DNAr+wj8xxfpEyt+j9H/zmpH1XZ1UuRXS5e8uAM0mLliQ3/ek+YmWks90hWsRx8e06rb/4Wh5fdGjNOKxfMhJQ==
+"@zowe/zos-files-for-zowe-sdk@7.9.3":
+  version "7.9.3"
+  resolved "https://registry.npmjs.org/@zowe/zos-files-for-zowe-sdk/-/zos-files-for-zowe-sdk-7.9.3.tgz#42ec1e67e29133962c3d59c288d61f586473c2ab"
+  integrity sha512-NpA7fJf4blRVIJV8P/9xjSJYsM1ijvvDyyR1eAExvhQfyQODsyTjp9Z5qS2A3tdgZNXVsw1VcObQ7mIj/WcwXg==
   dependencies:
     minimatch "5.0.1"
 
@@ -2554,43 +2554,43 @@
   dependencies:
     zos-node-accessor "1.0.12"
 
-"@zowe/zos-jobs-for-zowe-sdk@7.9.0":
-  version "7.9.0"
-  resolved "https://registry.npmjs.org/@zowe/zos-jobs-for-zowe-sdk/-/zos-jobs-for-zowe-sdk-7.9.0.tgz#64a41f31f2d1125bb8d2a27a968bfc392f8986ad"
-  integrity sha512-I5L02gxaRRS5Y8I+m1NZekr+w85nS2UkimYnHiV1WlCHBkWdh4IVu1ZJdm3XjhTOk88fNC16Jno1bw5JeMLQwQ==
+"@zowe/zos-jobs-for-zowe-sdk@7.9.3":
+  version "7.9.3"
+  resolved "https://registry.npmjs.org/@zowe/zos-jobs-for-zowe-sdk/-/zos-jobs-for-zowe-sdk-7.9.3.tgz#bfc33f0960bbf9f76156887d2ae2cad29c2141c9"
+  integrity sha512-pIh6qQaqH7bODYcEU3S/R+6HbYIRMARXnsZo0Epe4W9ylIdJL3AG5WQN82gzSCGdEjf4zQ2coGDgox2ZRbXAOA==
   dependencies:
-    "@zowe/zos-files-for-zowe-sdk" "7.9.0"
+    "@zowe/zos-files-for-zowe-sdk" "7.9.3"
 
-"@zowe/zos-logs-for-zowe-sdk@7.9.0":
-  version "7.9.0"
-  resolved "https://registry.npmjs.org/@zowe/zos-logs-for-zowe-sdk/-/zos-logs-for-zowe-sdk-7.9.0.tgz#886f62daf2bee4ff71e0c14fbec29ede21338006"
-  integrity sha512-yWjE+wWxE+63gayad8r2CFHd7tsEVgx+CUC7fB/Z7lNssJp8QijXw5p+uxIbtFDbeXKvFG+fEiiuocXBvLFlFA==
+"@zowe/zos-logs-for-zowe-sdk@7.9.3":
+  version "7.9.3"
+  resolved "https://registry.npmjs.org/@zowe/zos-logs-for-zowe-sdk/-/zos-logs-for-zowe-sdk-7.9.3.tgz#2009e50c226249f511202c5e31f1976d06a44a02"
+  integrity sha512-KX9lvKWpABsRg/pT7MbLMW8Lv6APpmuixHQ+nkbQMdezmSglkthJrL55Gsf2buuLQp/CUwPmFDubmoJB67qmMA==
 
-"@zowe/zos-tso-for-zowe-sdk@7.9.0":
-  version "7.9.0"
-  resolved "https://registry.npmjs.org/@zowe/zos-tso-for-zowe-sdk/-/zos-tso-for-zowe-sdk-7.9.0.tgz#91f4eaf1d72166552cdc722d63e5516514a75c33"
-  integrity sha512-JatIWXvZFMay3EjpI55QdncpJipi7E4aN4xl3uJWRmiw6PjAeOPVEuaTojHpnvHBsDr3VnSvODRBg9JmxWw+6w==
+"@zowe/zos-tso-for-zowe-sdk@7.9.3":
+  version "7.9.3"
+  resolved "https://registry.npmjs.org/@zowe/zos-tso-for-zowe-sdk/-/zos-tso-for-zowe-sdk-7.9.3.tgz#0090edd22c9d2fcd283a13eed7c5198f2ebdd070"
+  integrity sha512-JdeIKEdzJ+WK7Xi/EW7T9vac7lAETvQ14u9O8ibQZd/HheHU8xJUN6ZufDUNJySyOg27j7CalqsxSFcFRSTs1g==
   dependencies:
-    "@zowe/zosmf-for-zowe-sdk" "7.9.0"
+    "@zowe/zosmf-for-zowe-sdk" "7.9.3"
 
-"@zowe/zos-uss-for-zowe-sdk@7.9.0":
-  version "7.9.0"
-  resolved "https://registry.npmjs.org/@zowe/zos-uss-for-zowe-sdk/-/zos-uss-for-zowe-sdk-7.9.0.tgz#41bf36727e8ae489438c08f6b03a1f482f1103fd"
-  integrity sha512-H6f1Ip9qKy6uwKrH+DO1tPBFYjMzv5W9xsOZneuurc/dT/mVMVftTNds6T3bENOg3FNPuWBfLaSAW0p5nrLZ3w==
+"@zowe/zos-uss-for-zowe-sdk@7.9.3":
+  version "7.9.3"
+  resolved "https://registry.npmjs.org/@zowe/zos-uss-for-zowe-sdk/-/zos-uss-for-zowe-sdk-7.9.3.tgz#6c0680e1c4f263ecd90642ca1aff8fe6160334a4"
+  integrity sha512-hG0zw0yFkqyDZY4Uq+NXKRA8z9xmVr2rDmvikAH6+0PTKaJjjznPvUIAs4U/YgxdkP1cGss4gNZvzMXTqAUFNQ==
   dependencies:
     ssh2 "1.11.0"
 
-"@zowe/zos-workflows-for-zowe-sdk@7.9.0":
-  version "7.9.0"
-  resolved "https://registry.npmjs.org/@zowe/zos-workflows-for-zowe-sdk/-/zos-workflows-for-zowe-sdk-7.9.0.tgz#a5d0ab89347bb0a6cb100fde0554f12fde172778"
-  integrity sha512-j7p23hhGbg9sxsjash0gKHx2oZF3FfqeU2YimKCztVGX7IktsoNTU0m1o8G/BbQKcQrAwRQPadkzako99i5Fig==
+"@zowe/zos-workflows-for-zowe-sdk@7.9.3":
+  version "7.9.3"
+  resolved "https://registry.npmjs.org/@zowe/zos-workflows-for-zowe-sdk/-/zos-workflows-for-zowe-sdk-7.9.3.tgz#825a41dcfc3b35c9de25bedc09b442a1540ba31d"
+  integrity sha512-gRKKcnGfm5XqXJphbtoznHw9W+3DIxS+OYkhKpMLuSixPDo6y4tAXpICLkaN9R4p2XT7iCRuZMjevZ/ufZzvoA==
   dependencies:
-    "@zowe/zos-files-for-zowe-sdk" "7.9.0"
+    "@zowe/zos-files-for-zowe-sdk" "7.9.3"
 
-"@zowe/zosmf-for-zowe-sdk@7.9.0":
-  version "7.9.0"
-  resolved "https://registry.npmjs.org/@zowe/zosmf-for-zowe-sdk/-/zosmf-for-zowe-sdk-7.9.0.tgz#588bdbcd10cdfcd8a8bccd674b3453445a071f19"
-  integrity sha512-VoeHPji/nYzO57b5+uQpqqgoHHLlQG2PH9WG2JFmv0xiny552XlhAPk7E4sLA3KKJlqbJ2oSezi834Iy3fQ9TQ==
+"@zowe/zosmf-for-zowe-sdk@7.9.3":
+  version "7.9.3"
+  resolved "https://registry.npmjs.org/@zowe/zosmf-for-zowe-sdk/-/zosmf-for-zowe-sdk-7.9.3.tgz#adac3b1c183c53eb6638c0adffdb9111de261954"
+  integrity sha512-7vgrkhFqyuxRNJ8DPWkRuCwu+mf6wrNB4X9g48zxSEEOC8ou3VMkC/TIPRUeZ12RjbYz7FlMB3Rj6442pNEBYw==
 
 abab@^2.0.3, abab@^2.0.5:
   version "2.0.6"


### PR DESCRIPTION
## Proposed changes

Resolves #1997 by adding file association for `zowe.config.json` and `zowe.config.user.json` to automatically detect them as JSON with Comments.

## Release Notes

Milestone: 2.6.0

Changelog: updated in PR

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [ ] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

The original solution suggested in the issue was to define `contributes.configurationDefaults.files.associations` in package.json. However, I realized after testing this change that it was the wrong way to go about it, because it overrides default values set by other extensions. The correct solution seems to be defining a `contributes.languages` section.