### PR TITLE
Update stale bot to close issues as "not planned"

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v6
         with:
           any-of-issue-labels: "needs more info, pending closure"
           close-issue-message: >


### PR DESCRIPTION
These are the only breaking changes in [v5](https://github.com/actions/stale/releases/tag/v5.0.0) and [v6](https://github.com/actions/stale/releases/tag/v6.0.0) of the stale bot:
> Update Runtime to node16
> Issues/PRs default `close-issue-reason` is now `not_planned`(https://github.com/actions/stale/issues/789)
