### PR TITLE
fix(uss): Removed excess pop-ups when listing and opening USS files/folders

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 ### Bug fixes
 
 - Updated Imperative to fix failure to load schema when there is no profile of that type. [zowe/imperative#916](https://github.com/zowe/imperative/pull/916)
+- Added missing overload for `Gui.setStatusBarMessage` to allow passing `Thenable` objects.
 
 ## `2.5.0`
 

--- a/packages/zowe-explorer-api/src/globals/Gui.ts
+++ b/packages/zowe-explorer-api/src/globals/Gui.ts
@@ -145,6 +145,8 @@ export namespace Gui {
         return vscode.window.showOpenDialog(options);
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    export function setStatusBarMessage(text: string, hideAfterTimeout: Thenable<any>): vscode.Disposable;
     export function setStatusBarMessage(text: string, hideAfterTimeout: number): vscode.Disposable;
     export function setStatusBarMessage(text: string): vscode.Disposable;
     /**

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Removed extra files from the VSIX bundle to reduce download size by 64%. [#2042](https://github.com/zowe/vscode-extension-for-zowe/pull/2042)
 - Surfaced any errors from a dataset Recall/Migrate operation. [#2032](https://github.com/zowe/vscode-extension-for-zowe/issues/2032)
 - Re-implemented regular dataset API call if the dataSetsMatching does not exist. [#2084](https://github.com/zowe/vscode-extension-for-zowe/issues/2084)
+- Removed excess pop-ups when listing/opening USS files, and replaced required pop-ups with status bar items to improve UX. [#2091](https://github.com/zowe/vscode-extension-for-zowe/issues/2091)
 
 ## `2.5.0`
 

--- a/packages/zowe-explorer/__tests__/__unit__/shared/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/shared/actions.unit.test.ts
@@ -48,6 +48,12 @@ async function createGlobalMocks() {
         return globalMocks.mockCallback;
     });
 
+    Object.defineProperty(Gui, "setStatusBarMessage", {
+        value: jest.fn().mockReturnValue({
+            dispose: jest.fn(),
+        }),
+        configurable: true,
+    });
     Object.defineProperty(vscode.window, "createTreeView", { value: jest.fn(), configurable: true });
     Object.defineProperty(vscode.workspace, "getConfiguration", { value: jest.fn(), configurable: true });
     Object.defineProperty(vscode.window, "showInformationMessage", { value: jest.fn(), configurable: true });
@@ -59,6 +65,16 @@ async function createGlobalMocks() {
     Object.defineProperty(vscode.commands, "executeCommand", { value: globalMocks.withProgress, configurable: true });
     Object.defineProperty(vscode, "ProgressLocation", { value: globalMocks.ProgressLocation, configurable: true });
     Object.defineProperty(Profiles, "getInstance", { value: jest.fn(), configurable: true });
+    Object.defineProperty(zowe, "Download", {
+        value: {
+            ussFile: jest.fn().mockReturnValue({
+                apiResponse: {
+                    etag: "ABC123",
+                },
+            }),
+        },
+        configurable: true,
+    });
     Object.defineProperty(zowe, "Utilities", { value: jest.fn(), configurable: true });
     Object.defineProperty(zowe.Utilities, "isFileTagBinOrAscii", { value: jest.fn(), configurable: true });
     Object.defineProperty(globals, "LOG", { value: jest.fn(), configurable: true });

--- a/packages/zowe-explorer/__tests__/__unit__/uss/USSTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/USSTree.unit.test.ts
@@ -87,6 +87,12 @@ async function createGlobalMocks() {
     globalMocks.mockProfilesInstance.getBaseProfile.mockResolvedValue(globalMocks.testBaseProfile);
     globalMocks.mockProfilesInstance.loadNamedProfile.mockReturnValue(globalMocks.testProfile);
     globalMocks.mockProfilesInstance.allProfiles = [globalMocks.testProfile, { name: "firstName" }, { name: "secondName" }];
+    Object.defineProperty(Gui, "setStatusBarMessage", {
+        value: jest.fn().mockReturnValue({
+            dispose: jest.fn(),
+        }),
+        configurable: true,
+    });
     Object.defineProperty(vscode.window, "showWarningMessage", {
         value: globalMocks.mockShowWarningMessage,
         configurable: true,
@@ -113,6 +119,16 @@ async function createGlobalMocks() {
     Object.defineProperty(zowe, "ZosmfSession", { value: globalMocks.ZosmfSession, configurable: true });
     Object.defineProperty(globalMocks.filters, "getFilters", { value: globalMocks.getFilters, configurable: true });
     Object.defineProperty(vscode.window, "createQuickPick", { value: globalMocks.createQuickPick, configurable: true });
+    Object.defineProperty(zowe, "Download", {
+        value: {
+            ussFile: jest.fn().mockReturnValueOnce({
+                apiResponse: {
+                    etag: "ABC123",
+                },
+            }),
+        },
+        configurable: true,
+    });
     Object.defineProperty(zowe, "Utilities", { value: globalMocks.Utilities, configurable: true });
     Object.defineProperty(zowe.Utilities, "isFileTagBinOrAscii", { value: jest.fn(), configurable: true });
     Object.defineProperty(vscode.window, "showErrorMessage", {
@@ -1302,14 +1318,14 @@ describe("USSTree Unit Tests - Function USSTree.getChildren()", () => {
     it("Testing that getChildren() returns correct ZoweUSSNodes when passed element of type ZoweUSSNode<session>", async () => {
         const globalMocks = await createGlobalMocks();
 
-        const testDir = new ZoweUSSNode("testDir", vscode.TreeItemCollapsibleState.Collapsed, globalMocks.testTree.mSessionNodes[1], null, "test");
+        const testDir = new ZoweUSSNode("aDir", vscode.TreeItemCollapsibleState.Collapsed, globalMocks.testTree.mSessionNodes[1], null, "test");
         globalMocks.testTree.mSessionNodes[1].children.push(testDir);
         const mockApiResponseItems = {
             items: [
                 {
                     mode: "d",
                     mSessionName: "sestest",
-                    name: "testDir",
+                    name: "aDir",
                 },
             ],
         };
@@ -1357,7 +1373,7 @@ describe("USSTree Unit Tests - Function USSTree.getChildren()", () => {
         globalMocks.withProgress.mockReturnValue(mockApiResponseWithItems);
 
         const dirChildren = await globalMocks.testTree.getChildren(directory);
-        expect(dirChildren[0].label).toEqual(sampleChildren[0].label);
+        expect(dirChildren[1].label).toEqual(sampleChildren[0].label);
     });
     it("Testing that getChildren() gets profile-loaded favorites for profile node in Favorites section", async () => {
         const globalMocks = await createGlobalMocks();

--- a/packages/zowe-explorer/__tests__/__unit__/uss/ZoweUSSNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/ZoweUSSNode.unit.test.ts
@@ -48,6 +48,7 @@ async function createGlobalMocks() {
         showInformationMessage: jest.fn(),
         getConfiguration: jest.fn(),
         downloadUSSFile: jest.fn(),
+        setStatusBarMessage: jest.fn().mockReturnValue({ dispose: jest.fn() }),
         showInputBox: jest.fn(),
         mockExecuteCommand: jest.fn(),
         mockLoadNamedProfile: jest.fn(),
@@ -88,6 +89,10 @@ async function createGlobalMocks() {
     globalMocks.getUssApiMock.mockReturnValue(globalMocks.ussApi);
     ZoweExplorerApiRegister.getUssApi = globalMocks.getUssApiMock.bind(ZoweExplorerApiRegister);
 
+    Object.defineProperty(Gui, "setStatusBarMessage", {
+        value: globalMocks.setStatusBarMessage,
+        configurable: true,
+    });
     Object.defineProperty(vscode.workspace, "onDidSaveTextDocument", {
         value: globalMocks.onDidSaveTextDocument,
         configurable: true,
@@ -1067,13 +1072,7 @@ describe("ZoweUSSNode Unit Tests - Function node.openUSS()", () => {
         await node.openUSS(false, true, blockMocks.testUSSTree);
         expect(globalMocks.existsSync.mock.calls.length).toBe(1);
         expect(globalMocks.existsSync.mock.calls[0][0]).toBe(path.join(globals.USS_DIR, "/" + node.mProfileName + "/", node.fullPath));
-        expect(globalMocks.withProgress).toBeCalledWith(
-            {
-                location: vscode.ProgressLocation.Notification,
-                title: "Opening USS file...",
-            },
-            expect.any(Function)
-        );
+        expect(globalMocks.setStatusBarMessage).toBeCalledWith("$(sync~spin) Opening USS file...");
 
         // Tests that correct file is opened in editor
         globalMocks.withProgress(globalMocks.downloadUSSFile);
@@ -1118,14 +1117,7 @@ describe("ZoweUSSNode Unit Tests - Function node.openUSS()", () => {
         await node.openUSS(false, true, blockMocks.testUSSTree);
         expect(globalMocks.existsSync.mock.calls.length).toBe(1);
         expect(globalMocks.existsSync.mock.calls[0][0]).toBe(path.join(globals.USS_DIR, "/" + node.mProfileName + "/", node.fullPath));
-        expect(globalMocks.withProgress).toBeCalledWith(
-            {
-                location: vscode.ProgressLocation.Notification,
-                title: "Opening USS file...",
-            },
-            expect.any(Function)
-        );
-
+        expect(globalMocks.setStatusBarMessage).toBeCalledWith("$(sync~spin) Opening USS file...");
         // Tests that correct file is opened in editor
         globalMocks.withProgress(globalMocks.downloadUSSFile);
         expect(globalMocks.withProgress).toBeCalledWith(globalMocks.downloadUSSFile);
@@ -1275,14 +1267,7 @@ describe("ZoweUSSNode Unit Tests - Function node.openUSS()", () => {
         await node.openUSS(false, true, blockMocks.testUSSTree);
         expect(globalMocks.existsSync.mock.calls.length).toBe(1);
         expect(globalMocks.existsSync.mock.calls[0][0]).toBe(path.join(globals.USS_DIR, "/" + node.getProfileName() + "/", node.fullPath));
-        expect(globalMocks.withProgress).toBeCalledWith(
-            {
-                location: vscode.ProgressLocation.Notification,
-                title: "Opening USS file...",
-            },
-            expect.any(Function)
-        );
-
+        expect(globalMocks.setStatusBarMessage).toBeCalledWith("$(sync~spin) Opening USS file...");
         // Make sure correct file is displayed in the editor
         globalMocks.withProgress(globalMocks.downloadUSSFile);
         expect(globalMocks.openTextDocument.mock.calls.length).toBe(1);

--- a/packages/zowe-explorer/__tests__/__unit__/uss/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/actions.unit.test.ts
@@ -12,7 +12,7 @@
 jest.mock("fs");
 
 import * as zowe from "@zowe/cli";
-import { ProfilesCache, ValidProfileEnum } from "@zowe/zowe-explorer-api";
+import { Gui, ProfilesCache, ValidProfileEnum } from "@zowe/zowe-explorer-api";
 import * as ussNodeActions from "../../../src/uss/actions";
 import { createUSSTree, createUSSNode, createFavoriteUSSNode } from "../../../__mocks__/mockCreators/uss";
 import {
@@ -53,6 +53,7 @@ function createGlobalMocks() {
         withProgress: jest.fn(),
         writeText: jest.fn(),
         fileList: jest.fn(),
+        setStatusBarMessage: jest.fn().mockReturnValue({ dispose: jest.fn() }),
         showWarningMessage: jest.fn(),
         showErrorMessage: jest.fn(),
         createTreeView: jest.fn(),
@@ -90,6 +91,7 @@ function createGlobalMocks() {
     const profilesForValidation = { status: "active", name: "fake" };
     globals.initLogger(mock);
 
+    Object.defineProperty(Gui, "setStatusBarMessage", { value: globalMocks.setStatusBarMessage, configurable: true });
     Object.defineProperty(vscode.window, "showInputBox", { value: globalMocks.mockShowInputBox, configurable: true });
     Object.defineProperty(vscode.window, "showQuickPick", { value: globalMocks.showQuickPick, configurable: true });
     Object.defineProperty(zowe, "Create", { value: globalMocks.Create, configurable: true });

--- a/packages/zowe-explorer/i18n/sample/src/uss/ZoweUSSNode.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/uss/ZoweUSSNode.i18n.json
@@ -1,6 +1,5 @@
 {
   "getChildren.error.invalidNode": "Invalid node",
-  "ZoweUssNode.getList.progress": "Get USS file list command submitted.",
   "getChildren.error.response": "Retrieving response from ",
   "getChildren.responses.error.response": "The response from Zowe CLI was not successful",
   "getChildren.responses.open": "Open",
@@ -9,6 +8,7 @@
   "deleteUssNode.itemDeleted": "The item {0} has been deleted.",
   "openUSS.error.invalidNode": "open() called from invalid node.",
   "openUSS.name.exists": "There is already a file with the same name. Please change your OS file system settings if you want to give case sensitive file names",
+  "ussFile.opening": "$(sync~spin) Opening USS file...",
   "refreshUSS.error.invalidNode": "refreshUSS() called from invalid node.",
   "refreshUSS.error.notFound": "not found",
   "refreshUSS.file1": "Unable to find file: ",


### PR DESCRIPTION
Signed-off-by: Trae Yelovich <trae.yelovich@broadcom.com>

## Proposed changes

- Removes excess pop-ups when listing USS files in favor of a minimal progress bar at the top of the tree view.
- Replaced "Opening USS file..." pop-up => status bar item w/ `$(sync~spin)` icon.

## Release Notes

Milestone: 2.6.1

Changelog:
- Removed excess pop-ups when listing/opening USS files, and replaced required pop-ups with status bar items to improve UX. #2091

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found