### PR TITLE
fix (uss/ds): Data set members and USS files only open in preview mode

### DIFF
--- a/packages/zowe-explorer-api/__tests__/__unit__/globals/Gui.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/globals/Gui.unit.test.ts
@@ -9,9 +9,10 @@
  *                                                                                 *
  */
 
-import { Gui } from "../../../src/";
+import { Gui, IZoweTree, IZoweTreeNode } from "../../../src/";
 
 import * as vscode from "vscode";
+import { DOUBLE_CLICK_SPEED_MS } from "../../../src/globals";
 jest.mock("vscode");
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -148,5 +149,24 @@ describe("Gui unit tests", () => {
     it("can show an input box", async () => {
         await Gui.showInputBox({});
         expect(mocks.showInputBox).toHaveBeenCalled();
+    });
+});
+
+describe("Gui.utils - unit tests", () => {
+    it("returns false when checking if an invalid node was double-clicked", () => {
+        const doubleClicked = Gui.utils.wasDoubleClicked(null as unknown as IZoweTreeNode, { lastOpened: {} } as unknown as IZoweTree<unknown>);
+        expect(doubleClicked).toBe(false);
+    });
+
+    it("returns false when the second click event is after the DOUBLE_CLICK_SPEED_MS window", () => {
+        const mockTime = new Date();
+
+        setTimeout(() => {
+            const doubleClicked = Gui.utils.wasDoubleClicked(
+                null as unknown as IZoweTreeNode,
+                { lastOpened: { node: null, date: mockTime } } as unknown as IZoweTree<unknown>
+            );
+            expect(doubleClicked).toBe(false);
+        }, DOUBLE_CLICK_SPEED_MS * 2);
     });
 });

--- a/packages/zowe-explorer-api/__tests__/__unit__/globals/Gui.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/globals/Gui.unit.test.ts
@@ -158,15 +158,23 @@ describe("Gui.utils - unit tests", () => {
         expect(doubleClicked).toBe(false);
     });
 
-    it("returns false when the second click event is after the DOUBLE_CLICK_SPEED_MS window", () => {
+    const testDoubleClickEvent = (timeout: number, intendedResult: boolean): void => {
         const mockTime = new Date();
+        const fakeNode = { label: "fakeLabel" } as unknown as IZoweTreeNode;
 
         setTimeout(() => {
-            const doubleClicked = Gui.utils.wasDoubleClicked(
-                null as unknown as IZoweTreeNode,
-                { lastOpened: { node: null, date: mockTime } } as unknown as IZoweTree<unknown>
-            );
-            expect(doubleClicked).toBe(false);
-        }, DOUBLE_CLICK_SPEED_MS * 2);
+            const doubleClicked = Gui.utils.wasDoubleClicked(fakeNode, {
+                lastOpened: { node: fakeNode, date: mockTime },
+            } as unknown as IZoweTree<unknown>);
+            expect(doubleClicked).toBe(intendedResult);
+        }, timeout);
+    };
+
+    it("returns false when the second click event is after the DOUBLE_CLICK_SPEED_MS window", () => {
+        testDoubleClickEvent(DOUBLE_CLICK_SPEED_MS * 2, false);
+    });
+
+    it("returns true when the second click event is within the DOUBLE_CLICK_SPEED_MS window", () => {
+        testDoubleClickEvent(DOUBLE_CLICK_SPEED_MS / 2, true);
     });
 });

