### PR TITLE
fix(jobs): Job tree not creating new nodes after submitting job

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
+- Fixed issue where job session nodes were not adding new job nodes when refreshed. [#2370](https://github.com/zowe/vscode-extension-for-zowe/issues/2370)
+
 ## `2.9.1`
 
 ### Bug fixes

--- a/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
@@ -811,7 +811,7 @@ describe("ZosJobsProvider - getJobs", () => {
 
 describe("Job - sortJobs", () => {
     it("should sort jobs based on job ID", () => {
-        const jobs = [
+        const sorted = [
             {
                 job: {
                     jobid: "JOBID123",
@@ -819,19 +819,24 @@ describe("Job - sortJobs", () => {
             } as IZoweJobTreeNode,
             {
                 job: {
+                    jobid: "JOBID120",
+                },
+            } as IZoweJobTreeNode,
+            {
+                job: {
                     jobid: "JOBID124",
                 },
             } as IZoweJobTreeNode,
+            // In most cases, there won't be two identical job IDs. In case of overflow, this covers the case for equal job IDs.
             {
                 job: {
                     jobid: "JOBID120",
                 },
             } as IZoweJobTreeNode,
-        ];
-
-        const sorted = jobs.sort((a, b) => Job.sortJobs(a, b));
+        ].sort((a, b) => Job.sortJobs(a, b));
         expect(sorted[0].job.jobid).toBe("JOBID120");
-        expect(sorted[1].job.jobid).toBe("JOBID123");
-        expect(sorted[2].job.jobid).toBe("JOBID124");
+        expect(sorted[1].job.jobid).toBe("JOBID120");
+        expect(sorted[2].job.jobid).toBe("JOBID123");
+        expect(sorted[3].job.jobid).toBe("JOBID124");
     });
 });

--- a/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
@@ -561,11 +561,9 @@ describe("ZosJobsProvider - Function searchPrompt", () => {
         const globalMocks = await createGlobalMocks();
         jest.spyOn(globalMocks.testJobsProvider, "applyRegularSessionSearchLabel").mockReturnValue("Owner:kristina Prefix:* Status:*");
         const addSearchHistory = jest.spyOn(globalMocks.testJobsProvider, "addSearchHistory");
-        const refreshElement = jest.spyOn(globalMocks.testJobsProvider, "refreshElement");
         await globalMocks.testJobsProvider.searchPrompt(globalMocks.testJobsProvider.mSessionNodes[1]);
         expect(globalMocks.testJobsProvider);
         expect(addSearchHistory).toHaveBeenCalled();
-        expect(refreshElement).toHaveBeenCalled();
     });
     it("testing fav node to call applySearchLabelToNode", async () => {
         const globalMocks = await createGlobalMocks();

--- a/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
@@ -340,6 +340,18 @@ describe("ZoweJobNode unit tests - Function getChildren", () => {
         expect(spoolFilesAfter[0].owner).toEqual("fake");
     });
 
+    it("Tests that getChildren returns a placeholder node if no spool files are available", async () => {
+        const globalMocks = await createGlobalMocks();
+
+        jest.spyOn(ZoweExplorerApiRegister, "getJesApi").mockReturnValueOnce({
+            getSpoolFiles: jest.fn().mockReturnValueOnce([]),
+        } as any);
+        globalMocks.testJobNode.dirty = true;
+        const spoolFilesAfter = await globalMocks.testJobNode.getChildren();
+        expect(spoolFilesAfter.length).toBe(1);
+        expect(spoolFilesAfter[0].label).toEqual("There are no JES spool messages to display");
+    });
+
     it("Tests that getChildren returns the spool files if user/owner is not defined", async () => {
         const globalMocks = await createGlobalMocks();
 

--- a/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
@@ -808,3 +808,30 @@ describe("ZosJobsProvider - getJobs", () => {
         await expect(globalMocks.testJobNode.getJobs("test", "test", "test", "test")).resolves.not.toThrow();
     });
 });
+
+describe("Job - sortJobs", () => {
+    it("should sort jobs based on job ID", () => {
+        const jobs = [
+            {
+                job: {
+                    jobid: "JOBID123",
+                },
+            } as IZoweJobTreeNode,
+            {
+                job: {
+                    jobid: "JOBID124",
+                },
+            } as IZoweJobTreeNode,
+            {
+                job: {
+                    jobid: "JOBID120",
+                },
+            } as IZoweJobTreeNode,
+        ];
+
+        const sorted = jobs.sort((a, b) => Job.sortJobs(a, b));
+        expect(sorted[0].job.jobid).toBe("JOBID120");
+        expect(sorted[1].job.jobid).toBe("JOBID123");
+        expect(sorted[2].job.jobid).toBe("JOBID124");
+    });
+});

--- a/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
@@ -298,6 +298,23 @@ describe("ZoweJobNode unit tests - Function getChildren", () => {
         expect(jobs[1].tooltip).toEqual("TESTJOB(JOB1235) - 0");
     });
 
+    it("Tests that getChildren updates existing job nodes with new statuses", async () => {
+        const globalMocks = await createGlobalMocks();
+
+        await globalMocks.testJobsProvider.addSession("fake");
+        globalMocks.testJobsProvider.mSessionNodes[1].searchId = "JOB1234";
+        globalMocks.testJobsProvider.mSessionNodes[1].dirty = true;
+        globalMocks.testJobsProvider.mSessionNodes[1].filtered = true;
+        const jobs = await globalMocks.testJobsProvider.mSessionNodes[1].getChildren();
+        expect(jobs[0].label).toEqual("TESTJOB(JOB1234) - ACTIVE");
+
+        globalMocks.mockGetJob.mockReturnValueOnce({ ...globalMocks.testIJob, retcode: "CC 0000" });
+        globalMocks.testJobsProvider.mSessionNodes[1].dirty = true;
+        const newJobs = await globalMocks.testJobsProvider.mSessionNodes[1].getChildren();
+
+        expect(newJobs[0].label).toEqual("TESTJOB(JOB1234) - CC 0000");
+    });
+
     it("Tests that getChildren retrieves only child jobs which match a provided searchId", async () => {
         const globalMocks = await createGlobalMocks();
 

--- a/packages/zowe-explorer/i18n/sample/src/job/ZoweJobNode.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/job/ZoweJobNode.i18n.json
@@ -1,6 +1,7 @@
 {
   "getChildren.search": "Use the search button to display jobs",
   "getChildren.noSpoolFiles": "There are no JES spool messages to display",
+  "getChildren.noJobs": "There are no jobs to display",
   "getJobs.status.not.supported": "Filtering by job status is not yet supported with this profile type. Will show jobs with all statuses.",
   "getChildren.error.response": "Retrieving response from "
 }

--- a/packages/zowe-explorer/src/job/ZosJobsProvider.ts
+++ b/packages/zowe-explorer/src/job/ZosJobsProvider.ts
@@ -815,9 +815,9 @@ export class ZosJobsProvider extends ZoweTreeProvider implements IZoweTree<IZowe
 
             if (isSessionNotFav) {
                 searchCriteria = await this.applyRegularSessionSearchLabel(node);
-                await TreeViewUtils.expandNode(node, this);
 
                 if (searchCriteria != null) {
+                    await TreeViewUtils.expandNode(node, this);
                     node.label = node.getProfileName();
                     node.description = searchCriteria;
                     node.dirty = true;

--- a/packages/zowe-explorer/src/job/ZosJobsProvider.ts
+++ b/packages/zowe-explorer/src/job/ZosJobsProvider.ts
@@ -806,8 +806,6 @@ export class ZosJobsProvider extends ZoweTreeProvider implements IZoweTree<IZowe
             const isSessionNotFav = contextually.isSessionNotFav(node);
             const isExpanded = node.collapsibleState === vscode.TreeItemCollapsibleState.Expanded;
 
-            node.filtered = true;
-
             const icon = getIconByNode(node);
             if (icon) {
                 node.iconPath = icon.path;
@@ -817,6 +815,7 @@ export class ZosJobsProvider extends ZoweTreeProvider implements IZoweTree<IZowe
                 searchCriteria = await this.applyRegularSessionSearchLabel(node);
 
                 if (searchCriteria != null) {
+                    node.filtered = true;
                     await TreeViewUtils.expandNode(node, this);
                     node.label = node.getProfileName();
                     node.description = searchCriteria;

--- a/packages/zowe-explorer/src/job/ZosJobsProvider.ts
+++ b/packages/zowe-explorer/src/job/ZosJobsProvider.ts
@@ -821,8 +821,6 @@ export class ZosJobsProvider extends ZoweTreeProvider implements IZoweTree<IZowe
                     node.label = node.getProfileName();
                     node.description = searchCriteria;
                     this.addSearchHistory(searchCriteria);
-                    node.dirty = true;
-                    this.refreshElement(node);
                 }
             } else {
                 if (isExpanded) {

--- a/packages/zowe-explorer/src/job/ZosJobsProvider.ts
+++ b/packages/zowe-explorer/src/job/ZosJobsProvider.ts
@@ -820,6 +820,7 @@ export class ZosJobsProvider extends ZoweTreeProvider implements IZoweTree<IZowe
                 if (searchCriteria != null) {
                     node.label = node.getProfileName();
                     node.description = searchCriteria;
+                    node.dirty = true;
                     this.addSearchHistory(searchCriteria);
                 }
             } else {

--- a/packages/zowe-explorer/src/job/ZoweJobNode.ts
+++ b/packages/zowe-explorer/src/job/ZoweJobNode.ts
@@ -217,14 +217,23 @@ export class Job extends ZoweTreeNode implements IZoweJobTreeNode {
             }
 
             // Only add new children that are not in the list of existing child nodes
-            const newChildren = Object.values(elementChildren)
-                .sort((a, b) => a.job.jobid - b.job.jobid)
-                .filter((c) => this.children.find((ch) => ch.label === c.label) == null);
+            const newChildren = Object.values(elementChildren).filter((c) => this.children.find((ch) => ch.label === c.label) == null);
 
             // Remove any children that are no longer present in the built record
             this.children = this.children
                 .concat(newChildren)
-                .filter((ch) => Object.values(elementChildren).find((recordCh) => recordCh.jobid === ch.job.jobid) == null);
+                .filter((ch) => Object.values(elementChildren).find((recordCh) => recordCh.jobid === ch.job.jobid) == null)
+                .sort((a, b) => {
+                    if (a.job.jobid > b.job.jobid) {
+                        return 1;
+                    }
+
+                    if (a.job.jobid < b.job.jobid) {
+                        return -1;
+                    }
+
+                    return 0;
+                });
         }
         this.dirty = false;
         return this.children;

--- a/packages/zowe-explorer/src/job/ZoweJobNode.ts
+++ b/packages/zowe-explorer/src/job/ZoweJobNode.ts
@@ -222,12 +222,6 @@ export class Job extends ZoweTreeNode implements IZoweJobTreeNode {
                 .sort((a, b) => a.job.jobid - b.job.jobid)
                 .filter((c) => this.children.find((ch) => ch.label === c.label) == null);
 
-            // If there are no new children to add, return the cached list
-            if (Object.keys(elementChildren).length > 0 && newChildren.length == 0) {
-                this.dirty = false;
-                return this.children;
-            }
-
             // Remove any children that are no longer present in the built record
             this.children = this.children
                 .concat(newChildren)

--- a/packages/zowe-explorer/src/job/ZoweJobNode.ts
+++ b/packages/zowe-explorer/src/job/ZoweJobNode.ts
@@ -176,14 +176,13 @@ export class Job extends ZoweTreeNode implements IZoweJobTreeNode {
                 // Fetch jobs under session node
                 const jobs = await this.getJobs(this._owner, this._prefix, this._searchId, this._jobStatus);
                 if (!jobs.length) {
-                    const noJobsNode = new Spool(
+                    const noJobsNode = new Job(
                         localize("getChildren.noJobs", "There are no jobs to display"),
                         vscode.TreeItemCollapsibleState.None,
                         this,
                         null,
                         null,
-                        null,
-                        this
+                        null
                     );
                     noJobsNode.iconPath = null;
                     return [noJobsNode];

--- a/packages/zowe-explorer/src/job/ZoweJobNode.ts
+++ b/packages/zowe-explorer/src/job/ZoweJobNode.ts
@@ -158,6 +158,7 @@ export class Job extends ZoweTreeNode implements IZoweJobTreeNode {
                     const existing = this.children.find((element) => element.label?.includes(`${spool.stepname}:${spool.ddname}${spoolSuffix}`));
                     if (existing) {
                         existing.label = newLabel;
+                        elementChildren[newLabel] = existing;
                     } else {
                         const spoolNode = new Spool(newLabel, vscode.TreeItemCollapsibleState.None, this, this.session, spool, this.job, this);
                         const icon = getIconByNode(spoolNode);
@@ -202,6 +203,7 @@ export class Job extends ZoweTreeNode implements IZoweJobTreeNode {
                     if (existing) {
                         // If matched, update the label to reflect latest retcode/status
                         existing.label = nodeTitle;
+                        elementChildren[nodeTitle] = existing;
                     } else {
                         const jobNode = new Job(nodeTitle, vscode.TreeItemCollapsibleState.Collapsed, this, this.session, job, this.getProfile());
                         jobNode.contextValue = globals.JOBS_JOB_CONTEXT;
@@ -225,7 +227,7 @@ export class Job extends ZoweTreeNode implements IZoweJobTreeNode {
             // Remove any children that are no longer present in the built record
             this.children = this.children
                 .concat(newChildren)
-                .filter((ch) => Object.values(elementChildren).find((recordCh) => recordCh.jobid === ch.job.jobid) == null)
+                .filter((ch) => Object.values(elementChildren).find((recordCh) => recordCh.label === ch.label) != null)
                 .sort((a, b) => Job.sortJobs(a, b));
         }
         this.dirty = false;

--- a/packages/zowe-explorer/src/job/ZoweJobNode.ts
+++ b/packages/zowe-explorer/src/job/ZoweJobNode.ts
@@ -226,20 +226,22 @@ export class Job extends ZoweTreeNode implements IZoweJobTreeNode {
             this.children = this.children
                 .concat(newChildren)
                 .filter((ch) => Object.values(elementChildren).find((recordCh) => recordCh.jobid === ch.job.jobid) == null)
-                .sort((a, b) => {
-                    if (a.job.jobid > b.job.jobid) {
-                        return 1;
-                    }
-
-                    if (a.job.jobid < b.job.jobid) {
-                        return -1;
-                    }
-
-                    return 0;
-                });
+                .sort((a, b) => Job.sortJobs(a, b));
         }
         this.dirty = false;
         return this.children;
+    }
+
+    public static sortJobs(a: IZoweJobTreeNode, b: IZoweJobTreeNode): number {
+        if (a.job.jobid > b.job.jobid) {
+            return 1;
+        }
+
+        if (a.job.jobid < b.job.jobid) {
+            return -1;
+        }
+
+        return 0;
     }
 
     public getSessionNode(): IZoweJobTreeNode {


### PR DESCRIPTION
## Proposed changes

This PR should fix the issue where job nodes are not being created after submitting a job and then clicking "Refresh".
To verify, open a session in the jobs tree and search for a filter. Once searched, go to the data sets tree and submit a job. Come back to the jobs session and right click -> select "Refresh." The new job should appear in the list of children.

Fixes #2370 and #2376 

## Release Notes

Milestone: 2.9.2

Changelog:

- Fix bug in 2.9.1 where job session nodes were not updated with new nodes.

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)