### PR TITLE
Fix bug w/ job search in favorites; other jobs UX updates

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 ### New features and enhancements
 
+- Added `description` variable to `IZoweTreeNode` to prevent compilation errors when updating node descriptions.
+- Added `filtered` variable to `IZoweJobTreeNode` to track whether a job session node has been filtered.
+
 ### Bug fixes
 
 ## `2.6.0`

--- a/packages/zowe-explorer-api/src/tree/IZoweTreeNode.ts
+++ b/packages/zowe-explorer-api/src/tree/IZoweTreeNode.ts
@@ -35,6 +35,10 @@ export interface IZoweTreeNode {
      */
     label?: string | vscode.TreeItemLabel;
     /**
+     * A description for this tree item.
+     */
+    description?: string | boolean;
+    /**
      * The tooltip text when you hover over this item.
      */
     tooltip?: string | vscode.MarkdownString | undefined;
@@ -283,6 +287,10 @@ export interface IZoweJobTreeNode extends IZoweTreeNode {
      * Attribute of Job query
      */
     status?: string;
+    /**
+     * Returns whether the job node is a filtered search
+     */
+    filtered?: boolean;
     /**
      * Retrieves child nodes of this IZoweJobTreeNode
      *

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
+- Fixed issue where job search queries were not working properly when favorited. [#2122](https://github.com/zowe/vscode-extension-for-zowe/issues/2122)
+
 ## `2.6.1`
 
 ### Bug fixes

--- a/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
@@ -299,6 +299,7 @@ describe("ZoweJobNode unit tests - Function getChildren", () => {
         await globalMocks.testJobsProvider.addSession("fake");
         globalMocks.testJobsProvider.mSessionNodes[1].searchId = "JOB1234";
         globalMocks.testJobsProvider.mSessionNodes[1].dirty = true;
+        globalMocks.testJobsProvider.mSessionNodes[1].filtered = true;
 
         const jobs = await globalMocks.testJobsProvider.mSessionNodes[1].getChildren();
 
@@ -414,7 +415,7 @@ describe("ZoweJobNode unit tests - Function addFavorite", () => {
         const profileNodeInFavs: IZoweJobTreeNode = globalMocks.testJobsProvider.mFavorites[0];
 
         expect(profileNodeInFavs.children.length).toEqual(1);
-        expect(profileNodeInFavs.children[0].label).toEqual("Owner:myHLQ Prefix:* Status:*");
+        expect(profileNodeInFavs.children[0].label).toEqual("Owner: myHLQ | Prefix: * | Status: *");
         expect(profileNodeInFavs.children[0].contextValue).toEqual(globals.JOBS_SESSION_CONTEXT + globals.FAV_SUFFIX);
     });
 });
@@ -618,7 +619,7 @@ describe("ZosJobsProvider - Function parseJobSearchQuery", () => {
     });
     it("should parse search criteria without status", async () => {
         const globalMocks = await createGlobalMocks();
-        const actualCriteriaObj = globalMocks.testJobsProvider.parseJobSearchQuery("Owner:zowe Prefix:*");
+        const actualCriteriaObj = globalMocks.testJobsProvider.parseJobSearchQuery("Owner: zowe | Prefix: *");
         const expectedSearchCriteriaObj = {
             Owner: "zowe",
             Prefix: "*",

--- a/packages/zowe-explorer/src/job/ZosJobsProvider.ts
+++ b/packages/zowe-explorer/src/job/ZosJobsProvider.ts
@@ -311,11 +311,15 @@ export class ZosJobsProvider extends ZoweTreeProvider implements IZoweTree<IZowe
      */
     public createProfileNodeForFavs(profileName: string): Job {
         const favProfileNode = new Job(profileName, vscode.TreeItemCollapsibleState.Collapsed, this.mFavoriteSession, null, null, null);
-        favProfileNode.contextValue = globals.FAV_PROFILE_CONTEXT;
+
+        // Fake context value to pull correct icon
+        favProfileNode.contextValue = globals.JOBS_SESSION_CONTEXT + globals.HOME_SUFFIX;
         const icon = getIconByNode(favProfileNode);
         if (icon) {
             favProfileNode.iconPath = icon.path;
         }
+        favProfileNode.contextValue = globals.FAV_PROFILE_CONTEXT;
+
         this.mFavorites.push(favProfileNode);
         return favProfileNode;
     }
@@ -473,6 +477,7 @@ export class ZosJobsProvider extends ZoweTreeProvider implements IZoweTree<IZowe
         if (profileNodeInFavorites === undefined) {
             // If favorite node for profile doesn't exist yet, create a new one for it
             profileNodeInFavorites = this.createProfileNodeForFavs(profileName);
+            profileNodeInFavorites.iconPath = node.iconPath;
         }
         if (contextually.isSession(node)) {
             // Favorite a search/session
@@ -710,15 +715,18 @@ export class ZosJobsProvider extends ZoweTreeProvider implements IZoweTree<IZowe
         if (!searchCriteria) {
             return searchCriteriaObj;
         }
-        const searchOptionArray = searchCriteria.split(" ");
-        searchOptionArray.forEach((searchOption) => {
-            const keyValue = searchOption.split(":");
-            const key = keyValue[0]?.trim();
-            const value = keyValue[1]?.trim();
-            try {
-                searchCriteriaObj[key] = value;
-            } catch (e) {}
-        });
+        let searchOptionArray = searchCriteria.split(/\s\|\s|(?<!:)\s/);
+        if (searchOptionArray != null) {
+            searchOptionArray = searchOptionArray.filter((val) => val?.includes(":")).map((val) => (val.startsWith(":") ? val.substring(1) : val));
+            searchOptionArray.forEach((searchOption) => {
+                const keyValue = searchOption.split(":");
+                const key = keyValue[0]?.trim();
+                const value = keyValue[1]?.trim();
+                try {
+                    searchCriteriaObj[key] = value;
+                } catch (e) {}
+            });
+        }
         return searchCriteriaObj;
     }
 
@@ -744,7 +752,7 @@ export class ZosJobsProvider extends ZoweTreeProvider implements IZoweTree<IZowe
         const session = node.getProfileName();
         const faveNode = node;
         await this.addSession(session);
-        node = this.mSessionNodes.find((tempNode) => tempNode.label.toString() === session);
+        node = this.mSessionNodes.find((tempNode) => tempNode.label?.toString() === session);
         if (!node.getSession().ISession.user || !node.getSession().ISession.password) {
             node.getSession().ISession.user = faveNode.getSession().ISession.user;
             node.getSession().ISession.password = faveNode.getSession().ISession.password;
@@ -763,26 +771,39 @@ export class ZosJobsProvider extends ZoweTreeProvider implements IZoweTree<IZowe
         await this.checkCurrentProfile(node);
         let searchCriteria: string = "";
         if (Profiles.getInstance().validProfile === ValidProfileEnum.VALID || !contextually.isValidationEnabled(node)) {
-            if (contextually.isSessionNotFav(node)) {
-                searchCriteria = await this.applyRegularSessionSearchLabel(node);
-            } else {
-                searchCriteria = await this.applySavedFavoritesSearchLabel(node);
-                const jobQueryObj = this.parseJobSearchQuery(searchCriteria);
-                this.applySearchLabelToNode(node, jobQueryObj);
-            }
-            if (!searchCriteria) {
-                return undefined;
-            }
-            node.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
+            const isSessionNotFav = contextually.isSessionNotFav(node);
+            const isExpanded = node.collapsibleState === vscode.TreeItemCollapsibleState.Expanded;
+
+            node.filtered = true;
+
             const icon = getIconByNode(node);
             if (icon) {
                 node.iconPath = icon.path;
             }
-            node.label = `${node.getProfileName()} [${searchCriteria}]`;
-            labelRefresh(node);
-            node.dirty = true;
-            this.refreshElement(node);
-            this.addSearchHistory(searchCriteria);
+
+            if (isSessionNotFav) {
+                searchCriteria = await this.applyRegularSessionSearchLabel(node);
+                node.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
+
+                if (searchCriteria != null) {
+                    node.label = node.getProfileName();
+                    node.description = searchCriteria;
+                    this.addSearchHistory(searchCriteria);
+                    this.refreshElement(node);
+                    labelRefresh(node);
+                }
+            } else {
+                if (isExpanded) {
+                    node.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+                } else {
+                    searchCriteria = await this.applySavedFavoritesSearchLabel(node);
+                    const jobQueryObj = this.parseJobSearchQuery(searchCriteria);
+                    this.applySearchLabelToNode(node, jobQueryObj);
+                    node.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
+                }
+
+                labelRefresh(node);
+            }
         }
     }
 
@@ -817,14 +838,15 @@ export class ZosJobsProvider extends ZoweTreeProvider implements IZoweTree<IZowe
         }
         let revisedCriteria = "";
         if (owner) {
-            revisedCriteria = Job.Owner + owner.trim() + " ";
+            revisedCriteria = Job.Owner + owner.trim() + " | ";
         }
         if (prefix) {
-            revisedCriteria += Job.Prefix + prefix.trim() + " ";
+            revisedCriteria += Job.Prefix + prefix.trim() + " | ";
         }
         if (status) {
             revisedCriteria += Job.Status + status.trim();
         }
+
         return revisedCriteria.trim();
     }
 