--- a/packages/zowe-explorer-api/__tests__/__unit__/globals/Gui.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/globals/Gui.unit.test.ts
@@ -134,9 +134,10 @@ describe("Gui unit tests", () => {
     });
 
     it("can set a status bar message w/ a timeout", () => {
-        Gui.setStatusBarMessage("Example status bar message", 500);
+        const EXAMPLE_TIMEOUT_MS = 500;
+        Gui.setStatusBarMessage("Example status bar message", EXAMPLE_TIMEOUT_MS);
 
-        expect(mocks.setStatusBarMessage).toHaveBeenCalledWith("Example status bar message", 500);
+        expect(mocks.setStatusBarMessage).toHaveBeenCalledWith("Example status bar message", EXAMPLE_TIMEOUT_MS);
     });
 
     it("can show a file open dialog", async () => {

--- a/packages/zowe-explorer-api/src/globals/Constants.ts
+++ b/packages/zowe-explorer-api/src/globals/Constants.ts
@@ -20,4 +20,4 @@ export const SETTINGS_SCS_DEFAULT = SCS_ZOWE_CLI_V2;
 
 // default double-click speed for Windows
 // (since VScode does not have a double-click event for nodes, we need our own check)
-export const DOUBLE_CLICK_SPEED = 500;
+export const DOUBLE_CLICK_SPEED_MS = 500;

--- a/packages/zowe-explorer-api/src/globals/Constants.ts
+++ b/packages/zowe-explorer-api/src/globals/Constants.ts
@@ -17,3 +17,7 @@ export const SCS_BRIGHTSIDE = "@brightside/core";
 export const SCS_ZOWE_CLI = "@zowe/cli";
 export const SCS_BROADCOM_PLUGIN = "Broadcom-Plugin";
 export const SETTINGS_SCS_DEFAULT = SCS_ZOWE_CLI_V2;
+
+// default double-click speed for Windows
+// (since VScode does not have a double-click event for nodes, we need our own check)
+export const DOUBLE_CLICK_SPEED = 500;

--- a/packages/zowe-explorer-api/src/globals/Gui.ts
+++ b/packages/zowe-explorer-api/src/globals/Gui.ts
@@ -12,7 +12,7 @@
 import * as vscode from "vscode";
 import { IZoweLogger, MessageSeverity } from "../logger";
 import { IZoweTree, IZoweTreeNode } from "../tree";
-import { DOUBLE_CLICK_SPEED } from "./Constants";
+import { DOUBLE_CLICK_SPEED_MS } from "./Constants";
 
 export interface GuiMessageOptions<T extends string | vscode.MessageItem> {
     severity?: MessageSeverity;
@@ -281,13 +281,22 @@ export namespace Gui {
     }
 
     export namespace utils {
+        /**
+         * Determines whether a node has been double-clicked within a tree view.
+         *
+         * @param node The node that was just clicked
+         * @param provider The tree provider that the node belongs to
+         * @returns Whether the node has been double-clicked.
+         */
         export function wasDoubleClicked<T>(node: IZoweTreeNode, provider: IZoweTree<T>): boolean {
             const timeOfClick = new Date();
-            if (provider.lastOpened.node === node) {
+            if (provider.lastOpened?.node === node) {
                 const timeDelta = timeOfClick.getTime() - provider.lastOpened.date.getTime();
                 provider.lastOpened.date = timeOfClick;
 
-                return timeDelta <= DOUBLE_CLICK_SPEED;
+                // If the time (in ms) between clicks is less than the defined DOUBLE_CLICK_SPEED_MS,
+                // recognize the action as a double-click.
+                return timeDelta <= DOUBLE_CLICK_SPEED_MS;
             }
 
             provider.lastOpened = {

--- a/packages/zowe-explorer-api/src/globals/Gui.ts
+++ b/packages/zowe-explorer-api/src/globals/Gui.ts
@@ -11,6 +11,7 @@
 
 import * as vscode from "vscode";
 import { IZoweLogger, MessageSeverity } from "../logger";
+import { IZoweTree, IZoweTreeNode } from "../tree";
 
 export interface GuiMessageOptions<T extends string | vscode.MessageItem> {
     severity?: MessageSeverity;
@@ -276,5 +277,24 @@ export namespace Gui {
         task: (progress: vscode.Progress<{ message?: string; increment?: number }>, token: vscode.CancellationToken) => Thenable<R>
     ): Thenable<R> {
         return vscode.window.withProgress(options, task);
+    }
+
+    export namespace utils {
+        export function wasDoubleClicked<T>(node: IZoweTreeNode, provider: IZoweTree<T>): boolean {
+            const timeOfClick = new Date();
+            if (provider.lastOpened.node === node) {
+                const timeDelta = timeOfClick.getTime() - provider.lastOpened.date?.getTime();
+                provider.lastOpened.date = timeOfClick;
+
+                // Magic number: half of the max possible double click time (per Windows specification)
+                return timeDelta < 2500;
+            }
+
+            provider.lastOpened = {
+                node,
+                date: timeOfClick,
+            };
+            return false;
+        }
     }
 }

--- a/packages/zowe-explorer-api/src/globals/Gui.ts
+++ b/packages/zowe-explorer-api/src/globals/Gui.ts
@@ -12,6 +12,7 @@
 import * as vscode from "vscode";
 import { IZoweLogger, MessageSeverity } from "../logger";
 import { IZoweTree, IZoweTreeNode } from "../tree";
+import { DOUBLE_CLICK_SPEED } from "./Constants";
 
 export interface GuiMessageOptions<T extends string | vscode.MessageItem> {
     severity?: MessageSeverity;
@@ -283,17 +284,17 @@ export namespace Gui {
         export function wasDoubleClicked<T>(node: IZoweTreeNode, provider: IZoweTree<T>): boolean {
             const timeOfClick = new Date();
             if (provider.lastOpened.node === node) {
-                const timeDelta = timeOfClick.getTime() - provider.lastOpened.date?.getTime();
+                const timeDelta = timeOfClick.getTime() - provider.lastOpened.date.getTime();
                 provider.lastOpened.date = timeOfClick;
 
-                // Magic number: half of the max possible double click time (per Windows specification)
-                return timeDelta < 2500;
+                return timeDelta <= DOUBLE_CLICK_SPEED;
             }
 
             provider.lastOpened = {
                 node,
                 date: timeOfClick,
             };
+
             return false;
         }
     }

--- a/packages/zowe-explorer-api/src/tree/IZoweTree.ts
+++ b/packages/zowe-explorer-api/src/tree/IZoweTree.ts
@@ -23,10 +23,10 @@ import { PersistenceSchemaEnum } from "../profiles/UserSettings";
  * @template T provide a subtype of vscode.TreeItem
  */
 
-/* 
-    Contains a node that was interacted with,
-    as well as a timestamp for when that interaction occurred.
-*/
+/**
+ *  Contains a node that was recently interacted with,
+ *  as well as a timestamp for when that interaction occurred.
+ */
 export class NodeInteraction {
     public node?: IZoweTreeNode;
     public date?: Date;

--- a/packages/zowe-explorer-api/src/tree/IZoweTree.ts
+++ b/packages/zowe-explorer-api/src/tree/IZoweTree.ts
@@ -22,6 +22,16 @@ import { PersistenceSchemaEnum } from "../profiles/UserSettings";
  * @extends {vscode.TreeDataProvider<T>}
  * @template T provide a subtype of vscode.TreeItem
  */
+
+/* 
+    Contains a node that was interacted with,
+    as well as a timestamp for when that interaction occurred.
+*/
+export class NodeInteraction {
+    public node?: IZoweTreeNode;
+    public date?: Date;
+}
+
 export interface IZoweTree<T> extends vscode.TreeDataProvider<T> {
     /**
      * Root session nodes
@@ -36,6 +46,11 @@ export interface IZoweTree<T> extends vscode.TreeDataProvider<T> {
      * @deprecated should not be visible outside of class
      */
     mFavorites: IZoweTreeNode[];
+
+    /**
+     * Defines the last node that was opened in the editor
+     */
+    lastOpened?: NodeInteraction;
 
     /**
      * Adds a session to the container

--- a/packages/zowe-explorer/src/dataset/DatasetTree.ts
+++ b/packages/zowe-explorer/src/dataset/DatasetTree.ts
@@ -14,7 +14,7 @@ import * as nls from "vscode-nls";
 
 import * as globals from "../globals";
 import * as dsActions from "./actions";
-import { Gui, ValidProfileEnum, IZoweTree, IZoweDatasetTreeNode, PersistenceSchemaEnum } from "@zowe/zowe-explorer-api";
+import { Gui, ValidProfileEnum, IZoweTree, IZoweDatasetTreeNode, PersistenceSchemaEnum, NodeInteraction } from "@zowe/zowe-explorer-api";
 import { Profiles } from "../Profiles";
 import { ZoweExplorerApiRegister } from "../ZoweExplorerApiRegister";
 import { FilterDescriptor, FilterItem, errorHandling, syncSessionNode } from "../utils/ProfilesUtils";
@@ -64,6 +64,7 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
 
     public mSessionNodes: IZoweDatasetTreeNode[] = [];
     public mFavorites: IZoweDatasetTreeNode[] = [];
+    public lastOpened: NodeInteraction = {};
     // public memberPattern: IZoweDatasetTreeNode[] = [];
     private treeView: vscode.TreeView<IZoweDatasetTreeNode>;
 

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -397,6 +397,9 @@ export async function openPS(node: api.IZoweDatasetTreeNode, previewMember: bool
     if (datasetProvider) {
         await datasetProvider.checkCurrentProfile(node);
     }
+
+    const doubleClicked = api.Gui.utils.wasDoubleClicked(node, datasetProvider);
+    const shouldPreview = doubleClicked ? false : previewMember;
     if (Profiles.getInstance().validProfile !== api.ValidProfileEnum.INVALID) {
         try {
             let label: string;
@@ -437,11 +440,7 @@ export async function openPS(node: api.IZoweDatasetTreeNode, previewMember: bool
                 node.setEtag(response.apiResponse.etag);
             }
             const document = await vscode.workspace.openTextDocument(getDocumentFilePath(label, node));
-            if (previewMember === true) {
-                await api.Gui.showTextDocument(document);
-            } else {
-                await api.Gui.showTextDocument(document, { preview: false });
-            }
+            await api.Gui.showTextDocument(document, { preview: shouldPreview });
             if (datasetProvider) {
                 datasetProvider.addFileHistory(`[${node.getProfileName()}]: ${label}`);
             }

--- a/packages/zowe-explorer/src/job/ZosJobsProvider.ts
+++ b/packages/zowe-explorer/src/job/ZosJobsProvider.ts
@@ -13,7 +13,7 @@ import * as vscode from "vscode";
 import * as jobUtils from "../job/utils";
 import * as globals from "../globals";
 import { IJob, imperative } from "@zowe/cli";
-import { Gui, ValidProfileEnum, IZoweTree, IZoweJobTreeNode, PersistenceSchemaEnum } from "@zowe/zowe-explorer-api";
+import { Gui, ValidProfileEnum, IZoweTree, IZoweJobTreeNode, PersistenceSchemaEnum, NodeInteraction } from "@zowe/zowe-explorer-api";
 import { FilterItem, errorHandling } from "../utils/ProfilesUtils";
 import { Profiles } from "../Profiles";
 import { ZoweExplorerApiRegister } from "../ZoweExplorerApiRegister";
@@ -107,6 +107,7 @@ export class ZosJobsProvider extends ZoweTreeProvider implements IZoweTree<IZowe
 
     public mSessionNodes: IZoweJobTreeNode[] = [];
     public mFavorites: IZoweJobTreeNode[] = [];
+    public lastOpened: NodeInteraction = {};
     public searchByQuery = new FilterItem({
         text: globals.plusSign + localize("zosJobsProvider.option.prompt.createId", "Create job search filter"),
         menuType: globals.JobPickerTypes.QuerySearch,

--- a/packages/zowe-explorer/src/uss/USSTree.ts
+++ b/packages/zowe-explorer/src/uss/USSTree.ts
@@ -15,7 +15,7 @@ import * as path from "path";
 import { imperative } from "@zowe/cli";
 import { FilterItem, FilterDescriptor, errorHandling, syncSessionNode } from "../utils/ProfilesUtils";
 import { sortTreeItems, getAppName, checkIfChildPath } from "../shared/utils";
-import { Gui, IZoweTree, IZoweUSSTreeNode, ValidProfileEnum, PersistenceSchemaEnum } from "@zowe/zowe-explorer-api";
+import { Gui, IZoweTree, IZoweUSSTreeNode, NodeInteraction, ValidProfileEnum, PersistenceSchemaEnum } from "@zowe/zowe-explorer-api";
 import { Profiles } from "../Profiles";
 import { ZoweExplorerApiRegister } from "../ZoweExplorerApiRegister";
 import { ZoweUSSNode } from "./ZoweUSSNode";
@@ -59,6 +59,7 @@ export class USSTree extends ZoweTreeProvider implements IZoweTree<IZoweUSSTreeN
     public mFavoriteSession: ZoweUSSNode;
     public mSessionNodes: IZoweUSSTreeNode[] = [];
     public mFavorites: IZoweUSSTreeNode[] = [];
+    public lastOpened: NodeInteraction = {};
     private treeView: vscode.TreeView<IZoweUSSTreeNode>;
 
     constructor() {

--- a/packages/zowe-explorer/src/uss/ZoweUSSNode.ts
+++ b/packages/zowe-explorer/src/uss/ZoweUSSNode.ts
@@ -419,6 +419,9 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
      */
     public async openUSS(download = false, previewFile: boolean, ussFileProvider?: IZoweTree<IZoweUSSTreeNode>) {
         await ussFileProvider.checkCurrentProfile(this);
+
+        const doubleClicked = Gui.utils.wasDoubleClicked(this, ussFileProvider);
+        const shouldPreview = doubleClicked ? false : previewFile;
         if (Profiles.getInstance().validProfile === ValidProfileEnum.VALID || Profiles.getInstance().validProfile === ValidProfileEnum.UNVERIFIED) {
             try {
                 let label: string;
@@ -473,7 +476,7 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
                     ussFileProvider.addFileHistory(`[${this.getProfile().name}]: ${this.fullPath}`);
                     ussFileProvider.getTreeView().reveal(this, { select: true, focus: true, expand: false });
 
-                    await this.initializeFileOpening(documentFilePath, previewFile);
+                    await this.initializeFileOpening(documentFilePath, shouldPreview);
                 }
             } catch (err) {
                 await errorHandling(err, this.mProfileName, err.message);


### PR DESCRIPTION
## Proposed changes

This fixes #2125, where a double-click event always opened a data set member or USS file in preview mode. It implements a function to check for a double-click event on a node, found in the `Gui.utils` namespace. This implementation can be used for any Zowe node (in any Zowe tree provider), and works in tandem with an optional `lastOpened` member in the `IZoweTree` class so that extenders can also implement this functionality if desired.

## Release Notes

Milestone: 2.6.1 (?)

Changelog: 
- Fixes issue where data set members and USS files always opened in preview mode when double-clicked. #2125

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found

## Further comments

Are we satisfied with 500ms being the default value for `DOUBLE_CLICK_SPEED_MS`? Currently, 500ms is the default time for Windows double-click speed, and VScode seems to use that as well when double-clicking on nodes.
