### PR TITLE
fix(ds-list): Pass responseTimeout to MVS API calls

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 - Added Job search prefix validator [1971](https://github.com/zowe/vscode-extension-for-zowe/issues/1971)
 - Added file association for `zowe.config.json` and `zowe.config.user.json` to automatically detect them as JSON with Comments. [#1997](https://github.com/zowe/vscode-extension-for-zowe/issues/1997)
+- Fixed issue where responseTimeout (in Zowe config) was not provided when listing datasets. [#1907](https://github.com/zowe/vscode-extension-for-zowe/issues/1907)
 
 ### Bug fixes
 

--- a/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
@@ -263,29 +263,30 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
         const responses: zowe.IZosFilesResponse[] = [];
         try {
             const cachedProfile = Profiles.getInstance().loadNamedProfile(this.getProfileName());
-            const options: zowe.IListOptions = {};
-            options.attributes = true;
-            let label: string;
+            const options: zowe.IListOptions = {
+                attributes: true,
+                responseTimeout: cachedProfile.profile.responseTimeout,
+            };
             if (contextually.isSessionNotFav(this)) {
                 this.pattern = this.pattern.toUpperCase();
                 // loop through each pattern for datasets
                 for (const pattern of this.pattern.split(",")) {
                     responses.push(
-                        await ZoweExplorerApiRegister.getMvsApi(cachedProfile).dataSet(pattern.trim(), {
-                            attributes: true,
-                        })
+                        await ZoweExplorerApiRegister.getMvsApi(cachedProfile).dataSet(pattern.trim(), options)
                     );
                 }
             } else if (this.memberPattern !== undefined) {
                 this.memberPattern = this.memberPattern.toUpperCase();
                 for (const memPattern of this.memberPattern.split(",")) {
                     options.pattern = memPattern;
-                    label = this.label as string;
-                    responses.push(await ZoweExplorerApiRegister.getMvsApi(cachedProfile).allMembers(label, options));
+                    responses.push(
+                        await ZoweExplorerApiRegister.getMvsApi(cachedProfile).allMembers(this.label as string, options)
+                    );
                 }
             } else {
-                label = this.label as string;
-                responses.push(await ZoweExplorerApiRegister.getMvsApi(cachedProfile).allMembers(label, options));
+                responses.push(
+                    await ZoweExplorerApiRegister.getMvsApi(cachedProfile).allMembers(this.label as string, options)
+                );
             }
         } catch (err) {
             await errorHandling(


### PR DESCRIPTION
Signed-off-by: Trae Yelovich <trae.yelovich@broadcom.com>

## Proposed changes

Although the MVS API supports a `responseTimeout` option, it was never passed to the API from the user's cached profile. Hence, the `responseTimeout` was defaulted to 30 for dataset list operations. This has been changed, and now the response timeout will be passed from the user's profile (if it exists). 

## Release Notes

Milestone: 2.6.0

Changelog: 
- Fixed issue where responseTimeout (in Zowe config) was not provided when listing datasets. #1907

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [ ] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found