### PR TITLE
Fix errors related to Imperative overrides file

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 ### Bug fixes
 
+- Fixed credentials being updated for wrong v1 profile if multiple profiles had different types but same name.
+
 ## `2.7.0`
 
 ### New features and enhancements

--- a/packages/zowe-explorer-api/__tests__/__unit__/profiles/ProfilesCache.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/profiles/ProfilesCache.unit.test.ts
@@ -352,7 +352,6 @@ describe("ProfilesCache", () => {
 
     it("getProfileFromConfig should return profile attributes for given name", async () => {
         const profCache = new ProfilesCache(fakeLogger as any);
-        (profCache as any).allTypes = ["zosmf", "zftp"];
         jest.spyOn(profCache, "getProfileInfo").mockResolvedValue(createProfInfoMock([{ name: "lpar1", type: "zosmf" }]));
         const profAttrs = await profCache.getProfileFromConfig("lpar1");
         expect(profAttrs).toMatchObject({ profName: "lpar1", profType: "zosmf" });
@@ -360,7 +359,6 @@ describe("ProfilesCache", () => {
 
     it("getProfileFromConfig not return profile if name not found", async () => {
         const profCache = new ProfilesCache(fakeLogger as any);
-        (profCache as any).allTypes = ["zosmf", "zftp"];
         jest.spyOn(profCache, "getProfileInfo").mockResolvedValue(createProfInfoMock([{ name: "lpar1", type: "zosmf" }]));
         const profAttrs = await profCache.getProfileFromConfig("lpar2");
         expect(profAttrs).toBeUndefined();
@@ -368,15 +366,13 @@ describe("ProfilesCache", () => {
 
     it("getProfileFromConfig not return profile if type not found", async () => {
         const profCache = new ProfilesCache(fakeLogger as any);
-        (profCache as any).allTypes = ["zosmf"];
-        jest.spyOn(profCache, "getProfileInfo").mockResolvedValue(createProfInfoMock([{ name: "lpar1", type: "zftp" }]));
-        const profAttrs = await profCache.getProfileFromConfig("lpar1");
+        jest.spyOn(profCache, "getProfileInfo").mockResolvedValue(createProfInfoMock([{ name: "lpar1", type: "zosmf" }]));
+        const profAttrs = await profCache.getProfileFromConfig("lpar1", "zftp");
         expect(profAttrs).toBeUndefined();
     });
 
     it("getLoadedProfConfig should return profile object for given name", async () => {
         const profCache = new ProfilesCache(fakeLogger as any);
-        (profCache as any).allTypes = ["zosmf", "zftp"];
         jest.spyOn(profCache, "getProfileInfo").mockResolvedValue(createProfInfoMock([lpar1Profile]));
         const profile = await profCache.getLoadedProfConfig("lpar1");
         expect(profile).toMatchObject(lpar1Profile);
@@ -384,7 +380,6 @@ describe("ProfilesCache", () => {
 
     it("getLoadedProfConfig should not return profile if name not found", async () => {
         const profCache = new ProfilesCache(fakeLogger as any);
-        (profCache as any).allTypes = ["zosmf", "zftp"];
         jest.spyOn(profCache, "getProfileInfo").mockResolvedValue(createProfInfoMock([{ name: "lpar1", type: "zosmf" }]));
         const profile = await profCache.getLoadedProfConfig("lpar2");
         expect(profile).toBeUndefined();
@@ -392,9 +387,8 @@ describe("ProfilesCache", () => {
 
     it("getLoadedProfConfig should not return profile if type not found", async () => {
         const profCache = new ProfilesCache(fakeLogger as any);
-        (profCache as any).allTypes = ["zosmf"];
-        jest.spyOn(profCache, "getProfileInfo").mockResolvedValue(createProfInfoMock([{ name: "lpar1", type: "zftp" }]));
-        const profile = await profCache.getLoadedProfConfig("lpar1");
+        jest.spyOn(profCache, "getProfileInfo").mockResolvedValue(createProfInfoMock([{ name: "lpar1", type: "zosmf" }]));
+        const profile = await profCache.getLoadedProfConfig("lpar1", "zftp");
         expect(profile).toBeUndefined();
     });
 

--- a/packages/zowe-explorer-api/__tests__/__unit__/profiles/ProfilesCache.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/profiles/ProfilesCache.unit.test.ts
@@ -352,6 +352,7 @@ describe("ProfilesCache", () => {
 
     it("getProfileFromConfig should return profile attributes for given name", async () => {
         const profCache = new ProfilesCache(fakeLogger as any);
+        (profCache as any).allTypes = ["zosmf", "zftp"];
         jest.spyOn(profCache, "getProfileInfo").mockResolvedValue(createProfInfoMock([{ name: "lpar1", type: "zosmf" }]));
         const profAttrs = await profCache.getProfileFromConfig("lpar1");
         expect(profAttrs).toMatchObject({ profName: "lpar1", profType: "zosmf" });
@@ -359,13 +360,23 @@ describe("ProfilesCache", () => {
 
     it("getProfileFromConfig not return profile if name not found", async () => {
         const profCache = new ProfilesCache(fakeLogger as any);
+        (profCache as any).allTypes = ["zosmf", "zftp"];
         jest.spyOn(profCache, "getProfileInfo").mockResolvedValue(createProfInfoMock([{ name: "lpar1", type: "zosmf" }]));
         const profAttrs = await profCache.getProfileFromConfig("lpar2");
         expect(profAttrs).toBeUndefined();
     });
 
+    it("getProfileFromConfig not return profile if type not found", async () => {
+        const profCache = new ProfilesCache(fakeLogger as any);
+        (profCache as any).allTypes = ["zosmf"];
+        jest.spyOn(profCache, "getProfileInfo").mockResolvedValue(createProfInfoMock([{ name: "lpar1", type: "zftp" }]));
+        const profAttrs = await profCache.getProfileFromConfig("lpar1");
+        expect(profAttrs).toBeUndefined();
+    });
+
     it("getLoadedProfConfig should return profile object for given name", async () => {
         const profCache = new ProfilesCache(fakeLogger as any);
+        (profCache as any).allTypes = ["zosmf", "zftp"];
         jest.spyOn(profCache, "getProfileInfo").mockResolvedValue(createProfInfoMock([lpar1Profile]));
         const profile = await profCache.getLoadedProfConfig("lpar1");
         expect(profile).toMatchObject(lpar1Profile);
@@ -373,8 +384,17 @@ describe("ProfilesCache", () => {
 
     it("getLoadedProfConfig should not return profile if name not found", async () => {
         const profCache = new ProfilesCache(fakeLogger as any);
+        (profCache as any).allTypes = ["zosmf", "zftp"];
         jest.spyOn(profCache, "getProfileInfo").mockResolvedValue(createProfInfoMock([{ name: "lpar1", type: "zosmf" }]));
         const profile = await profCache.getLoadedProfConfig("lpar2");
+        expect(profile).toBeUndefined();
+    });
+
+    it("getLoadedProfConfig should not return profile if type not found", async () => {
+        const profCache = new ProfilesCache(fakeLogger as any);
+        (profCache as any).allTypes = ["zosmf"];
+        jest.spyOn(profCache, "getProfileInfo").mockResolvedValue(createProfInfoMock([{ name: "lpar1", type: "zftp" }]));
+        const profile = await profCache.getLoadedProfConfig("lpar1");
         expect(profile).toBeUndefined();
     });
 

--- a/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
+++ b/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
@@ -317,7 +317,7 @@ export class ProfilesCache {
     public async getProfileFromConfig(profileName: string): Promise<zowe.imperative.IProfAttrs | undefined> {
         const mProfileInfo = await this.getProfileInfo();
         const configAllProfiles = mProfileInfo.getAllProfiles().filter((prof) => prof.profLoc.osLoc.length !== 0);
-        return configAllProfiles.find((prof) => prof.profName === profileName);
+        return configAllProfiles.find((prof) => prof.profName === profileName && this.allTypes.includes(prof.profType));
     }
 
     public async getLoadedProfConfig(profileName: string): Promise<zowe.imperative.IProfileLoaded | undefined> {

--- a/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
+++ b/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
@@ -314,15 +314,15 @@ export class ProfilesCache {
         return;
     }
 
-    public async getProfileFromConfig(profileName: string): Promise<zowe.imperative.IProfAttrs | undefined> {
+    public async getProfileFromConfig(profileName: string, profileType?: string): Promise<zowe.imperative.IProfAttrs | undefined> {
         const mProfileInfo = await this.getProfileInfo();
         const configAllProfiles = mProfileInfo.getAllProfiles().filter((prof) => prof.profLoc.osLoc.length !== 0);
-        return configAllProfiles.find((prof) => prof.profName === profileName && this.allTypes.includes(prof.profType));
+        return configAllProfiles.find((prof) => prof.profName === profileName && (!profileType || prof.profType === profileType));
     }
 
-    public async getLoadedProfConfig(profileName: string): Promise<zowe.imperative.IProfileLoaded | undefined> {
+    public async getLoadedProfConfig(profileName: string, profileType?: string): Promise<zowe.imperative.IProfileLoaded | undefined> {
         const mProfileInfo = await this.getProfileInfo();
-        const currentProfile = await this.getProfileFromConfig(profileName);
+        const currentProfile = await this.getProfileFromConfig(profileName, profileType);
         if (currentProfile == null) return undefined;
         const profile = this.getMergedAttrs(mProfileInfo, currentProfile);
         return this.getProfileLoaded(currentProfile.profName, currentProfile.profType, profile);

--- a/packages/zowe-explorer-api/src/vscode/ZoweVsCodeExtension.ts
+++ b/packages/zowe-explorer-api/src/vscode/ZoweVsCodeExtension.ts
@@ -108,7 +108,7 @@ export class ZoweVsCodeExtension {
         const cache = this.profilesCache;
         const profInfo = await cache.getProfileInfo();
         const setSecure = options.secure ?? profInfo.isSecured();
-        const loadProfile = await cache.getLoadedProfConfig(options.sessionName);
+        const loadProfile = await cache.getLoadedProfConfig(options.sessionName, options.sessionType);
         const loadSession = loadProfile.profile as imperative.ISession;
         const creds = await ZoweVsCodeExtension.promptUserPass({ session: loadSession, ...options });
 

--- a/packages/zowe-explorer-api/src/vscode/doc/IPromptCredentials.ts
+++ b/packages/zowe-explorer-api/src/vscode/doc/IPromptCredentials.ts
@@ -20,6 +20,7 @@ export interface IPromptCredentialsCommonOptions {
 
 export interface IPromptCredentialsOptions extends IPromptCredentialsCommonOptions {
     sessionName: string;
+    sessionType?: string;
     secure?: boolean;
 }
 

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 - Fixed issue where job search queries were not working properly when favorited. [#2122](https://github.com/zowe/vscode-extension-for-zowe/issues/2122)
 - Fixed issues where document changes may fail to upload if the environment has a slow filesystem or mainframe connection, or when VS Code exits during an upload operation. [#1948](https://github.com/zowe/vscode-extension-for-zowe/issues/1948)
+- Fixed custom credential manager in `~/.zowe/settings/imperative.json` file being overwritten with invalid JSON. [#2187](https://github.com/zowe/vscode-extension-for-zowe/issues/2187)
 
 ## `2.6.2`
 

--- a/packages/zowe-explorer/__mocks__/@zowe/cli.ts
+++ b/packages/zowe-explorer/__mocks__/@zowe/cli.ts
@@ -29,6 +29,10 @@ export function getZoweDir(): string {
     return imperative.ImperativeConfig.instance.cliHome;
 }
 
+export function getImperativeConfig() {
+    return {};
+}
+
 export namespace ZosmfSession {
     export function createSessCfgFromArgs(cmdArgs: imperative.ICommandArguments) {
         return {

--- a/packages/zowe-explorer/__mocks__/@zowe/imperative.ts
+++ b/packages/zowe-explorer/__mocks__/@zowe/imperative.ts
@@ -224,6 +224,8 @@ export class CliProfileManager {
             },
         ];
     }
+
+    public static initialize() {}
 }
 
 export class ProfileInfo {

--- a/packages/zowe-explorer/__tests__/__unit__/Profiles.extended.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/Profiles.extended.unit.test.ts
@@ -345,9 +345,10 @@ describe("Profiles Unit Tests - Function createNewConnection for v1 Profiles", (
     it("Tests that createNewConnection throws an exception and shows a config error", async () => {
         const globalMocks = await createGlobalMocks();
         const blockMocks = await createBlockMocks(globalMocks);
+        const testError = new Error("saveProfile error");
 
         const mockSaveProfile = jest.spyOn(ProfilesCache.prototype as any, "saveProfile").mockImplementationOnce(async (_values, _name, _type) => {
-            throw new Error("saveProfile error");
+            throw testError;
         });
         const mockShowZoweConfigError = jest.spyOn(ZoweExplorerExtender, "showZoweConfigError").mockImplementation();
 
@@ -361,7 +362,7 @@ describe("Profiles Unit Tests - Function createNewConnection for v1 Profiles", (
         await Profiles.getInstance().createNewConnection("fake", "zosmf");
         expect(mockSaveProfile).toHaveBeenCalled();
         expect(globalMocks.mockShowInformationMessage).not.toHaveBeenCalled();
-        expect(errorHandlingSpy).toHaveBeenCalledWith("saveProfile error");
+        expect(errorHandlingSpy).toHaveBeenCalledWith(testError, "fake", testError.message);
         expect(mockShowZoweConfigError).toHaveBeenCalledWith("saveProfile error");
     });
 

--- a/packages/zowe-explorer/__tests__/__unit__/ZoweExplorerExtender.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/ZoweExplorerExtender.unit.test.ts
@@ -23,6 +23,7 @@ import * as path from "path";
 import * as fs from "fs";
 import { getZoweDir, Gui } from "@zowe/zowe-explorer-api";
 import * as profilesUtils from "../../src/utils/ProfilesUtils";
+import * as globals from "../../src/globals";
 jest.mock("fs");
 
 describe("ZoweExplorerExtender unit tests", () => {
@@ -65,6 +66,8 @@ describe("ZoweExplorerExtender unit tests", () => {
             value: newMocks.mockGetConfiguration,
             configurable: true,
         });
+        Object.defineProperty(globals, "LOG", { value: jest.fn(), configurable: true });
+        Object.defineProperty(globals.LOG, "error", { value: jest.fn(), configurable: true });
 
         return newMocks;
     }
@@ -157,6 +160,7 @@ describe("ZoweExplorerExtender unit tests", () => {
             await ZoweExplorerExtender.showZoweConfigError(userInput.configError);
             expect(blockMocks.mockErrorMessage).toHaveBeenCalledWith(
                 'Error encountered when loading your Zowe config. Click "Show Config" for more details.',
+                undefined,
                 "Show Config"
             );
             if (userInput.choice == null) {
@@ -176,6 +180,15 @@ describe("ZoweExplorerExtender unit tests", () => {
                 }
             }
         }
+    });
+
+    it("properly handles error parsing Imperative overrides json", async () => {
+        const blockMocks = await createBlockMocks();
+        ZoweExplorerExtender.createInstance();
+        const errMsg = "Failed to parse JSON file imperative.json";
+
+        await ZoweExplorerExtender.showZoweConfigError(errMsg);
+        expect(blockMocks.mockErrorMessage).toHaveBeenCalledWith("Error: " + errMsg, undefined);
     });
 
     it("should initialize zowe", async () => {

--- a/packages/zowe-explorer/__tests__/__unit__/utils/ProfileUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/ProfileUtils.unit.test.ts
@@ -20,261 +20,287 @@ import { Profiles } from "../../../src/Profiles";
 
 jest.mock("fs");
 jest.mock("vscode");
+jest.mock("@zowe/cli");
+jest.mock("@zowe/imperative");
 
 afterEach(() => {
     jest.clearAllMocks();
 });
 
-describe("ProfileUtils.writeOverridesFile Unit Tests", () => {
+describe("ProfileUtils unit tests", () => {
     function createBlockMocks() {
         const newMocks = {
+            mockExistsSync: jest.fn().mockReturnValue(true),
             mockReadFileSync: jest.fn(),
-            mockWriteSync: jest.fn(),
+            mockWriteFileSync: jest.fn(),
+            mockOpenSync: jest.fn().mockReturnValue(process.stdout.fd),
+            mockMkdirSync: jest.fn(),
             mockFileRead: { overrides: { CredentialManager: "@zowe/cli" } },
             zoweDir: path.normalize("__tests__/.zowe/settings/imperative.json"),
             fileHandle: process.stdout.fd,
-            encoding: "utf-8",
         };
-        Object.defineProperty(fs, "writeSync", { value: newMocks.mockWriteSync, configurable: true });
-        Object.defineProperty(fs, "existsSync", {
-            value: () => {
-                return true;
-            },
-            configurable: true,
-        });
+        Object.defineProperty(fs, "existsSync", { value: newMocks.mockExistsSync, configurable: true });
+        Object.defineProperty(fs, "readFileSync", { value: newMocks.mockReadFileSync, configurable: true });
+        Object.defineProperty(fs, "writeFileSync", { value: newMocks.mockWriteFileSync, configurable: true });
+        Object.defineProperty(fs, "openSync", { value: newMocks.mockOpenSync, configurable: true });
+        Object.defineProperty(fs, "mkdirSync", { value: newMocks.mockMkdirSync, configurable: true });
         Object.defineProperty(Gui, "errorMessage", { value: jest.fn(), configurable: true });
+        Object.defineProperty(globals, "setGlobalSecurityValue", { value: jest.fn(), configurable: true });
         Object.defineProperty(globals, "LOG", { value: jest.fn(), configurable: true });
         Object.defineProperty(globals.LOG, "error", { value: jest.fn(), configurable: true });
         return newMocks;
     }
-    it("should have file exist", async () => {
-        const blockMocks = createBlockMocks();
-        const fileJson = { overrides: { CredentialManager: "@zowe/cli", testValue: true } };
-        const content = JSON.stringify(fileJson, null, 2);
-        jest.spyOn(fs, "readFileSync").mockReturnValueOnce(JSON.stringify({ overrides: { CredentialManager: false, testValue: true } }, null, 2));
-        const spyOpen = jest.spyOn(fs, "openSync");
-        const spyWrite = jest.spyOn(fs, "writeSync");
-        profileUtils.writeOverridesFile();
-        expect(spyOpen).toBeCalledWith(blockMocks.zoweDir, "r+");
-        expect(spyWrite).toBeCalledWith(blockMocks.fileHandle, content, 0, blockMocks.encoding);
-        spyOpen.mockClear();
-        spyWrite.mockClear();
+
+    describe("errorHandling", () => {
+        it("should log error details", async () => {
+            createBlockMocks();
+            const errorDetails = new Error("i haz error");
+            const label = "test";
+            const moreInfo = "Task failed successfully";
+            await profileUtils.errorHandling(errorDetails, label, moreInfo);
+            expect(Gui.errorMessage).toBeCalledWith(`${moreInfo} ` + errorDetails);
+            expect(globals.LOG.error).toBeCalledWith(`Error: ${errorDetails.message}\n` + JSON.stringify({ errorDetails, label, moreInfo }));
+        });
+
+        it("should handle error and open config file", async () => {
+            const errorDetails = {
+                mDetails: {
+                    errorCode: 404,
+                },
+                toString: () => "hostname",
+            };
+            const label = "test";
+            const moreInfo = "Task failed successfully";
+            const spyOpenConfigFile = jest.fn();
+            Object.defineProperty(Profiles, "getInstance", {
+                value: () => ({
+                    getProfileInfo: () => ({
+                        usingTeamConfig: true,
+                        getAllProfiles: () => [
+                            {
+                                profName: "test",
+                                profLoc: {
+                                    osLoc: ["test"],
+                                },
+                            },
+                        ],
+                    }),
+                    openConfigFile: spyOpenConfigFile,
+                }),
+            });
+            await profileUtils.errorHandling(errorDetails, label, moreInfo);
+            expect(spyOpenConfigFile).toBeCalledTimes(1);
+        });
+
+        it("should handle error and prompt for authentication", async () => {
+            const errorDetails = {
+                mDetails: {
+                    errorCode: 401,
+                    additionalDetails: "Token is not valid or expired.",
+                },
+                toString: () => "error",
+            };
+            const label = "test";
+            const moreInfo = "Task failed successfully";
+            jest.spyOn(profileUtils, "isTheia").mockReturnValue(false);
+            const showMessageSpy = jest.spyOn(Gui, "showMessage").mockResolvedValue("selection");
+            const ssoLoginSpy = jest.fn();
+            Object.defineProperty(Profiles, "getInstance", {
+                value: () => ({
+                    ssoLogin: ssoLoginSpy,
+                }),
+            });
+            await profileUtils.errorHandling(errorDetails, label, moreInfo);
+            expect(showMessageSpy).toBeCalledTimes(1);
+            expect(ssoLoginSpy).toBeCalledTimes(1);
+        });
     });
-    it("should have no change to global variable PROFILE_SECURITY and returns", async () => {
-        const fileJson = {
-            test: null,
-        };
-        jest.spyOn(fs, "readFileSync").mockReturnValueOnce(JSON.stringify(fileJson, null, 2));
-        const spy = jest.spyOn(fs, "writeSync");
-        profileUtils.writeOverridesFile();
-        expect(spy).toBeCalledTimes(0);
-        spy.mockClear();
+
+    describe("readConfigFromDisk", () => {
+        it("should readConfigFromDisk and log 'Not Available'", async () => {
+            Object.defineProperty(vscode.workspace, "workspaceFolders", {
+                value: [
+                    {
+                        uri: {
+                            fsPath: "./test",
+                        },
+                    },
+                ],
+                configurable: true,
+            });
+            const mockReadProfilesFromDisk = jest.fn();
+            jest.spyOn(zowe.imperative, "ProfileInfo").mockResolvedValue({
+                readProfilesFromDisk: mockReadProfilesFromDisk,
+                usingTeamConfig: true,
+                getTeamConfig: () => ({
+                    layers: [
+                        {
+                            path: "test",
+                            exists: true,
+                            properties: {
+                                defaults: "test",
+                            },
+                        },
+                        {
+                            path: "test",
+                            exists: true,
+                            properties: {},
+                        },
+                    ],
+                }),
+            } as never);
+            Object.defineProperty(globals.LOG, "debug", {
+                value: jest.fn(),
+                configurable: true,
+            });
+            await expect(profileUtils.readConfigFromDisk()).resolves.not.toThrow();
+            expect(mockReadProfilesFromDisk).toHaveBeenCalledTimes(1);
+        });
+
+        it("should readConfigFromDisk and find with defaults", async () => {
+            Object.defineProperty(vscode.workspace, "workspaceFolders", {
+                value: [
+                    {
+                        uri: {
+                            fsPath: "./test",
+                        },
+                    },
+                ],
+                configurable: true,
+            });
+            const mockReadProfilesFromDisk = jest.fn();
+            jest.spyOn(zowe.imperative, "ProfileInfo").mockResolvedValue({
+                readProfilesFromDisk: mockReadProfilesFromDisk,
+                usingTeamConfig: true,
+                getTeamConfig: () => [],
+            } as never);
+            Object.defineProperty(globals.LOG, "debug", {
+                value: jest.fn(),
+                configurable: true,
+            });
+            await expect(profileUtils.readConfigFromDisk()).resolves.not.toThrow();
+            expect(mockReadProfilesFromDisk).toHaveBeenCalledTimes(1);
+        });
     });
-    it("should have not exist and create default file", async () => {
-        const blockMocks = createBlockMocks();
-        Object.defineProperty(fs, "openSync", {
-            value: (path: string, mode: string) => {
+
+    describe("promptCredentials", () => {
+        it("calls getProfileInfo", async () => {
+            const mockProfileInstance = new Profiles(zowe.imperative.Logger.getAppLogger());
+            Object.defineProperty(Profiles, "getInstance", {
+                value: () => mockProfileInstance,
+                configurable: true,
+            });
+            Object.defineProperty(mockProfileInstance, "getProfileInfo", {
+                value: jest.fn(() => {
+                    return {
+                        profileName: "emptyConfig",
+                    };
+                }),
+                configurable: true,
+            });
+            Object.defineProperty(vscode.window, "showInputBox", {
+                value: jest.fn().mockResolvedValue(undefined),
+                configurable: true,
+            });
+            await profileUtils.promptCredentials(null);
+            expect(mockProfileInstance.getProfileInfo).toHaveBeenCalled();
+        });
+
+        it("shows a message if Update Credentials operation is called when autoStore = false", async () => {
+            const mockProfileInstance = new Profiles(zowe.imperative.Logger.getAppLogger());
+            Object.defineProperty(Profiles, "getInstance", {
+                value: () => mockProfileInstance,
+                configurable: true,
+            });
+            Object.defineProperty(mockProfileInstance, "getProfileInfo", {
+                value: jest.fn(() => {
+                    return {
+                        profileName: "emptyConfig",
+                        usingTeamConfig: true,
+                        getTeamConfig: jest.fn().mockReturnValueOnce({
+                            properties: {
+                                autoStore: false,
+                            },
+                        }),
+                    };
+                }),
+                configurable: true,
+            });
+            Object.defineProperty(Gui, "showMessage", {
+                value: jest.fn(),
+                configurable: true,
+            });
+            await profileUtils.promptCredentials(null);
+            expect(mockProfileInstance.getProfileInfo).toHaveBeenCalled();
+            expect(Gui.showMessage).toHaveBeenCalledWith('"Update Credentials" operation not supported when "autoStore" is false');
+        });
+    });
+
+    describe("initializeZoweFolder", () => {
+        it("should create directories and files that do not exist", async () => {
+            const blockMocks = createBlockMocks();
+            blockMocks.mockExistsSync.mockReturnValue(false);
+            await profileUtils.initializeZoweFolder();
+            expect(blockMocks.mockMkdirSync).toHaveBeenCalledTimes(2);
+            expect(blockMocks.mockWriteFileSync).toHaveBeenCalledTimes(1);
+        });
+
+        it("should skip creating directories and files that already exist", async () => {
+            const blockMocks = createBlockMocks();
+            blockMocks.mockExistsSync.mockReturnValue(true);
+            await profileUtils.initializeZoweFolder();
+            expect(blockMocks.mockMkdirSync).toHaveBeenCalledTimes(0);
+            expect(blockMocks.mockWriteFileSync).toHaveBeenCalledTimes(0);
+        });
+    });
+
+    describe("writeOverridesFile", () => {
+        it("should have file exist", async () => {
+            const blockMocks = createBlockMocks();
+            const fileJson = { overrides: { CredentialManager: "@zowe/cli", testValue: true } };
+            const content = JSON.stringify(fileJson, null, 2);
+            blockMocks.mockReadFileSync.mockReturnValueOnce(JSON.stringify({ overrides: { CredentialManager: false, testValue: true } }, null, 2));
+            profileUtils.writeOverridesFile();
+            expect(blockMocks.mockOpenSync).toBeCalledWith(blockMocks.zoweDir, "r+");
+            expect(blockMocks.mockWriteFileSync).toBeCalledWith(blockMocks.fileHandle, content);
+        });
+
+        it("should have no change to global variable PROFILE_SECURITY and returns", async () => {
+            const blockMocks = createBlockMocks();
+            const fileJson = {
+                test: null,
+            };
+            blockMocks.mockReadFileSync.mockReturnValueOnce(JSON.stringify(fileJson, null, 2));
+            profileUtils.writeOverridesFile();
+            expect(blockMocks.mockWriteFileSync).toBeCalledTimes(0);
+        });
+
+        it("should have not exist and create default file", async () => {
+            const blockMocks = createBlockMocks();
+            blockMocks.mockOpenSync.mockImplementation((path: string, mode: string) => {
                 if (mode.startsWith("r")) {
                     throw new Error("ENOENT");
                 }
                 return blockMocks.fileHandle;
-            },
-            configurable: true,
+            });
+            const content = JSON.stringify(blockMocks.mockFileRead, null, 2);
+            profileUtils.writeOverridesFile();
+            expect(blockMocks.mockWriteFileSync).toBeCalledWith(blockMocks.fileHandle, content);
+            expect(blockMocks.mockOpenSync).toBeCalledTimes(2);
+            expect(blockMocks.mockReadFileSync).toBeCalledTimes(0);
         });
-        const content = JSON.stringify(blockMocks.mockFileRead, null, 2);
-        const spyOpen = jest.spyOn(fs, "openSync");
-        const spyRead = jest.spyOn(fs, "readFileSync");
-        const spyWrite = jest.spyOn(fs, "writeSync");
-        profileUtils.writeOverridesFile();
-        expect(spyWrite).toBeCalledWith(blockMocks.fileHandle, content, 0, blockMocks.encoding);
-        expect(spyOpen).toBeCalledTimes(2);
-        expect(spyRead).toBeCalledTimes(0);
-        spyOpen.mockClear();
-        spyRead.mockClear();
-        spyWrite.mockClear();
-    });
-    it("should log error details", async () => {
-        createBlockMocks();
-        const errorDetails = new Error("i haz error");
-        const label = "test";
-        const moreInfo = "Task failed successfully";
-        await profileUtils.errorHandling(errorDetails, label, moreInfo);
-        expect(Gui.errorMessage).toBeCalledWith(`${moreInfo} ` + errorDetails);
-        expect(globals.LOG.error).toBeCalledWith(`Error: ${errorDetails.message}\n` + JSON.stringify({ errorDetails, label, moreInfo }));
-    });
-    it("should handle error and open config file", async () => {
-        const errorDetails = {
-            mDetails: {
-                errorCode: 404,
-            },
-            toString: () => "hostname",
-        };
-        const label = "test";
-        const moreInfo = "Task failed successfully";
-        const spyOpenConfigFile = jest.fn();
-        Object.defineProperty(Profiles, "getInstance", {
-            value: () => ({
-                getProfileInfo: () => ({
-                    usingTeamConfig: true,
-                    getAllProfiles: () => [
-                        {
-                            profName: "test",
-                            profLoc: {
-                                osLoc: ["test"],
-                            },
-                        },
-                    ],
-                }),
-                openConfigFile: spyOpenConfigFile,
-            }),
-        });
-        await profileUtils.errorHandling(errorDetails, label, moreInfo);
-        expect(spyOpenConfigFile).toBeCalledTimes(1);
-    });
-    it("should handle error and prompt for authentication", async () => {
-        const errorDetails = {
-            mDetails: {
-                errorCode: 401,
-                additionalDetails: "Token is not valid or expired.",
-            },
-            toString: () => "error",
-        };
-        const label = "test";
-        const moreInfo = "Task failed successfully";
-        jest.spyOn(profileUtils, "isTheia").mockReturnValue(false);
-        const showMessageSpy = jest.spyOn(Gui, "showMessage").mockResolvedValue("selection");
-        const ssoLoginSpy = jest.fn();
-        Object.defineProperty(Profiles, "getInstance", {
-            value: () => ({
-                ssoLogin: ssoLoginSpy,
-            }),
-        });
-        await profileUtils.errorHandling(errorDetails, label, moreInfo);
-        expect(showMessageSpy).toBeCalledTimes(1);
-        expect(ssoLoginSpy).toBeCalledTimes(1);
-    });
-});
 
-describe("ProfileUtils.promptCredentials Unit Tests", () => {
-    it("calls getProfileInfo", async () => {
-        const mockProfileInstance = new Profiles(zowe.imperative.Logger.getAppLogger());
-        Object.defineProperty(Profiles, "getInstance", {
-            value: () => mockProfileInstance,
-            configurable: true,
+        it("should throw error if overrides file contains invalid JSON", async () => {
+            const blockMocks = createBlockMocks();
+            const fileJson = {
+                test: null,
+            };
+            blockMocks.mockReadFileSync.mockReturnValueOnce(JSON.stringify(fileJson, null, 2).slice(1));
+            expect(profileUtils.writeOverridesFile).toThrow();
         });
-        Object.defineProperty(mockProfileInstance, "getProfileInfo", {
-            value: jest.fn(() => {
-                return {
-                    profileName: "emptyConfig",
-                };
-            }),
-            configurable: true,
-        });
-        Object.defineProperty(vscode.window, "showInputBox", {
-            value: jest.fn().mockResolvedValue(undefined),
-            configurable: true,
-        });
-        await profileUtils.promptCredentials(null);
-        expect(mockProfileInstance.getProfileInfo).toHaveBeenCalled();
     });
-    it("shows a message if Update Credentials operation is called when autoStore = false", async () => {
-        const mockProfileInstance = new Profiles(zowe.imperative.Logger.getAppLogger());
-        Object.defineProperty(Profiles, "getInstance", {
-            value: () => mockProfileInstance,
-            configurable: true,
-        });
-        Object.defineProperty(mockProfileInstance, "getProfileInfo", {
-            value: jest.fn(() => {
-                return {
-                    profileName: "emptyConfig",
-                    usingTeamConfig: true,
-                    getTeamConfig: jest.fn().mockReturnValueOnce({
-                        properties: {
-                            autoStore: false,
-                        },
-                    }),
-                };
-            }),
-            configurable: true,
-        });
-        Object.defineProperty(Gui, "showMessage", {
-            value: jest.fn(),
-            configurable: true,
-        });
-        await profileUtils.promptCredentials(null);
-        expect(mockProfileInstance.getProfileInfo).toHaveBeenCalled();
-        expect(Gui.showMessage).toHaveBeenCalledWith('"Update Credentials" operation not supported when "autoStore" is false');
-    });
-});
 
-describe("ProfileUtils.readConfigFromDisk Unit Tests", () => {
-    it("should readConfigFromDisk and log 'Not Available'", async () => {
-        Object.defineProperty(vscode.workspace, "workspaceFolders", {
-            value: [
-                {
-                    uri: {
-                        fsPath: "./test",
-                    },
-                },
-            ],
-            configurable: true,
-        });
-        const mockReadProfilesFromDisk = jest.fn();
-        jest.spyOn(zowe.imperative, "ProfileInfo").mockResolvedValue({
-            readProfilesFromDisk: mockReadProfilesFromDisk,
-            usingTeamConfig: true,
-            getTeamConfig: () => ({
-                layers: [
-                    {
-                        path: "test",
-                        exists: true,
-                        properties: {
-                            defaults: "test",
-                        },
-                    },
-                    {
-                        path: "test",
-                        exists: true,
-                        properties: {},
-                    },
-                ],
-            }),
-        } as never);
-        Object.defineProperty(globals.LOG, "debug", {
-            value: jest.fn(),
-            configurable: true,
-        });
-        await expect(profileUtils.readConfigFromDisk()).resolves.not.toThrow();
-        expect(mockReadProfilesFromDisk).toHaveBeenCalledTimes(1);
-    });
-    it("should readConfigFromDisk and find with defaults", async () => {
-        Object.defineProperty(vscode.workspace, "workspaceFolders", {
-            value: [
-                {
-                    uri: {
-                        fsPath: "./test",
-                    },
-                },
-            ],
-            configurable: true,
-        });
-        const mockReadProfilesFromDisk = jest.fn();
-        jest.spyOn(zowe.imperative, "ProfileInfo").mockResolvedValue({
-            readProfilesFromDisk: mockReadProfilesFromDisk,
-            usingTeamConfig: true,
-            getTeamConfig: () => [],
-        } as never);
-        Object.defineProperty(globals.LOG, "debug", {
-            value: jest.fn(),
-            configurable: true,
-        });
-        await expect(profileUtils.readConfigFromDisk()).resolves.not.toThrow();
-        expect(mockReadProfilesFromDisk).toHaveBeenCalledTimes(1);
-    });
-});
-
-describe("ProfileUtils.filterItem Unit Tests", () => {
-    it("should get label if the filterItem icon exists", () => {
+    it("filterItem should get label if the filterItem icon exists", () => {
         const testFilterItem = new profileUtils.FilterItem({
             icon: "test",
         } as any);

--- a/packages/zowe-explorer/i18n/sample/src/utils/ProfilesUtils.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/utils/ProfilesUtils.i18n.json
@@ -10,5 +10,6 @@
   "createNewConnection.option.prompt.profileName.placeholder": "Connection Name",
   "createNewConnection.option.prompt.profileName": "Enter a name for the connection.",
   "createNewConnection.undefined.passWord": "Operation Cancelled",
-  "promptCredentials.updatedCredentials": "Credentials for {0} were successfully updated"
+  "promptCredentials.updatedCredentials": "Credentials for {0} were successfully updated",
+  "writeOverridesFile.jsonParseError": "Failed to parse JSON file {0}:"
 }

--- a/packages/zowe-explorer/src/Profiles.ts
+++ b/packages/zowe-explorer/src/Profiles.ts
@@ -555,7 +555,7 @@ export class Profiles extends ProfilesCache {
 
             return updSchemaValues;
         } catch (error) {
-            await errorHandling(error.message);
+            await errorHandling(error, profileName, error.message);
         }
     }
 
@@ -839,7 +839,7 @@ export class Profiles extends ProfilesCache {
             await readConfigFromDisk();
             return newProfileName;
         } catch (error) {
-            await errorHandling(error.message);
+            await errorHandling(error, profileName, error.message);
             ZoweExplorerExtender.showZoweConfigError(error.message);
         }
     }

--- a/packages/zowe-explorer/src/Profiles.ts
+++ b/packages/zowe-explorer/src/Profiles.ts
@@ -92,7 +92,7 @@ export class Profiles extends ProfilesCache {
             });
             let values: string[];
             try {
-                values = await Profiles.getInstance().promptCredentials(theProfile.name);
+                values = await Profiles.getInstance().promptCredentials(theProfile);
             } catch (error) {
                 errorHandling(
                     error,
@@ -844,7 +844,7 @@ export class Profiles extends ProfilesCache {
         }
     }
 
-    public async promptCredentials(sessionName: string, rePrompt?: boolean): Promise<string[]> {
+    public async promptCredentials(profile: string | zowe.imperative.IProfileLoaded, rePrompt?: boolean): Promise<string[]> {
         const userInputBoxOptions: vscode.InputBoxOptions = {
             placeHolder: localize("createNewConnection.option.prompt.username.placeholder", "User Name"),
             prompt: localize("createNewConnection.option.prompt.username", "Enter the user name for the connection. Leave blank to not store."),
@@ -856,7 +856,8 @@ export class Profiles extends ProfilesCache {
 
         const promptInfo = await ZoweVsCodeExtension.updateCredentials(
             {
-                sessionName,
+                sessionName: typeof profile !== "string" ? profile.name : profile,
+                sessionType: typeof profile !== "string" ? profile.type : undefined,
                 rePrompt,
                 secure: (await this.getProfileInfo()).isSecured(),
                 userInputBoxOptions,

--- a/packages/zowe-explorer/src/ZoweExplorerExtender.ts
+++ b/packages/zowe-explorer/src/ZoweExplorerExtender.ts
@@ -27,7 +27,6 @@ import {
     ProfilesCache,
     getZoweDir,
     getFullPath,
-    MessageSeverity,
 } from "@zowe/zowe-explorer-api";
 import { Profiles } from "./Profiles";
 import { ZoweExplorerApiRegister } from "./ZoweExplorerApiRegister";

--- a/packages/zowe-explorer/src/ZoweExplorerExtender.ts
+++ b/packages/zowe-explorer/src/ZoweExplorerExtender.ts
@@ -58,12 +58,9 @@ export class ZoweExplorerExtender implements ZoweExplorerApi.IApiExplorerExtende
             errorHandling(errorDetails);
             return;
         }
-        Gui.showMessage(
+        Gui.errorMessage(
             localize("initialize.profiles.error", 'Error encountered when loading your Zowe config. Click "Show Config" for more details.'),
-            {
-                severity: MessageSeverity.ERROR,
-                items: ["Show Config"],
-            }
+            { items: ["Show Config"] }
         ).then((selection) => {
             if (selection !== "Show Config") {
                 return;

--- a/packages/zowe-explorer/src/uss/actions.ts
+++ b/packages/zowe-explorer/src/uss/actions.ts
@@ -64,7 +64,6 @@ export async function createUSSNode(node: IZoweUSSTreeNode, ussFileProvider: IZo
             filePath = `${filePath}/${name}`;
             await ZoweExplorerApiRegister.getUssApi(node.getProfile()).create(filePath, nodeType);
             if (isTopLevel) {
-                await Profiles.getInstance().refresh(ZoweExplorerApiRegister.getInstance());
                 refreshAll(ussFileProvider);
             } else {
                 ussFileProvider.refreshElement(node);

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -287,11 +287,9 @@ export async function promptCredentials(node: IZoweTreeNode) {
             return;
         }
         profileName = profileName.trim();
-    } else {
-        profileName = node.getProfile().name;
     }
 
-    const creds = await Profiles.getInstance().promptCredentials(profileName, true);
+    const creds = await Profiles.getInstance().promptCredentials(profileName ?? node.getProfile(), true);
 
     if (creds != null) {
         Gui.showMessage(localize("promptCredentials.updatedCredentials", "Credentials for {0} were successfully updated", profileName));

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -244,30 +244,26 @@ export function getProfile(node: vscode.TreeItem) {
 
 export async function readConfigFromDisk() {
     let rootPath: string;
-    try {
-        const mProfileInfo = await getProfileInfo(globals.ISTHEIA);
-        if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0]) {
-            rootPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
-            await mProfileInfo.readProfilesFromDisk({ homeDir: getZoweDir(), projectDir: getFullPath(rootPath) });
-        } else {
-            await mProfileInfo.readProfilesFromDisk({ homeDir: getZoweDir(), projectDir: undefined });
-        }
-        if (mProfileInfo.usingTeamConfig) {
-            globals.setConfigPath(rootPath);
-            globals.LOG.debug('Zowe Explorer is using the team configuration file "%s"', mProfileInfo.getTeamConfig().configName);
-            const layers = mProfileInfo.getTeamConfig().layers || [];
-            const layerSummary = layers.map(
-                (config: imperative.IConfigLayer) =>
-                    `Path: ${config.path}: ${
-                        config.exists
-                            ? "Found, with the following defaults:" + JSON.stringify(config.properties?.defaults || "Undefined default")
-                            : "Not available"
-                    } `
-            );
-            globals.LOG.debug("Summary of team configuration files considered for Zowe Explorer: %s", JSON.stringify(layerSummary));
-        }
-    } catch (error) {
-        throw new Error(error);
+    const mProfileInfo = await getProfileInfo(globals.ISTHEIA);
+    if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0]) {
+        rootPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
+        await mProfileInfo.readProfilesFromDisk({ homeDir: getZoweDir(), projectDir: getFullPath(rootPath) });
+    } else {
+        await mProfileInfo.readProfilesFromDisk({ homeDir: getZoweDir(), projectDir: undefined });
+    }
+    if (mProfileInfo.usingTeamConfig) {
+        globals.setConfigPath(rootPath);
+        globals.LOG.debug('Zowe Explorer is using the team configuration file "%s"', mProfileInfo.getTeamConfig().configName);
+        const layers = mProfileInfo.getTeamConfig().layers || [];
+        const layerSummary = layers.map(
+            (config: imperative.IConfigLayer) =>
+                `Path: ${config.path}: ${
+                    config.exists
+                        ? "Found, with the following defaults:" + JSON.stringify(config.properties?.defaults || "Undefined default")
+                        : "Not available"
+                } `
+        );
+        globals.LOG.debug("Summary of team configuration files considered for Zowe Explorer: %s", JSON.stringify(layerSummary));
     }
 }
 
@@ -361,7 +357,7 @@ export function writeOverridesFile() {
             settings = { overrides: { CredentialManager: globals.PROFILE_SECURITY } };
         }
         fileContent = JSON.stringify(settings, null, 2);
-        fs.writeFileSync(fd, fileContent);
+        fs.writeFileSync(fd, fileContent, "utf-8");
     } finally {
         fs.closeSync(fd);
     }


### PR DESCRIPTION
## Proposed changes

Fixes #2187 by implementing the following behavior:
* When ZE launches it should create `imperative.json` if it doesn't exist, but should not overwrite the file if it already exists unless requested to.
* When ZE updates the contents of `imperative.json` it should remove all old contents from the file even if the new contents are shorter.
* When ZE fails to parse the contents of `imperative.json` it should show an error message that accurately conveys what happened.

Also fixes a few other credential-related issues discovered when testing the K8s plugin:
* The utility method `readConfigFromDisk` was catching errors and rethrowing them with less information, which can make it difficult to debug problems with loading custom credential managers.
* When v1 profiles are in use, right-clicking on a session and selecting "Update Credentials" may update credentials for the wrong profile if another profile exists with a different type but the same name.

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog -->
<!-- If there is a linked issue, it should have the same milestone as this PR -->

Milestone: 2.8.0

Changelog: Fixed custom credential manager in `~/.zowe/settings/imperative.json` file being overwritten with invalid JSON.

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [ ] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [ ] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [x] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
