### PR TITLE
fix(cwe): `null`-like node in `ProfilesUtils.promptCredentials`

### DIFF
--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -273,26 +273,33 @@ export async function promptCredentials(node: IZoweTreeNode) {
         Gui.showMessage(localize("zowe.promptCredentials.notSupported", '"Update Credentials" operation not supported when "autoStore" is false'));
         return;
     }
-    let profileName: string;
-    if (node == null) {
+    let profile: string | imperative.IProfileLoaded = node?.getProfile();
+    if (profile == null) {
         // prompt for profile
-        profileName = await Gui.showInputBox({
-            placeHolder: localize("createNewConnection.option.prompt.profileName.placeholder", "Connection Name"),
-            prompt: localize("createNewConnection.option.prompt.profileName", "Enter a name for the connection."),
-            ignoreFocusOut: true,
-        });
+        profile = (
+            await Gui.showInputBox({
+                placeHolder: localize("createNewConnection.option.prompt.profileName.placeholder", "Connection Name"),
+                prompt: localize("createNewConnection.option.prompt.profileName", "Enter a name for the connection."),
+                ignoreFocusOut: true,
+            })
+        ).trim();
 
-        if (profileName === undefined) {
+        if (!profile) {
             Gui.showMessage(localize("createNewConnection.undefined.passWord", "Operation Cancelled"));
             return;
         }
-        profileName = profileName.trim();
     }
 
-    const creds = await Profiles.getInstance().promptCredentials(profileName ?? node.getProfile(), true);
+    const creds = await Profiles.getInstance().promptCredentials(profile, true);
 
     if (creds != null) {
-        Gui.showMessage(localize("promptCredentials.updatedCredentials", "Credentials for {0} were successfully updated", profileName));
+        Gui.showMessage(
+            localize(
+                "promptCredentials.updatedCredentials",
+                "Credentials for {0} were successfully updated",
+                typeof profile === "string" ? profile : profile.name
+            )
+        );
     }
 }
 


### PR DESCRIPTION
## Proposed changes

There was a null-like access of `node` when trying to determine profile info, specifically when updating credentials. This should resolve the CWE on Coverity.

## Release Notes

Milestone: 2.8.0

Changelog: 

- Fixed issue where a node is accessed while updating credentials, even if the node is invalid.

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [x] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
