### PR TITLE
remove success message from when error is returned

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 - Fixed issue where "Show Attributes" feature used conflicting colors with light VS Code themes. [#2048](https://github.com/zowe/vscode-extension-for-zowe/issues/2048)
 - Fixed settings not persisting in Theia versions >=1.29.0.
+- Fixed issue with a success message being returned along with error for Job deletion. [#2075](https://github.com/zowe/vscode-extension-for-zowe/issues/2075)
 
 ## `2.5.0`
 

--- a/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
@@ -247,14 +247,17 @@ describe("ZoweJobNode unit tests - Function delete", () => {
             vscode.TreeItemCollapsibleState.Collapsed,
             null,
             globalMocks.testSession,
-            null,
+            globalMocks.testIJob,
             globalMocks.testProfile
         );
-        const errorHandlingSpy = jest.spyOn(utils, "errorHandling");
 
-        await globalMocks.testJobsProvider.delete(badJobNode);
-
-        expect(errorHandlingSpy).toBeCalledTimes(1);
+        const apiRegisterInstance = ZoweExplorerApiRegister.getInstance();
+        const mockJesApi = await apiRegisterInstance.getJesApi(globalMocks.testProfile);
+        const getJesApiMock = jest.fn();
+        getJesApiMock.mockReturnValue(mockJesApi);
+        apiRegisterInstance.getJesApi = getJesApiMock.bind(apiRegisterInstance);
+        jest.spyOn(mockJesApi, "deleteJob").mockImplementationOnce(() => Promise.reject("test error"));
+        await expect(globalMocks.testJobsProvider.delete(badJobNode.job.jobname, badJobNode.job.jobid)).rejects.toThrow();
     });
 });
 

--- a/packages/zowe-explorer/src/job/ZosJobsProvider.ts
+++ b/packages/zowe-explorer/src/job/ZosJobsProvider.ts
@@ -257,14 +257,10 @@ export class ZosJobsProvider extends ZoweTreeProvider implements IZoweTree<IZowe
     }
 
     public async delete(node: IZoweJobTreeNode) {
-        try {
-            await ZoweExplorerApiRegister.getJesApi(node.getProfile()).deleteJob(node.job.jobname, node.job.jobid);
-            await this.removeFavorite(this.createJobsFavorite(node));
-            node.getSessionNode().children = node.getSessionNode().children.filter((n) => n !== node);
-            this.refresh();
-        } catch (error) {
-            await errorHandling(error, node.getProfileName(), error.message);
-        }
+        await ZoweExplorerApiRegister.getJesApi(node.getProfile()).deleteJob(node.job.jobname, node.job.jobid);
+        await this.removeFavorite(this.createJobsFavorite(node));
+        node.getSessionNode().children = node.getSessionNode().children.filter((n) => n !== node);
+        this.refresh();
     }
 
     /**

--- a/packages/zowe-explorer/src/job/actions.ts
+++ b/packages/zowe-explorer/src/job/actions.ts
@@ -326,12 +326,10 @@ async function deleteSingleJob(job: IZoweJobTreeNode, jobsProvider: IZoweTree<IZ
 
     try {
         await jobsProvider.delete(job);
+        vscode.window.showInformationMessage(localize("deleteCommand.job", "Job {0} was deleted.", jobName));
     } catch (error) {
         await errorHandling(error.toString(), job.getProfile().name, error.message.toString());
-        return;
     }
-
-    vscode.window.showInformationMessage(localize("deleteCommand.job", "Job {0} was deleted.", jobName));
 }
 
 async function deleteMultipleJobs(jobs: ReadonlyArray<IZoweJobTreeNode>, jobsProvider: IZoweTree<IZoweJobTreeNode>): Promise<void> {


### PR DESCRIPTION
Signed-off-by: Billie Simmons <49491949+JillieBeanSim@users.noreply.github.com>

## Proposed changes

Brought success message inside the try of the try/catch and removed try/catch from provider.delete method so error will be thrown for methods, like job delete, that is calling it.

## Release Notes

Milestone: 2.6.0

Changelog: Fixed issue with a success message being returned along with error for Job deletion. [#2075](https://github.com/zowe/vscode-extension-for-zowe/issues/2075)
## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
