### PR TITLE
fix(fs): `realpathSync.native` sometimes fails on Windows

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 - Fixed credentials being updated for wrong v1 profile if multiple profiles had different types but same name.
 - Updated dependencies for security audits.
+- Added fallback for `realPathSync` to resolve edge cases where the native call fails on Windows systems. [#1773](https://github.com/zowe/vscode-extension-for-zowe/issues/1773)
 
 ## `2.7.0`
 

--- a/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
+++ b/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
@@ -50,7 +50,11 @@ export function getZoweDir(): string {
 
 export function getFullPath(anyPath: string): string {
     if (os.platform() === "win32") {
-        return fs.realpathSync.native(anyPath);
+        try {
+            return fs.realpathSync.native(anyPath);
+        } catch (err) {
+            // Fallback to realpathSync below
+        }
     }
     return fs.realpathSync(anyPath);
 }


### PR DESCRIPTION
## Proposed changes

Sometimes `fs.realpathSync.native` will throw an error on Windows. Previously, we were defaulting to this method for Windows systems, but were not catching any exceptions from this function within `getFullPath`.

This proposes a fallback to `fs.realpathSync` when `fs.realpathSync.native` throws an error. Thanks @t1m0thyj for finding where realpath was referenced and for the helpful discussion 🙂 

Inspired by [this issue](https://github.com/SimenB/realpath-native/issues/35), from a repo that proposed the addition of this implementation into Node.js.

## Release Notes

Milestone: 2.8.0

Changelog:

- Resolved an issue where Windows users encountered errors, specifically while Zowe Explorer is building the path for a project directory. (This should help with [this issue](https://github.com/zowe/vscode-extension-for-zowe/issues/1773))

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)
