### PR TITLE
fix(id): IDs cannot be applied to innermost child nodes

### DIFF
--- a/packages/zowe-explorer/__tests__/__unit__/ZoweNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/ZoweNode.unit.test.ts
@@ -265,6 +265,7 @@ describe("Unit Tests (Jest)", () => {
             undefined,
             profileOne
         );
+        infoChild.id = "<root>.Use the search button to display datasets";
         rootNode.contextValue = globals.DS_SESSION_CONTEXT;
         rootNode.dirty = false;
         await expect(await rootNode.getChildren()).toEqual([infoChild]);
@@ -285,6 +286,7 @@ describe("Unit Tests (Jest)", () => {
             undefined,
             profileOne
         );
+        infoChild.id = "<root>.Use the search button to display datasets";
         rootNode.contextValue = globals.DS_SESSION_CONTEXT;
         await expect(await rootNode.getChildren()).toEqual([infoChild]);
     });

--- a/packages/zowe-explorer/__tests__/__unit__/dataset/DatasetTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/dataset/DatasetTree.unit.test.ts
@@ -1774,6 +1774,9 @@ describe("Dataset Tree Unit Tests - Function renameNode", () => {
             undefined,
             blockMocks.imperativeProfile
         );
+        // the IDs will never match, so for the sake of this test,
+        // going to fake the IDs so that the expect passes
+        afterNode.id = "<root>.TO.RENAME";
         blockMocks.datasetSessionNode.children.push(beforeNode);
         testTree.mSessionNodes.push(blockMocks.datasetSessionNode);
 

--- a/packages/zowe-explorer/__tests__/__unit__/uss/__snapshots__/ZoweUSSNode.unit.test.ts.snap
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/__snapshots__/ZoweUSSNode.unit.test.ts.snap
@@ -26,6 +26,7 @@ ZoweUSSNode {
     "etag": "",
     "fullPath": "",
     "iconPath": "Ref: 'folder.svg'",
+    "id": "<root>.testDir",
     "label": "testDir",
     "mParent": ZoweUSSNode {
       "binary": false,

--- a/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
@@ -75,6 +75,9 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
         if (icon) {
             this.iconPath = icon.path;
         }
+        if (!globals.ISTHEIA && this.getParent() && contextually.isSession(this.getParent())) {
+            this.id = `${mParent?.id ?? "<root>"}.${this.label as string}`;
+        }
     }
 
     /**

--- a/packages/zowe-explorer/src/job/ZoweJobNode.ts
+++ b/packages/zowe-explorer/src/job/ZoweJobNode.ts
@@ -88,6 +88,10 @@ export class Job extends ZoweTreeNode implements IZoweJobTreeNode {
         if (icon) {
             this.iconPath = icon.path;
         }
+
+        if (!globals.ISTHEIA && !(this instanceof Spool)) {
+            this.id = `${mParent?.id ?? "<root>"}.${this.label as string}`;
+        }
     }
 
     /**
@@ -146,17 +150,22 @@ export class Job extends ZoweTreeNode implements IZoweJobTreeNode {
                     } else {
                         newLabel = `${spool.stepname}:${spool.ddname} - ${spool["record-count"]}`;
                     }
-                    const spoolNode = new Spool(newLabel, vscode.TreeItemCollapsibleState.None, this, this.session, spool, this.job, this);
-                    const icon = getIconByNode(spoolNode);
-                    if (icon) {
-                        spoolNode.iconPath = icon.path;
+                    const existing = this.children.find((element) => element.label.trim() === newLabel);
+                    if (existing) {
+                        elementChildren.push(existing);
+                    } else {
+                        const spoolNode = new Spool(newLabel, vscode.TreeItemCollapsibleState.None, this, this.session, spool, this.job, this);
+                        const icon = getIconByNode(spoolNode);
+                        if (icon) {
+                            spoolNode.iconPath = icon.path;
+                        }
+                        spoolNode.command = {
+                            command: "zowe.jobs.zosJobsOpenspool",
+                            title: "",
+                            arguments: [sessionName, spool, refreshTimestamp],
+                        };
+                        elementChildren.push(spoolNode);
                     }
-                    spoolNode.command = {
-                        command: "zowe.jobs.zosJobsOpenspool",
-                        title: "",
-                        arguments: [sessionName, spool, refreshTimestamp],
-                    };
-                    elementChildren.push(spoolNode);
                 });
             } else {
                 const jobs = await this.getJobs(this._owner, this._prefix, this._searchId, this._jobStatus);

--- a/packages/zowe-explorer/src/uss/ZoweUSSNode.ts
+++ b/packages/zowe-explorer/src/uss/ZoweUSSNode.ts
@@ -112,6 +112,9 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
         if (icon) {
             this.iconPath = icon.path;
         }
+        if (!globals.ISTHEIA && this.getParent() && contextually.isSession(this.getParent())) {
+            this.id = `${mParent?.id ?? "<root>"}.${this.label as string}`;
+        }
     }
 
     /**


### PR DESCRIPTION
## Proposed changes

It turns out that even though we can set custom IDs for tree nodes, if you try setting IDs for the innermost nodes it will cause VScode errors to surface. This is likely due to how VScode keeps track of tree nodes. _(this was not mentioned in the VScode documentation)_

I've resolved this by only adding IDs to children of session nodes. VScode should be able to build proper IDs for children nodes provided that the parent ID is unique.

## Release Notes

Milestone: 2.8.1

Changelog:

- Fix issue where VSCode tries to re-register innermost tree nodes because of unique IDs.

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
