### PR TITLE
Fix error message when no data sets found

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed issue where "Paste" option is shown for a multi-select operation in the "Data Sets" pane.
 - Fixed z/OSMF profiles issue with Data Sets and Jobs with special characters in the names. [#2175](https://github.com/zowe/vscode-extension-for-zowe/issues/2175)
 - Fixed redundant text in error messages that included the same error details twice.
+- Fixed error message when no data sets found that match pattern.
 
 ## `2.7.0`
 

--- a/packages/zowe-explorer/__tests__/__integration__/extension.integration.test.ts
+++ b/packages/zowe-explorer/__tests__/__integration__/extension.integration.test.ts
@@ -896,7 +896,7 @@ async function getAllNodes(nodes: IZoweTreeNode[]) {
 
     for (const node of nodes) {
         let nodeChildren = await node.getChildren();
-        nodeChildren = nodeChildren.filter((item) => !item.label.toString().includes("No datasets found"));
+        nodeChildren = nodeChildren.filter((item) => !item.label.toString().includes("No data sets found"));
         allNodes = allNodes.concat(await getAllNodes(nodeChildren));
         allNodes.push(node);
     }

--- a/packages/zowe-explorer/__tests__/__unit__/ZoweNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/ZoweNode.unit.test.ts
@@ -214,7 +214,7 @@ describe("Unit Tests (Jest)", () => {
      * Checks that returning an unsuccessful response results in an error being thrown and caught
      *************************************************************************************************************/
     it(
-        "Checks that when bright.List.dataSet/allMembers() returns an unsuccessful response, " + "it returns a label of 'No datasets found'",
+        "Checks that when bright.List.dataSet/allMembers() returns an unsuccessful response, " + "it returns a label of 'No data sets found'",
         async () => {
             Object.defineProperty(Profiles, "getInstance", {
                 value: jest.fn(() => {
@@ -246,7 +246,7 @@ describe("Unit Tests (Jest)", () => {
             ]);
             subNode.dirty = true;
             const response = await subNode.getChildren();
-            expect(response[0].label).toBe("No datasets found");
+            expect(response[0].label).toBe("No data sets found");
         }
     );
 
@@ -403,6 +403,6 @@ describe("Unit Tests (Jest)", () => {
             };
         });
         Object.defineProperty(List, "allMembers", { value: allMembers });
-        expect((await pds.getChildren())[0].label).toEqual("No datasets found");
+        expect((await pds.getChildren())[0].label).toEqual("No data sets found");
     });
 });

--- a/packages/zowe-explorer/i18n/sample/src/dataset/DatasetTree.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/dataset/DatasetTree.i18n.json
@@ -1,6 +1,6 @@
 {
   "Favorites": "Favorites",
-  "getChildren.noDataset": "No datasets found",
+  "getChildren.noDataset": "No data sets found",
   "initializeFavorites.log.debug": "Initializing profiles with data set favorites.",
   "initializeFavorites.no.favorites": "No data set favorites found.",
   "initializeFavorites.invalidDsFavorite1": "Invalid Data Sets favorite: {0}.",

--- a/packages/zowe-explorer/i18n/sample/src/dataset/ZoweDatasetNode.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/dataset/ZoweDatasetNode.i18n.json
@@ -2,6 +2,6 @@
   "getChildren.search": "Use the search button to display datasets",
   "getChildren.error.invalidNode": "Invalid node",
   "getChildren.responses.error": "The response from Zowe CLI was not successful",
-  "getChildren.noDataset": "No datasets found",
+  "getChildren.noDataset": "No data sets found",
   "getChildren.error.response": "Retrieving response from "
 }

--- a/packages/zowe-explorer/src/dataset/DatasetTree.ts
+++ b/packages/zowe-explorer/src/dataset/DatasetTree.ts
@@ -174,7 +174,7 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
             if (finalResponse.length === 0) {
                 return (element.children = [
                     new ZoweDatasetNode(
-                        localize("getChildren.noDataset", "No datasets found"),
+                        localize("getChildren.noDataset", "No data sets found"),
                         vscode.TreeItemCollapsibleState.None,
                         element,
                         null,
@@ -997,7 +997,7 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
                 for (const child of response) {
                     for (const item of dsSets) {
                         const label = child.label as string;
-                        if (item.member && label !== "No datasets found") {
+                        if (item.member && label !== "No data sets found") {
                             const dsn = item.dsn.split(".");
                             const name = label.split(".");
                             let index = 0;

--- a/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
@@ -129,7 +129,8 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
         const elementChildren: { [k: string]: ZoweDatasetNode } = {};
         for (const response of responses) {
             // Throws reject if the Zowe command does not throw an error but does not succeed
-            if (!response.success) {
+            // The dataSetsMatchingPattern API may return success=false and apiResponse=[] when no data sets found
+            if (!response.success && !(Array.isArray(response.apiResponse) && response.apiResponse.length === 0)) {
                 await errorHandling(localize("getChildren.responses.error", "The response from Zowe CLI was not successful"));
                 return;
             }
@@ -231,7 +232,7 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
         if (Object.keys(elementChildren).length === 0) {
             this.children = [
                 new ZoweDatasetNode(
-                    localize("getChildren.noDataset", "No datasets found"),
+                    localize("getChildren.noDataset", "No data sets found"),
                     vscode.TreeItemCollapsibleState.None,
                     this,
                     null,


### PR DESCRIPTION
## Proposed changes

Fixes a regression in ZE 2.6.0 and restores the original behavior

Before:
![image](https://user-images.githubusercontent.com/22344007/230208732-8e30e32e-6d1a-44ec-af1b-b2416554524b.png)

After:
![image](https://user-images.githubusercontent.com/22344007/230209152-f654c89c-3dfd-4dbc-aae3-9da3a473c1a5.png)

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog -->
<!-- If there is a linked issue, it should have the same milestone as this PR -->

Milestone: 2.8.0

Changelog: Fixed error message when no data sets found that match pattern.

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [ ] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [ ] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
