### PR TITLE
fix(profiles): Apply #2330 fix to maintenance branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "yarn": "1.22.19"
   },
   "resolutions": {
-    "**/json5": "^2.2.2"
+    "**/json5": "^2.2.2",
+    "**/semver": "^7.5.2"
   },
   "scripts": {
     "clean": "yarn workspaces run clean",

--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -18,8 +18,11 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 - Added a new type `DataSetAllocTemplate` for data set attributes.
 - Added optional `cancelJob` function to `ZoweExplorerApi.IJes` interface.
 - Added z/OSMF API implementation for `cancelJob` function.
+- Added optional `profile` parameter to `IPromptCredentialsOptions` so developers can choose to skip rebuilding the profile with ProfilesCache.
 - Added optional `id` variable to `IZoweTreeNode` interface, which can be used to designate a unique ID for a tree node. [#2215](https://github.com/zowe/vscode-extension-for-zowe/issues/2215)
 - Fixed error shown by API when accessing the `name` and `type` property of a profile when updating the profile arrays [#2334](https://github.com/zowe/vscode-extension-for-zowe/issues/2334).
+
+- Fixed issue where profiles with authentication tokens were breaking functionality for direct-to-service profiles after user interaction. [#2111](https://github.com/zowe/vscode-extension-for-zowe/issues/2111)
 
 ## `2.8.1`
 

--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -21,7 +21,6 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 - Added optional `profile` parameter to `IPromptCredentialsOptions` so developers can choose to skip rebuilding the profile with ProfilesCache.
 - Added optional `id` variable to `IZoweTreeNode` interface, which can be used to designate a unique ID for a tree node. [#2215](https://github.com/zowe/vscode-extension-for-zowe/issues/2215)
 - Fixed error shown by API when accessing the `name` and `type` property of a profile when updating the profile arrays [#2334](https://github.com/zowe/vscode-extension-for-zowe/issues/2334).
-
 - Fixed issue where profiles with authentication tokens were breaking functionality for direct-to-service profiles after user interaction. [#2111](https://github.com/zowe/vscode-extension-for-zowe/issues/2111)
 
 ## `2.8.1`

--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -6,9 +6,12 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 ### New features and enhancements
 
+- Added optional `profile` parameter to `IPromptCredentialsOptions` so developers can choose to skip rebuilding the profile with ProfilesCache.
+
 ### Bug fixes
 
 - Fixed error when an extender's extension attempts to access the keyring in a remote VSCode session [#324](https://github.com/zowe/vscode-extension-for-cics/issues/324).
+- Fixed issue where profiles with authentication tokens were breaking functionality for direct-to-service profiles after user interaction. [#2330](https://github.com/zowe/vscode-extension-for-zowe/issues/2330)
 
 ## `2.9.0`
 
@@ -18,10 +21,8 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 - Added a new type `DataSetAllocTemplate` for data set attributes.
 - Added optional `cancelJob` function to `ZoweExplorerApi.IJes` interface.
 - Added z/OSMF API implementation for `cancelJob` function.
-- Added optional `profile` parameter to `IPromptCredentialsOptions` so developers can choose to skip rebuilding the profile with ProfilesCache.
 - Added optional `id` variable to `IZoweTreeNode` interface, which can be used to designate a unique ID for a tree node. [#2215](https://github.com/zowe/vscode-extension-for-zowe/issues/2215)
 - Fixed error shown by API when accessing the `name` and `type` property of a profile when updating the profile arrays [#2334](https://github.com/zowe/vscode-extension-for-zowe/issues/2334).
-- Fixed issue where profiles with authentication tokens were breaking functionality for direct-to-service profiles after user interaction. [#2111](https://github.com/zowe/vscode-extension-for-zowe/issues/2111)
 
 ## `2.8.1`
 

--- a/packages/zowe-explorer-api/__tests__/__unit__/vscode/ZoweVsCodeExtension.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/vscode/ZoweVsCodeExtension.unit.test.ts
@@ -14,7 +14,8 @@ import { Gui } from "../../../src/globals/Gui";
 import { MessageSeverity, IZoweLogger } from "../../../src/logger/IZoweLogger";
 import { IProfileLoaded } from "@zowe/imperative";
 import { IPromptCredentialsOptions, ZoweVsCodeExtension } from "../../../src/vscode";
-import { ZoweExplorerApi } from "../../../src";
+import { ProfilesCache, ZoweExplorerApi } from "../../../src";
+import { imperative } from "@zowe/cli";
 
 describe("ZoweVsCodeExtension", () => {
     const fakeVsce = {
@@ -327,6 +328,51 @@ describe("ZoweVsCodeExtension", () => {
             expect(profileLoaded).toBeUndefined();
             expect(showInputBoxSpy).toHaveBeenCalledTimes(2);
             expect(mockUpdateProperty).toHaveBeenCalledTimes(0);
+        });
+
+        it("should do nothing if profile and sessionName args are not provided", async () => {
+            const mockUpdateProperty = jest.fn();
+            jest.spyOn(ZoweVsCodeExtension as any, "profilesCache", "get").mockReturnValue({
+                getLoadedProfConfig: jest.fn().mockReturnValue({
+                    profile: {},
+                }),
+                getProfileInfo: jest.fn().mockReturnValue({
+                    isSecured: jest.fn().mockReturnValue(true),
+                    updateProperty: mockUpdateProperty,
+                }),
+                refresh: jest.fn(),
+            });
+            const showInputBoxSpy = jest.spyOn(Gui, "showInputBox").mockResolvedValueOnce("fakeUser").mockResolvedValueOnce(undefined);
+            const profileLoaded = await ZoweVsCodeExtension.updateCredentials({}, undefined as unknown as ZoweExplorerApi.IApiRegisterClient);
+            expect(profileLoaded).toBeUndefined();
+            expect(showInputBoxSpy).not.toHaveBeenCalled();
+            expect(mockUpdateProperty).not.toHaveBeenCalled();
+        });
+
+        it("should not call ProfilesCache.getLoadedProfConfig if profile object is provided", async () => {
+            const mockUpdateProperty = jest.fn();
+            jest.spyOn(ZoweVsCodeExtension as any, "profilesCache", "get").mockReturnValue({
+                getLoadedProfConfig: jest.fn().mockReturnValue({
+                    profile: {
+                        name: "someExampleProfile",
+                        profile: {
+                            user: "testUser",
+                            password: "testPassword",
+                        } as imperative.IProfile,
+                    } as imperative.IProfileLoaded,
+                }),
+                getProfileInfo: jest.fn().mockReturnValue({
+                    isSecured: jest.fn().mockReturnValue(true),
+                    updateProperty: mockUpdateProperty,
+                }),
+                refresh: jest.fn(),
+            });
+            const getLoadedProfConfigSpy = jest.spyOn(ProfilesCache.prototype, "getLoadedProfConfig");
+            const showInputBoxSpy = jest.spyOn(Gui, "showInputBox").mockResolvedValueOnce("fakeUser").mockResolvedValueOnce(undefined);
+            const profileLoaded = await ZoweVsCodeExtension.updateCredentials({}, undefined as unknown as ZoweExplorerApi.IApiRegisterClient);
+            expect(profileLoaded).toBeUndefined();
+            expect(getLoadedProfConfigSpy).not.toHaveBeenCalled();
+            expect(showInputBoxSpy).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/zowe-explorer-api/src/vscode/ZoweVsCodeExtension.ts
+++ b/packages/zowe-explorer-api/src/vscode/ZoweVsCodeExtension.ts
@@ -120,11 +120,11 @@ export class ZoweVsCodeExtension {
 
         const loadProfile = typeof options.profile === "string" ? await cache.getLoadedProfConfig(options.profile, undefined) : options.profile;
         const loadSession = loadProfile?.profile as imperative.ISession;
-        const creds = await ZoweVsCodeExtension.promptUserPass({ session: loadSession, ...options });
 
         if (loadProfile == null || loadSession == null) {
-            return;
+            return undefined;
         }
+        const creds = await ZoweVsCodeExtension.promptUserPass({ session: loadSession, ...options });
 
         if (creds && creds.length > 0) {
             loadProfile.profile.user = loadSession.user = creds[0];

--- a/packages/zowe-explorer-api/src/vscode/ZoweVsCodeExtension.ts
+++ b/packages/zowe-explorer-api/src/vscode/ZoweVsCodeExtension.ts
@@ -81,7 +81,7 @@ export class ZoweVsCodeExtension {
      */
     public static async promptCredentials(options: IPromptCredentialsOptions): Promise<imperative.IProfileLoaded> {
         const loadProfile = options.sessionName ? await this.profilesCache.getLoadedProfConfig(options.sessionName.trim()) : options.profile;
-        if (typeof loadProfile === "string" || loadProfile == null) {
+        if (loadProfile == null) {
             return undefined;
         }
         const loadSession = loadProfile.profile as imperative.ISession;
@@ -118,7 +118,11 @@ export class ZoweVsCodeExtension {
         const profInfo = await cache.getProfileInfo();
         const setSecure = options.secure ?? profInfo.isSecured();
 
-        const loadProfile = typeof options.profile === "string" ? await cache.getLoadedProfConfig(options.profile, undefined) : options.profile;
+        if (options.profile == null && options.sessionName == null) {
+            return undefined;
+        }
+
+        const loadProfile = options.sessionName ? await cache.getLoadedProfConfig(options.sessionName) : options.profile;
         const loadSession = loadProfile?.profile as imperative.ISession;
 
         if (loadProfile == null || loadSession == null) {

--- a/packages/zowe-explorer-api/src/vscode/doc/IPromptCredentials.ts
+++ b/packages/zowe-explorer-api/src/vscode/doc/IPromptCredentials.ts
@@ -19,7 +19,7 @@ export interface IPromptCredentialsCommonOptions {
 }
 
 export interface IPromptCredentialsOptions extends IPromptCredentialsCommonOptions {
-    profile?: string | imperative.IProfileLoaded;
+    profile?: imperative.IProfileLoaded;
     sessionName?: string;
     sessionType?: string;
     secure?: boolean;

--- a/packages/zowe-explorer-api/src/vscode/doc/IPromptCredentials.ts
+++ b/packages/zowe-explorer-api/src/vscode/doc/IPromptCredentials.ts
@@ -19,7 +19,8 @@ export interface IPromptCredentialsCommonOptions {
 }
 
 export interface IPromptCredentialsOptions extends IPromptCredentialsCommonOptions {
-    sessionName: string;
+    profile?: string | imperative.IProfileLoaded;
+    sessionName?: string;
     sessionType?: string;
     secure?: boolean;
 }

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
+- Fixed issue where profiles with authentication tokens were breaking functionality for direct-to-service profiles after user interaction. [#2330](https://github.com/zowe/vscode-extension-for-zowe/issues/2330)
+
 ## `2.9.0`
 
 ### New features and enhancements
@@ -27,7 +29,6 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue where the mismatch etag error returned was not triggering the diff editor, resulting in possible loss of data due to the issue. [#2277](https://github.com/zowe/vscode-extension-for-zowe/issues/2277)
 - Fixed issue where refreshing views collapsed the respective trees. [#2215](https://github.com/zowe/vscode-extension-for-zowe/issues/2215)
 - Fixed an issue where user would not get prompted when authentication error is thrown. [#2334](https://github.com/zowe/vscode-extension-for-zowe/issues/2334)
-- Fixed issue where profiles with authentication tokens were breaking functionality for direct-to-service profiles after user interaction. [#2111](https://github.com/zowe/vscode-extension-for-zowe/issues/2111)
 
 ## `2.8.2`
 

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue where the mismatch etag error returned was not triggering the diff editor, resulting in possible loss of data due to the issue. [#2277](https://github.com/zowe/vscode-extension-for-zowe/issues/2277)
 - Fixed issue where refreshing views collapsed the respective trees. [#2215](https://github.com/zowe/vscode-extension-for-zowe/issues/2215)
 - Fixed an issue where user would not get prompted when authentication error is thrown. [#2334](https://github.com/zowe/vscode-extension-for-zowe/issues/2334)
+- Fixed issue where profiles with authentication tokens were breaking functionality for direct-to-service profiles after user interaction. [#2111](https://github.com/zowe/vscode-extension-for-zowe/issues/2111)
 
 ## `2.8.2`
 

--- a/packages/zowe-explorer/src/Profiles.ts
+++ b/packages/zowe-explorer/src/Profiles.ts
@@ -869,8 +869,7 @@ export class Profiles extends ProfilesCache {
 
         const promptInfo = await ZoweVsCodeExtension.updateCredentials(
             {
-                sessionName: typeof profile !== "string" ? profile.name : profile,
-                sessionType: typeof profile !== "string" ? profile.type : undefined,
+                profile,
                 rePrompt,
                 secure: (await this.getProfileInfo()).isSecured(),
                 userInputBoxOptions,
@@ -883,14 +882,6 @@ export class Profiles extends ProfilesCache {
             return; // See https://github.com/zowe/vscode-extension-for-zowe/issues/1827
         }
 
-        const isImperativeProfile = (prof: string | zowe.imperative.IProfileLoaded): prof is zowe.imperative.IProfileLoaded =>
-            typeof prof !== "string";
-
-        if (isImperativeProfile(profile)) {
-            if (profile.profile?.tokenValue == null || profile.profile?.tokenType == null) {
-                promptInfo.profile.tokenType = promptInfo.profile.tokenValue = null;
-            }
-        }
         const returnValue: string[] = [promptInfo.profile.user, promptInfo.profile.password, promptInfo.profile.base64EncodedAuth];
         this.updateProfilesArrays(promptInfo);
         return returnValue;

--- a/packages/zowe-explorer/src/Profiles.ts
+++ b/packages/zowe-explorer/src/Profiles.ts
@@ -869,7 +869,8 @@ export class Profiles extends ProfilesCache {
 
         const promptInfo = await ZoweVsCodeExtension.updateCredentials(
             {
-                profile,
+                profile: typeof profile === "string" ? undefined : profile,
+                sessionName: typeof profile === "string" ? profile : undefined,
                 rePrompt,
                 secure: (await this.getProfileInfo()).isSecured(),
                 userInputBoxOptions,

--- a/packages/zowe-explorer/src/Profiles.ts
+++ b/packages/zowe-explorer/src/Profiles.ts
@@ -883,8 +883,15 @@ export class Profiles extends ProfilesCache {
             return; // See https://github.com/zowe/vscode-extension-for-zowe/issues/1827
         }
 
-        const updSession = promptInfo.profile as zowe.imperative.ISession;
-        const returnValue = [updSession.user, updSession.password, updSession.base64EncodedAuth];
+        const isImperativeProfile = (prof: string | zowe.imperative.IProfileLoaded): prof is zowe.imperative.IProfileLoaded =>
+            typeof prof !== "string";
+
+        if (isImperativeProfile(profile)) {
+            if (profile.profile?.tokenValue == null || profile.profile?.tokenType == null) {
+                promptInfo.profile.tokenType = promptInfo.profile.tokenValue = null;
+            }
+        }
+        const returnValue: string[] = [promptInfo.profile.user, promptInfo.profile.password, promptInfo.profile.base64EncodedAuth];
         this.updateProfilesArrays(promptInfo);
         return returnValue;
     }
@@ -1213,7 +1220,7 @@ export class Profiles extends ProfilesCache {
                     };
                     await this.updateBaseProfileFileLogin(baseProfile, updBaseProfile);
                     const baseIndex = this.allProfiles.findIndex((profile) => profile.name === baseProfile.name);
-                    this.allProfiles[baseIndex] = { ...baseProfile, profile: { ...baseProfile, ...updBaseProfile } };
+                    this.allProfiles[baseIndex] = { ...baseProfile, profile: { ...baseProfile.profile, ...updBaseProfile } };
                     node.setProfileToChoice({
                         ...node.getProfile(),
                         profile: { ...node.getProfile().profile, ...updBaseProfile },

--- a/packages/zowe-explorer/src/abstract/ZoweTreeProvider.ts
+++ b/packages/zowe-explorer/src/abstract/ZoweTreeProvider.ts
@@ -247,17 +247,25 @@ export class ZoweTreeProvider {
     public async ssoLogin(node: IZoweTreeNode): Promise<void> {
         ZoweLogger.trace("ZoweTreeProvider.ssoLogin called.");
         await Profiles.getInstance().ssoLogin(node);
-        await vscode.commands.executeCommand("zowe.ds.refreshAll");
-        await vscode.commands.executeCommand("zowe.uss.refreshAll");
-        await vscode.commands.executeCommand("zowe.jobs.refreshAllJobs");
+        if (contextually.isDsSession(node)) {
+            await vscode.commands.executeCommand("zowe.ds.refreshAll");
+        } else if (contextually.isUssSession(node)) {
+            await vscode.commands.executeCommand("zowe.uss.refreshAll");
+        } else {
+            await vscode.commands.executeCommand("zowe.jobs.refreshAllJobs");
+        }
     }
 
     public async ssoLogout(node: IZoweTreeNode): Promise<void> {
         ZoweLogger.trace("ZoweTreeProvider.ssoLogout called.");
         await Profiles.getInstance().ssoLogout(node);
-        await vscode.commands.executeCommand("zowe.ds.refreshAll");
-        await vscode.commands.executeCommand("zowe.uss.refreshAll");
-        await vscode.commands.executeCommand("zowe.jobs.refreshAllJobs");
+        if (contextually.isDsSession(node)) {
+            await vscode.commands.executeCommand("zowe.ds.refreshAll");
+        } else if (contextually.isUssSession(node)) {
+            await vscode.commands.executeCommand("zowe.uss.refreshAll");
+        } else {
+            await vscode.commands.executeCommand("zowe.jobs.refreshAllJobs");
+        }
     }
 
     public async createZoweSchema(zoweFileProvider: IZoweTree<IZoweNodeType>): Promise<void> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9583,44 +9583,10 @@ semver-greatest-satisfied-range@^1.1.0:
   dependencies:
     sver-compat "^1.5.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.5.0, semver@^5.6.0:
-  version "5.7.1"
-  resolved "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
-  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
-
-semver@5.7.0:
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
-  integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
-
-semver@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
-  integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
-
-semver@7.x, semver@^7.3.7:
-  version "7.3.8"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
-  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
-  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.0.0, semver@^7.1.1, semver@^7.1.3, semver@^7.3.4, semver@^7.3.5:
-  version "7.3.7"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
-  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@^7.2.1:
-  version "7.5.1"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz#c90c4d631cf74720e46b21c1d37ea07edfab91ec"
-  integrity sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==
+"semver@2 || 3 || 4 || 5", semver@5.7.0, semver@7.0.0, semver@7.x, semver@^5.1.0, semver@^5.5.0, semver@^5.6.0, semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0, semver@^7.0.0, semver@^7.1.1, semver@^7.1.3, semver@^7.2.1, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.2:
+  version "7.5.3"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz#161ce8c2c6b4b3bdca6caadc9fa3317a4c4fe88e"
+  integrity sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
## Proposed changes

This PR cherry-picks the fix for #2330 for merging into the maintenance branch.

## Release Notes

Milestone: 2.9.1

Changelog: 

Fixed issue where profiles with authentication tokens were breaking functionality for direct-to-service profiles after user interaction. #2330 

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [x] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found

