### PR TITLE
fix: Zowe Explorer API to use VSCode keytar

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 ### Bug fixes
 
+- Fixed error when an extender's extension attempts to access the keyring in a remote VSCode session [#324](https://github.com/zowe/vscode-extension-for-cics/issues/324).
 - Fixed error shown by API when accessing the `name` and `type` property of a profile when updating the profile arrays [#2334](https://github.com/zowe/vscode-extension-for-zowe/issues/2334).
 
 ## `2.8.1`

--- a/packages/zowe-explorer-api/__tests__/__unit__/profiles/ProfilesCache.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/profiles/ProfilesCache.unit.test.ts
@@ -14,8 +14,6 @@ import * as path from "path";
 import * as zowe from "@zowe/cli";
 import { ProfilesCache } from "../../../src/profiles/ProfilesCache";
 import { ZoweExplorerApi } from "../../../src";
-import { getSecurityModules } from "../../../src/security/KeytarCredentialManager";
-jest.mock("../../../src/security/KeytarCredentialManager");
 
 jest.mock("fs");
 jest.mock("@zowe/cli", () => {

--- a/packages/zowe-explorer-api/__tests__/__unit__/profiles/ProfilesCache.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/profiles/ProfilesCache.unit.test.ts
@@ -14,6 +14,8 @@ import * as path from "path";
 import * as zowe from "@zowe/cli";
 import { ProfilesCache } from "../../../src/profiles/ProfilesCache";
 import { ZoweExplorerApi } from "../../../src";
+import { getSecurityModules } from "../../../src/security/KeytarCredentialManager";
+jest.mock("../../../src/security/KeytarCredentialManager");
 
 jest.mock("fs");
 jest.mock("@zowe/cli", () => {
@@ -124,6 +126,7 @@ describe("ProfilesCache", () => {
     const fakeLogger = { debug: jest.fn() };
     const fakeZoweDir = zowe.getZoweDir();
     const readProfilesFromDiskSpy = jest.spyOn(zowe.imperative.ProfileInfo.prototype, "readProfilesFromDisk");
+    const defaultCredMgrWithKeytarSpy = jest.spyOn(zowe.imperative.ProfileCredentials, "defaultCredMgrWithKeytar");
 
     afterEach(() => {
         jest.clearAllMocks();
@@ -132,6 +135,7 @@ describe("ProfilesCache", () => {
     it("getProfileInfo should initialize ProfileInfo API", async () => {
         const profInfo = await new ProfilesCache(fakeLogger as unknown as zowe.imperative.Logger, __dirname).getProfileInfo();
         expect(readProfilesFromDiskSpy).toHaveBeenCalledTimes(1);
+        expect(defaultCredMgrWithKeytarSpy).toHaveBeenCalledTimes(1);
         const teamConfig = profInfo.getTeamConfig();
         expect(teamConfig.appName).toBe("zowe");
         expect(teamConfig.paths).toEqual([

--- a/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
+++ b/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
@@ -16,6 +16,7 @@ import { URL } from "url";
 
 import * as zowe from "@zowe/cli";
 import { ZoweExplorerApi } from "./ZoweExplorerApi";
+import { getSecurityModules } from "../security";
 
 // TODO: find a home for constants
 export const CONTEXT_PREFIX = "_";
@@ -72,8 +73,10 @@ export class ProfilesCache {
         this.cwd = cwd != null ? getFullPath(cwd) : undefined;
     }
 
-    public async getProfileInfo(): Promise<zowe.imperative.ProfileInfo> {
-        const mProfileInfo = new zowe.imperative.ProfileInfo("zowe");
+    public async getProfileInfo(envTheia = false): Promise<zowe.imperative.ProfileInfo> {
+        const mProfileInfo = new zowe.imperative.ProfileInfo("zowe", {
+            credMgrOverride: zowe.imperative.ProfileCredentials.defaultCredMgrWithKeytar(() => getSecurityModules("keytar", envTheia)),
+        });
         await mProfileInfo.readProfilesFromDisk({ homeDir: getZoweDir(), projectDir: this.cwd ?? undefined });
         return mProfileInfo;
     }


### PR DESCRIPTION
## Proposed changes

This fix introduces a patch to allow extenders to handle Theia environments, and use the VSCode provided keytar, fixing an error in the CICS extension for specific remote sessions.

## Release Notes

Fixed error when an extender's extension attempts to access the keyring in a remote VSCode session

Milestone:

Changelog:

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
