### PR TITLE
fix(vscode): Added back multi-select fix; remove 'Paste' from dataset multi-select

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
+- Added back fix that was accidentally removed between updates: Resolved an issue where VSCode did not provide all context menu options for a profile node after a multi-select operation. [#2108](https://github.com/zowe/vscode-extension-for-zowe/pull/2108)
+- Fixed issue where "Paste" option is shown for a multi-select operation in the "Data Sets" pane.
+
 ## `2.7.0`
 
 ### New features and enhancements

--- a/packages/zowe-explorer/__tests__/__unit__/dataset/init.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/dataset/init.unit.test.ts
@@ -181,7 +181,7 @@ describe("Test src/dataset/extension", () => {
                 name: "zowe.ds.pasteDataSets:1",
                 parm: [false],
                 mock: [
-                    { spy: jest.spyOn(dsProvider, "getTreeView"), arg: [], ret: { selection: [test.value] } },
+                    { spy: jest.spyOn(dsProvider, "getTreeView"), arg: [], ret: { reveal: jest.fn(), selection: [test.value] } },
                     { spy: jest.spyOn(dsActions, "pasteDataSetMembers"), arg: [dsProvider, test.value] },
                     { spy: jest.spyOn(dsActions, "refreshDataset"), arg: ["test", dsProvider] },
                 ],
@@ -189,6 +189,7 @@ describe("Test src/dataset/extension", () => {
             {
                 name: "zowe.ds.pasteDataSets:2",
                 mock: [
+                    { spy: jest.spyOn(dsProvider, "getTreeView"), arg: [], ret: { reveal: jest.fn(), selection: [test.value] } },
                     { spy: jest.spyOn(dsActions, "pasteDataSetMembers"), arg: [dsProvider, test.value] },
                     { spy: jest.spyOn(dsActions, "refreshDataset"), arg: ["test", dsProvider] },
                 ],

--- a/packages/zowe-explorer/__tests__/__unit__/uss/init.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/init.unit.test.ts
@@ -42,6 +42,9 @@ describe("Test src/dataset/extension", () => {
             ssoLogin: jest.fn(),
             ssoLogout: jest.fn(),
             onDidChangeConfiguration: jest.fn(),
+            getTreeView: jest.fn().mockReturnValue({
+                reveal: jest.fn(),
+            }),
         };
         const commands: IJestIt[] = [
             {

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -112,7 +112,7 @@
         "command": "zowe.ds.pasteDataSets",
         "key": "ctrl+v",
         "mac": "cmd+v",
-        "when": "focusedView == zowe.ds.explorer"
+        "when": "focusedView == zowe.ds.explorer && !listSupportsMultiselect"
       }
     ],
     "commands": [
@@ -1014,7 +1014,7 @@
           "group": "001_zowe_dsCreate@6"
         },
         {
-          "when": "view == zowe.ds.explorer && viewItem =~ /^(?!.*profile=zftp.*)(session|pds).*/",
+          "when": "view == zowe.ds.explorer && viewItem =~ /^(?!.*profile=zftp.*)(session|pds).*/ && !listMultiSelection",
           "command": "zowe.ds.pasteDataSets",
           "group": "001_zowe_dsCreate@7"
         },

--- a/packages/zowe-explorer/src/dataset/init.ts
+++ b/packages/zowe-explorer/src/dataset/init.ts
@@ -20,6 +20,7 @@ import { ZoweDatasetNode } from "./ZoweDatasetNode";
 import * as contextuals from "../shared/context";
 import { getSelectedNodeList } from "../shared/utils";
 import { initSubscribers } from "../shared/init";
+import { TreeViewUtils } from "../utils/TreeViewUtils";
 
 export async function initDatasetProvider(context: vscode.ExtensionContext) {
     const datasetProvider: IZoweTree<IZoweDatasetTreeNode> = await createDatasetTree(globals.LOG);
@@ -104,6 +105,7 @@ export async function initDatasetProvider(context: vscode.ExtensionContext) {
             for (const select of selectedNodes) {
                 datasetProvider.deleteSession(select);
             }
+            TreeViewUtils.fixVsCodeMultiSelect(datasetProvider);
         })
     );
     context.subscriptions.push(

--- a/packages/zowe-explorer/src/uss/init.ts
+++ b/packages/zowe-explorer/src/uss/init.ts
@@ -19,6 +19,7 @@ import * as contextuals from "../shared/context";
 import { getSelectedNodeList } from "../shared/utils";
 import { createUSSTree } from "./USSTree";
 import { initSubscribers } from "../shared/init";
+import { TreeViewUtils } from "../utils/TreeViewUtils";
 
 export async function initUSSProvider(context: vscode.ExtensionContext) {
     const ussFileProvider: IZoweTree<IZoweUSSTreeNode> = await createUSSTree(globals.LOG);
@@ -85,6 +86,7 @@ export async function initUSSProvider(context: vscode.ExtensionContext) {
             for (const item of selectedNodes) {
                 ussFileProvider.deleteSession(item);
             }
+            TreeViewUtils.fixVsCodeMultiSelect(ussFileProvider);
         })
     );
     context.subscriptions.push(


### PR DESCRIPTION
## Proposed changes

Looks like the function call to `TreeViewUtils.fixVsCodeMultiSelect` (VSCode multi-select bug workaround) was removed in a previous commit to the codebase.

This adds back the function calls for USS and Dataset trees, and also removes the "Paste" option from dataset multi-select, as it currently only supports one selected node per operation.

## Release Notes

Milestone: 2.8.0

Changelog: 

- Added back fix that was accidentally removed between updates: Resolved an issue where VSCode did not provide all context menu options for a profile node after a multi-select operation. [#2108](https://github.com/zowe/vscode-extension-for-zowe/pull/2108)
- Fixed issue where "Paste" option is shown for a multi-select operation in the "Data Sets" pane (currently unsupported).

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [x] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
