### PR TITLE
fix(deps): Add `postinstall` script to ZE API

### DIFF
--- a/packages/zowe-explorer-api/package.json
+++ b/packages/zowe-explorer-api/package.json
@@ -26,6 +26,7 @@
     "lint": "concurrently -n \"_eslint_,prettier\" \"eslint .\" \"prettier --check .\"",
     "lintErrors": "echo \"zowe-explorer-api: coming soon.\"",
     "pretty": "prettier --write .",
+    "postinstall": "yarn",
     "clean": "rimraf lib",
     "fresh-clone": "yarn clean && rimraf node_modules",
     "license": "node ../../scripts/updateLicenses.js",


### PR DESCRIPTION
## Proposed changes

Adds a `postinstall` script to the ZE API scripts. This should help resolve edge-case scenarios where `imperative` is not properly imported, but is referenced through the ZE API.

**Note:** Although frowned upon, would it be worth changing this script to `npm install`? This way, the `postinstall` script will also work for users that are using NPM, but don't have Yarn installed.

## Release Notes

Milestone: 2.8.0

Changelog:

- Added `postinstall` script to ZE API to pull dependencies as a safety measure, specifically to help with cases where import conflicts occur with `imperative`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