--- a/packages/zowe-explorer/src/job/ZoweJobNode.ts
+++ b/packages/zowe-explorer/src/job/ZoweJobNode.ts
@@ -29,10 +29,10 @@ nls.config({
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 export class Job extends ZoweTreeNode implements IZoweJobTreeNode {
-    public static readonly JobId = "JobId:";
-    public static readonly Owner = "Owner:";
-    public static readonly Prefix = "Prefix:";
-    public static readonly Status = "Status:";
+    public static readonly JobId = "Job ID: ";
+    public static readonly Owner = "Owner: ";
+    public static readonly Prefix = "Prefix: ";
+    public static readonly Status = "Status: ";
 
     public children: IZoweJobTreeNode[] = [];
     public dirty = true;
@@ -54,6 +54,11 @@ export class Job extends ZoweTreeNode implements IZoweJobTreeNode {
         this._prefix = "*";
         this._searchId = "";
         this._jobStatus = "*";
+        this.filtered = false;
+
+        if (mParent == null && label !== "Favorites") {
+            this.contextValue = globals.JOBS_SESSION_CONTEXT;
+        }
 
         if (session) {
             this._owner = "*";
@@ -74,7 +79,7 @@ export class Job extends ZoweTreeNode implements IZoweJobTreeNode {
      * @returns {Promise<IZoweJobTreeNode[]>}
      */
     public async getChildren(): Promise<IZoweJobTreeNode[]> {
-        if (!this._owner && contextually.isSession(this)) {
+        if (contextually.isSession(this) && !this.filtered) {
             return [
                 new Job(
                     localize("getChildren.search", "Use the search button to display jobs"),


### PR DESCRIPTION
## Proposed changes

This PR fixed the following issues with job nodes:

1. Favorited search queries for jobs were not executing properly (fixes #2122)
2. Cached job session nodes execute last search query (when clicked) after reloading VS Code (inconsistent w/ session nodes from other tree views)
3. Session icons in "Favorites" section were missing
4. Search query in "Favorites" section did not maintain same expand/collapse behavior as non-favorited session nodes

Updated a few UX behaviors as well as node structure:
- Search query was reformatted with spacing and delimiters between values: `Owner: testowner | Prefix: prefix | Status: *` (previous filters will still work)
- Brackets were removed from search query, and search query was moved to description
- Added `description` to `IZoweTreeNode` so that Zowe tree nodes can use this variable without compilation errors
- Added `filtered` variable to `IZoweJobTreeNode` so that job session nodes can track whether they have been filtered

## Release Notes

Milestone: 2.7.0

Changelog: 
- Fixed issue where job search queries were not working properly when favorited. [#2122](https://github.com/zowe/vscode-extension-for-zowe/issues/2122)

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [ ] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
