### PR TITLE
added section on BiDi languages support

### DIFF
--- a/packages/zowe-explorer/README.md
+++ b/packages/zowe-explorer/README.md
@@ -25,6 +25,7 @@ The Zowe Explorer extension modernizes the way developers and system administrat
 - [Usage tips](#usage-tips)
 - [Keyboard shortcuts](#keyboard-shortcuts)
 - [Extending Zowe Explorer](#extending-zowe-explorer)
+- [Known Issues](#known-issues)
 - [More information](#more-information)
 
 > Zowe Explorer is compatible only with Theia 1.18.0 or higher.
@@ -412,6 +413,16 @@ For the comprehensive Zowe Explorer documentation that also includes information
 You can add new functionalities to Zowe Explorer by creating your own extension. For more information, see [Extensions for Zowe Explorer](https://github.com/zowe/vscode-extension-for-zowe/blob/main/docs/README-Extending.md).
 
 **Tip:** View an example of a Zowe Explorer extension: [Zowe Explorer FTP extension documentation](https://github.com/zowe/zowe-explorer-ftp-extension#zowe-explorer-ftp-extension).
+
+## Known Issues
+
+### Bidirectional languages
+
+Scripts written in languages primarily read from right to left (Arabic, Hebrew, many Asian languages) can include portions of text that are written and read left to right, such as numbers.
+
+These bidirectional (BiDi) languages are not currently supported in Visual Studio Code. (See [Issue #86667](https://github.com/microsoft/vscode/issues/86667) for more information.)
+
+As a result, VS Code extensions like Zowe Explorer, Zowe Explorer CICS Extension, and Zowe Explorer FTP Extension are not able to support BiDi languages in scripts or code comments.
 
 ## More information
 

--- a/packages/zowe-explorer/README.md
+++ b/packages/zowe-explorer/README.md
@@ -418,11 +418,11 @@ You can add new functionalities to Zowe Explorer by creating your own extension.
 
 ### Bidirectional languages
 
-Scripts written in languages primarily read from right to left (Arabic, Hebrew, many Asian languages) can include portions of text that are written and read left to right, such as numbers.
+Files written in languages primarily read from right to left (Arabic, Hebrew, many Asian languages) can include portions of text that are written and read left to right, such as numbers.
 
 These bidirectional (BiDi) languages are not currently supported in Visual Studio Code. (See [Issue #86667](https://github.com/microsoft/vscode/issues/86667) for more information.)
 
-As a result, VS Code extensions like Zowe Explorer, Zowe Explorer CICS Extension, and Zowe Explorer FTP Extension are not able to support BiDi languages in scripts or code comments.
+As a result, VS Code extensions like Zowe Explorer, Zowe Explorer CICS Extension, and Zowe Explorer FTP Extension are not able to support BiDi languages in files.
 
 ## More information
 


### PR DESCRIPTION
Added "Known Issues" section to ReadMe file, which contains a section titled "Bidirectional languages."

A user reached out to Brightside and asked about support for BiDi languages and was informed that VSC doesn't currently support these. (See Microsoft VSC [Issue 86667](https://github.com/microsoft/vscode/issues/86667)) 

Adding it to the ReadMe documentation in case of similar queries in the future. (Already added to Zowe Docs via [PR 2634](https://github.com/zowe/docs-site/pull/2634))