### PR TITLE
feat: Use `keyring` module from `@zowe/secrets-for-zowe-sdk` to replace use of `node-keytar`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ debug.log
 npm-shrinkwrap.json
 vscode-extension-for-zowe*.vsix
 .vscode/settings.json
+.vscode/*.env
 .vscode-test
 .history
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ temp
 *.tgz
 .tmp
 coverage/
+prebuilds/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,8 @@
       "outFiles": ["${workspaceFolder}/packages/zowe-explorer/out/**/*.js"],
       "preLaunchTask": "build dev watch",
       "smartStep": true,
-      "skipFiles": ["<node_internals>/**"]
+      "skipFiles": ["<node_internals>/**"],
+      "envFile": "${workspaceFolder}/.vscode/.env"
     },
     {
       // TODO: This launch-configuration should be updated to run the Theia container locally

--- a/.vscode/sample_env
+++ b/.vscode/sample_env
@@ -1,0 +1,6 @@
+# Create a ".env" file with the contents of this file
+
+# Make sure to get a valid DBus Session Address
+# by unlocking the keyring on a terminal, and
+# copy the contents of "echo $DBUS_SESSION_BUS_ADDRESS"
+DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/0/bus

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,2 @@
 registry: "https://registry.npmjs.org/"
+"@zowe:registry" "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "vscode": "^1.53.2"
   },
   "dependencies": {
-    "@zowe/cli": "7.16.2",
+    "@zowe/cli": "7.18.0",
     "vscode-nls": "4.1.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
     "yarn": "1.22.19"
   },
   "resolutions": {
-    "**/json5": "^2.2.2"
+    "**/json5": "^2.2.2",
+    "**/@zowe/cli": "file:../zowe-cli/packages/cli",
+    "**/@zowe/imperative": "file:../imperative"
   },
   "scripts": {
     "clean": "yarn workspaces run clean",

--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 ### New features and enhancements
 
+- Replaced `keytar` dependency with `keyring` module from [`@zowe/secrets-for-zowe-sdk`](https://github.com/zowe/zowe-cli/tree/master/packages/secrets). [#2358](https://github.com/zowe/vscode-extension-for-zowe/issues/2358)
+
 ### Bug fixes
 
 ## `2.9.1`

--- a/packages/zowe-explorer-api/__tests__/__unit__/profiles/ProfilesCache.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/profiles/ProfilesCache.unit.test.ts
@@ -134,6 +134,7 @@ describe("ProfilesCache", () => {
         const profInfo = await new ProfilesCache(fakeLogger as unknown as zowe.imperative.Logger, __dirname).getProfileInfo();
         expect(readProfilesFromDiskSpy).toHaveBeenCalledTimes(1);
         expect(defaultCredMgrWithKeytarSpy).toHaveBeenCalledTimes(1);
+        expect(defaultCredMgrWithKeytarSpy).toHaveBeenCalledWith(ProfilesCache.requireKeyring);
         const teamConfig = profInfo.getTeamConfig();
         expect(teamConfig.appName).toBe("zowe");
         expect(teamConfig.paths).toEqual([

--- a/packages/zowe-explorer-api/__tests__/__unit__/profiles/ProfilesCache.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/profiles/ProfilesCache.unit.test.ts
@@ -145,6 +145,12 @@ describe("ProfilesCache", () => {
         ]);
     });
 
+    it("requireKeyring returns keyring module from Secrets SDK", async () => {
+        const keyring = ProfilesCache.requireKeyring();
+        expect(keyring).toBeDefined();
+        expect(Object.keys(keyring).length).toBe(5);
+    });
+
     it("loadNamedProfile should find profiles by name and type", () => {
         const profCache = new ProfilesCache(fakeLogger as unknown as zowe.imperative.Logger);
         profCache.allProfiles = [lpar1Profile as zowe.imperative.IProfileLoaded, zftpProfile as zowe.imperative.IProfileLoaded];

--- a/packages/zowe-explorer-api/__tests__/__unit__/security/KeytarApi.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/security/KeytarApi.unit.test.ts
@@ -12,11 +12,9 @@
 import { imperative } from "@zowe/cli";
 import { ProfilesCache } from "../../../src/profiles/ProfilesCache";
 import { KeytarApi } from "../../../src/security/KeytarApi";
-import { KeytarCredentialManager } from "../../../src/security/KeytarCredentialManager";
 
 describe("KeytarApi", () => {
     const isCredsSecuredSpy = jest.spyOn(ProfilesCache.prototype, "isSecureCredentialPluginActive");
-    const getSecurityModulesSpy = jest.spyOn(KeytarCredentialManager, "getSecurityModules");
     const credMgrInitializeSpy = jest.spyOn(imperative.CredentialManagerFactory, "initialize");
 
     afterEach(() => {
@@ -25,11 +23,9 @@ describe("KeytarApi", () => {
 
     it("should initialize Imperative credential manager", async () => {
         isCredsSecuredSpy.mockReturnValueOnce(true);
-        getSecurityModulesSpy.mockReturnValueOnce({} as NodeModule);
         credMgrInitializeSpy.mockResolvedValueOnce();
         await new KeytarApi(undefined as unknown as imperative.Logger).activateKeytar(false, false);
         expect(isCredsSecuredSpy).toBeCalledTimes(1);
-        expect(getSecurityModulesSpy).toBeCalledTimes(1);
         expect(credMgrInitializeSpy).toBeCalledTimes(1);
     });
 
@@ -37,25 +33,21 @@ describe("KeytarApi", () => {
         isCredsSecuredSpy.mockReturnValueOnce(false);
         await new KeytarApi(undefined as unknown as imperative.Logger).activateKeytar(false, false);
         expect(isCredsSecuredSpy).toBeCalledTimes(1);
-        expect(getSecurityModulesSpy).not.toBeCalled();
         expect(credMgrInitializeSpy).not.toBeCalled();
     });
 
     it("should do nothing if API has already been initialized", async () => {
         isCredsSecuredSpy.mockReturnValueOnce(true);
-        getSecurityModulesSpy.mockReturnValueOnce({} as NodeModule);
         await new KeytarApi(undefined as unknown as imperative.Logger).activateKeytar(true, false);
         expect(isCredsSecuredSpy).toBeCalledTimes(1);
-        expect(getSecurityModulesSpy).toBeCalledTimes(1);
         expect(credMgrInitializeSpy).not.toBeCalled();
     });
 
     it("should do nothing if Keytar module is missing", async () => {
+        jest.mock("@zowe/secrets-for-zowe-sdk", () => {});
         isCredsSecuredSpy.mockReturnValueOnce(true);
-        getSecurityModulesSpy.mockReturnValueOnce(undefined);
         await new KeytarApi(undefined as unknown as imperative.Logger).activateKeytar(false, false);
         expect(isCredsSecuredSpy).toBeCalledTimes(1);
-        expect(getSecurityModulesSpy).toBeCalledTimes(1);
         expect(credMgrInitializeSpy).not.toBeCalled();
     });
 });

--- a/packages/zowe-explorer-api/__tests__/__unit__/security/KeytarCredentialManager.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/security/KeytarCredentialManager.unit.test.ts
@@ -55,7 +55,7 @@ describe("KeytarCredentialManager", () => {
             loggerWarnSpy = jest.spyOn(imperative.Logger.prototype, "warn").mockImplementation();
         });
 
-        it("should handle CredentialManager in Imperative settings", () => {
+        it("should handle CredentialManager in Imperative settings", async () => {
             jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
             const readFileSyncSpy = jest.spyOn(fs, "readFileSync").mockReturnValue(
                 JSON.stringify({
@@ -64,14 +64,14 @@ describe("KeytarCredentialManager", () => {
                     },
                 })
             );
-            const keytar = KeytarCredentialManager.getSecurityModules("@traeok/keytar-rs", false);
+            const { keyring: keytar } = await import("@zowe/secrets-for-zowe-sdk");
             expect(keytar).toBeDefined();
             expect(loggerWarnSpy).not.toHaveBeenCalled();
             expect(readFileSyncSpy).toHaveBeenCalledTimes(1);
             expect(Object.keys(keytar as object).length).toBe(5);
         });
 
-        it("should handle credential-manager in Imperative settings", () => {
+        it("should handle credential-manager in Imperative settings", async () => {
             jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
             const readFileSyncSpy = jest.spyOn(fs, "readFileSync").mockReturnValue(
                 JSON.stringify({
@@ -80,14 +80,14 @@ describe("KeytarCredentialManager", () => {
                     },
                 })
             );
-            const keytar = KeytarCredentialManager.getSecurityModules("@traeok/keytar-rs", false);
+            const { keyring: keytar } = await import("@zowe/secrets-for-zowe-sdk");
             expect(keytar).toBeDefined();
             expect(loggerWarnSpy).not.toHaveBeenCalled();
             expect(readFileSyncSpy).toHaveBeenCalledTimes(1);
             expect(Object.keys(keytar as object).length).toBe(5);
         });
 
-        it("should handle CredentialManager in Imperative settings - Theia", () => {
+        it("should handle CredentialManager in Imperative settings - Theia", async () => {
             jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
             const readFileSyncSpy = jest.spyOn(fs, "readFileSync").mockReturnValue(
                 JSON.stringify({
@@ -97,42 +97,42 @@ describe("KeytarCredentialManager", () => {
                 })
             );
             jest.spyOn(process, "cwd").mockReturnValueOnce(__dirname + "/../../../../..");
-            const keytar = KeytarCredentialManager.getSecurityModules("@traeok/keytar-rs", true);
+            const { keyring: keytar } = await import("@zowe/secrets-for-zowe-sdk");
             expect(keytar).toBeDefined();
             expect(loggerWarnSpy).not.toHaveBeenCalled();
             expect(readFileSyncSpy).toHaveBeenCalledTimes(1);
             expect(Object.keys(keytar as object).length).toBe(5);
         });
 
-        it("should handle empty Imperative settings", () => {
+        it("should handle empty Imperative settings", async () => {
             jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
             const readFileSyncSpy = jest.spyOn(fs, "readFileSync").mockReturnValue(JSON.stringify({}));
-            const keytar = KeytarCredentialManager.getSecurityModules("@traeok/keytar-rs", false);
+            const { keyring: keytar } = await import("@zowe/secrets-for-zowe-sdk");
             expect(loggerWarnSpy).not.toHaveBeenCalled();
             expect(readFileSyncSpy).toHaveBeenCalledTimes(1);
             expect(keytar).toBeUndefined();
         });
 
-        it("should handle non-existent Imperative settings", () => {
+        it("should handle non-existent Imperative settings", async () => {
             jest.spyOn(fs, "existsSync").mockReturnValueOnce(false);
             const readFileSyncSpy = jest.spyOn(fs, "readFileSync");
-            const keytar = KeytarCredentialManager.getSecurityModules("@traeok/keytar-rs", false);
+            const { keyring: keytar } = await import("@zowe/secrets-for-zowe-sdk");
             expect(loggerWarnSpy).not.toHaveBeenCalled();
             expect(readFileSyncSpy).not.toHaveBeenCalled();
             expect(keytar).toBeUndefined();
         });
 
-        it("should handle error loading Imperative settings", () => {
+        it("should handle error loading Imperative settings", async () => {
             jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
             const readFileSyncSpy = jest.spyOn(fs, "readFileSync").mockReturnValueOnce("invalid json");
-            const keytar = KeytarCredentialManager.getSecurityModules("@traeok/keytar-rs", false);
+            const { keyring: keytar } = await import("@zowe/secrets-for-zowe-sdk");
             expect(loggerWarnSpy).toHaveBeenCalledTimes(1);
             expect(loggerWarnSpy.mock.calls[0][0].message).toContain("Unexpected token");
             expect(readFileSyncSpy).toHaveBeenCalledTimes(1);
             expect(keytar).toBeUndefined();
         });
 
-        it("should handle error loading invalid security module", () => {
+        it("should handle error loading invalid security module", async () => {
             jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
             const readFileSyncSpy = jest.spyOn(fs, "readFileSync").mockReturnValue(
                 JSON.stringify({
@@ -141,7 +141,7 @@ describe("KeytarCredentialManager", () => {
                     },
                 })
             );
-            const keytar = KeytarCredentialManager.getSecurityModules("keytar_bad", false);
+            const keytar = require("nonexistent-keytar");
             expect(loggerWarnSpy).toHaveBeenCalledTimes(2);
             expect(loggerWarnSpy.mock.calls[0][0].message).toContain("Cannot find module");
             expect(readFileSyncSpy).toHaveBeenCalledTimes(1);

--- a/packages/zowe-explorer-api/__tests__/__unit__/security/KeytarCredentialManager.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/security/KeytarCredentialManager.unit.test.ts
@@ -55,7 +55,7 @@ describe("KeytarCredentialManager", () => {
             loggerWarnSpy = jest.spyOn(imperative.Logger.prototype, "warn").mockImplementation();
         });
 
-        it("should handle CredentialManager in Imperative settings", async () => {
+        it("should handle CredentialManager in Imperative settings", () => {
             jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
             const readFileSyncSpy = jest.spyOn(fs, "readFileSync").mockReturnValue(
                 JSON.stringify({
@@ -64,14 +64,14 @@ describe("KeytarCredentialManager", () => {
                     },
                 })
             );
-            const { keyring: keytar } = await import("@zowe/secrets-for-zowe-sdk");
+            const keytar = KeytarCredentialManager.getSecurityModules("@zowe/secrets-for-zowe-sdk", false);
             expect(keytar).toBeDefined();
             expect(loggerWarnSpy).not.toHaveBeenCalled();
             expect(readFileSyncSpy).toHaveBeenCalledTimes(1);
-            expect(Object.keys(keytar as object).length).toBe(5);
+            expect(Object.keys((keytar as object)["keyring"]).length).toBe(5);
         });
 
-        it("should handle credential-manager in Imperative settings", async () => {
+        it("should handle credential-manager in Imperative settings", () => {
             jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
             const readFileSyncSpy = jest.spyOn(fs, "readFileSync").mockReturnValue(
                 JSON.stringify({
@@ -80,14 +80,14 @@ describe("KeytarCredentialManager", () => {
                     },
                 })
             );
-            const { keyring: keytar } = await import("@zowe/secrets-for-zowe-sdk");
+            const keytar = KeytarCredentialManager.getSecurityModules("@zowe/secrets-for-zowe-sdk", false);
             expect(keytar).toBeDefined();
             expect(loggerWarnSpy).not.toHaveBeenCalled();
             expect(readFileSyncSpy).toHaveBeenCalledTimes(1);
-            expect(Object.keys(keytar as object).length).toBe(5);
+            expect(Object.keys((keytar as object)["keyring"]).length).toBe(5);
         });
 
-        it("should handle CredentialManager in Imperative settings - Theia", async () => {
+        it("should handle CredentialManager in Imperative settings - Theia", () => {
             jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
             const readFileSyncSpy = jest.spyOn(fs, "readFileSync").mockReturnValue(
                 JSON.stringify({
@@ -97,42 +97,42 @@ describe("KeytarCredentialManager", () => {
                 })
             );
             jest.spyOn(process, "cwd").mockReturnValueOnce(__dirname + "/../../../../..");
-            const { keyring: keytar } = await import("@zowe/secrets-for-zowe-sdk");
+            const keytar = KeytarCredentialManager.getSecurityModules("@zowe/secrets-for-zowe-sdk", true);
             expect(keytar).toBeDefined();
             expect(loggerWarnSpy).not.toHaveBeenCalled();
             expect(readFileSyncSpy).toHaveBeenCalledTimes(1);
-            expect(Object.keys(keytar as object).length).toBe(5);
+            expect(Object.keys((keytar as object)["keyring"]).length).toBe(5);
         });
 
-        it("should handle empty Imperative settings", async () => {
+        it("should handle empty Imperative settings", () => {
             jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
             const readFileSyncSpy = jest.spyOn(fs, "readFileSync").mockReturnValue(JSON.stringify({}));
-            const { keyring: keytar } = await import("@zowe/secrets-for-zowe-sdk");
+            const keytar = KeytarCredentialManager.getSecurityModules("@zowe/secrets-for-zowe-sdk", false);
             expect(loggerWarnSpy).not.toHaveBeenCalled();
             expect(readFileSyncSpy).toHaveBeenCalledTimes(1);
             expect(keytar).toBeUndefined();
         });
 
-        it("should handle non-existent Imperative settings", async () => {
+        it("should handle non-existent Imperative settings", () => {
             jest.spyOn(fs, "existsSync").mockReturnValueOnce(false);
             const readFileSyncSpy = jest.spyOn(fs, "readFileSync");
-            const { keyring: keytar } = await import("@zowe/secrets-for-zowe-sdk");
+            const keytar = KeytarCredentialManager.getSecurityModules("@zowe/secrets-for-zowe-sdk", false);
             expect(loggerWarnSpy).not.toHaveBeenCalled();
             expect(readFileSyncSpy).not.toHaveBeenCalled();
             expect(keytar).toBeUndefined();
         });
 
-        it("should handle error loading Imperative settings", async () => {
+        it("should handle error loading Imperative settings", () => {
             jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
             const readFileSyncSpy = jest.spyOn(fs, "readFileSync").mockReturnValueOnce("invalid json");
-            const { keyring: keytar } = await import("@zowe/secrets-for-zowe-sdk");
+            const keytar = KeytarCredentialManager.getSecurityModules("@zowe/secrets-for-zowe-sdk", false);
             expect(loggerWarnSpy).toHaveBeenCalledTimes(1);
             expect(loggerWarnSpy.mock.calls[0][0].message).toContain("Unexpected token");
             expect(readFileSyncSpy).toHaveBeenCalledTimes(1);
             expect(keytar).toBeUndefined();
         });
 
-        it("should handle error loading invalid security module", async () => {
+        it("should handle error loading invalid security module", () => {
             jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
             const readFileSyncSpy = jest.spyOn(fs, "readFileSync").mockReturnValue(
                 JSON.stringify({
@@ -141,7 +141,7 @@ describe("KeytarCredentialManager", () => {
                     },
                 })
             );
-            const keytar = require("nonexistent-keytar");
+            const keytar = KeytarCredentialManager.getSecurityModules("keytar_bad", false);
             expect(loggerWarnSpy).toHaveBeenCalledTimes(2);
             expect(loggerWarnSpy.mock.calls[0][0].message).toContain("Cannot find module");
             expect(readFileSyncSpy).toHaveBeenCalledTimes(1);

--- a/packages/zowe-explorer-api/__tests__/__unit__/security/KeytarCredentialManager.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/security/KeytarCredentialManager.unit.test.ts
@@ -64,7 +64,7 @@ describe("KeytarCredentialManager", () => {
                     },
                 })
             );
-            const keytar = KeytarCredentialManager.getSecurityModules("keytar", false);
+            const keytar = KeytarCredentialManager.getSecurityModules("@traeok/keytar-rs", false);
             expect(keytar).toBeDefined();
             expect(loggerWarnSpy).not.toHaveBeenCalled();
             expect(readFileSyncSpy).toHaveBeenCalledTimes(1);
@@ -80,7 +80,7 @@ describe("KeytarCredentialManager", () => {
                     },
                 })
             );
-            const keytar = KeytarCredentialManager.getSecurityModules("keytar", false);
+            const keytar = KeytarCredentialManager.getSecurityModules("@traeok/keytar-rs", false);
             expect(keytar).toBeDefined();
             expect(loggerWarnSpy).not.toHaveBeenCalled();
             expect(readFileSyncSpy).toHaveBeenCalledTimes(1);
@@ -97,7 +97,7 @@ describe("KeytarCredentialManager", () => {
                 })
             );
             jest.spyOn(process, "cwd").mockReturnValueOnce(__dirname + "/../../../../..");
-            const keytar = KeytarCredentialManager.getSecurityModules("keytar", true);
+            const keytar = KeytarCredentialManager.getSecurityModules("@traeok/keytar-rs", true);
             expect(keytar).toBeDefined();
             expect(loggerWarnSpy).not.toHaveBeenCalled();
             expect(readFileSyncSpy).toHaveBeenCalledTimes(1);
@@ -107,7 +107,7 @@ describe("KeytarCredentialManager", () => {
         it("should handle empty Imperative settings", () => {
             jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
             const readFileSyncSpy = jest.spyOn(fs, "readFileSync").mockReturnValue(JSON.stringify({}));
-            const keytar = KeytarCredentialManager.getSecurityModules("keytar", false);
+            const keytar = KeytarCredentialManager.getSecurityModules("@traeok/keytar-rs", false);
             expect(loggerWarnSpy).not.toHaveBeenCalled();
             expect(readFileSyncSpy).toHaveBeenCalledTimes(1);
             expect(keytar).toBeUndefined();
@@ -116,7 +116,7 @@ describe("KeytarCredentialManager", () => {
         it("should handle non-existent Imperative settings", () => {
             jest.spyOn(fs, "existsSync").mockReturnValueOnce(false);
             const readFileSyncSpy = jest.spyOn(fs, "readFileSync");
-            const keytar = KeytarCredentialManager.getSecurityModules("keytar", false);
+            const keytar = KeytarCredentialManager.getSecurityModules("@traeok/keytar-rs", false);
             expect(loggerWarnSpy).not.toHaveBeenCalled();
             expect(readFileSyncSpy).not.toHaveBeenCalled();
             expect(keytar).toBeUndefined();
@@ -125,7 +125,7 @@ describe("KeytarCredentialManager", () => {
         it("should handle error loading Imperative settings", () => {
             jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
             const readFileSyncSpy = jest.spyOn(fs, "readFileSync").mockReturnValueOnce("invalid json");
-            const keytar = KeytarCredentialManager.getSecurityModules("keytar", false);
+            const keytar = KeytarCredentialManager.getSecurityModules("@traeok/keytar-rs", false);
             expect(loggerWarnSpy).toHaveBeenCalledTimes(1);
             expect(loggerWarnSpy.mock.calls[0][0].message).toContain("Unexpected token");
             expect(readFileSyncSpy).toHaveBeenCalledTimes(1);

--- a/packages/zowe-explorer-api/package.json
+++ b/packages/zowe-explorer-api/package.json
@@ -16,7 +16,7 @@
     "@types/semver": "^7.5.0"
   },
   "dependencies": {
-    "@zowe/cli": "^7.16.2",
+    "@zowe/cli": "^7.18.0",
     "semver": "^7.5.3"
   },
   "scripts": {

--- a/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
+++ b/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
@@ -75,7 +75,7 @@ export class ProfilesCache {
 
     public async getProfileInfo(envTheia = false): Promise<zowe.imperative.ProfileInfo> {
         const mProfileInfo = new zowe.imperative.ProfileInfo("zowe", {
-            credMgrOverride: zowe.imperative.ProfileCredentials.defaultCredMgrWithKeytar(() => getSecurityModules("keytar", envTheia)),
+            credMgrOverride: zowe.imperative.ProfileCredentials.defaultCredMgrWithKeytar(() => getSecurityModules("@traeok/keytar-rs", envTheia)),
         });
         await mProfileInfo.readProfilesFromDisk({ homeDir: getZoweDir(), projectDir: this.cwd ?? undefined });
         return mProfileInfo;

--- a/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
+++ b/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
@@ -75,7 +75,8 @@ export class ProfilesCache {
 
     public async getProfileInfo(envTheia = false): Promise<zowe.imperative.ProfileInfo> {
         const mProfileInfo = new zowe.imperative.ProfileInfo("zowe", {
-            credMgrOverride: zowe.imperative.ProfileCredentials.defaultCredMgrWithKeytar(() => getSecurityModules("@traeok/keytar-rs", envTheia)),
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+            credMgrOverride: zowe.imperative.ProfileCredentials.defaultCredMgrWithKeytar(() => require("@zowe/secrets-for-zowe-sdk").keyring),
         });
         await mProfileInfo.readProfilesFromDisk({ homeDir: getZoweDir(), projectDir: this.cwd ?? undefined });
         return mProfileInfo;

--- a/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
+++ b/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
@@ -73,10 +73,15 @@ export class ProfilesCache {
         this.cwd = cwd != null ? getFullPath(cwd) : undefined;
     }
 
-    public async getProfileInfo(envTheia = false): Promise<zowe.imperative.ProfileInfo> {
+    public static requireKeyring(this: void): NodeModule {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-var-requires
+        return require("@zowe/secrets-for-zowe-sdk").keyring;
+    }
+
+    public async getProfileInfo(_envTheia = false): Promise<zowe.imperative.ProfileInfo> {
         const mProfileInfo = new zowe.imperative.ProfileInfo("zowe", {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-            credMgrOverride: zowe.imperative.ProfileCredentials.defaultCredMgrWithKeytar(() => require("@zowe/secrets-for-zowe-sdk").keyring),
+            credMgrOverride: zowe.imperative.ProfileCredentials.defaultCredMgrWithKeytar(ProfilesCache.requireKeyring),
         });
         await mProfileInfo.readProfilesFromDisk({ homeDir: getZoweDir(), projectDir: this.cwd ?? undefined });
         return mProfileInfo;

--- a/packages/zowe-explorer-api/src/security/KeytarApi.ts
+++ b/packages/zowe-explorer-api/src/security/KeytarApi.ts
@@ -24,7 +24,7 @@ export class KeytarApi {
         const profiles = new ProfilesCache(log, vscode.workspace.workspaceFolders?.[0]?.uri.fsPath);
         const scsActive = profiles.isSecureCredentialPluginActive();
         if (scsActive) {
-            const keytar = KeytarCredentialManager.getSecurityModules("keytar", isTheia);
+            const keytar = KeytarCredentialManager.getSecurityModules("@traeok/keytar-rs", isTheia);
             if (!initialized && keytar) {
                 KeytarCredentialManager.keytar = keytar as unknown as KeytarModule;
                 await imperative.CredentialManagerFactory.initialize({

--- a/packages/zowe-explorer-api/src/security/KeytarApi.ts
+++ b/packages/zowe-explorer-api/src/security/KeytarApi.ts
@@ -19,14 +19,19 @@ export class KeytarApi {
     public constructor(protected log: imperative.Logger) {}
 
     // v1 specific
-    public async activateKeytar(initialized: boolean, isTheia: boolean): Promise<void> {
+    public async activateKeytar(initialized: boolean, _isTheia: boolean): Promise<void> {
         const log = imperative.Logger.getAppLogger();
         const profiles = new ProfilesCache(log, vscode.workspace.workspaceFolders?.[0]?.uri.fsPath);
         const scsActive = profiles.isSecureCredentialPluginActive();
         if (scsActive) {
-            const { keyring: keytar } = await import("@zowe/secrets-for-zowe-sdk");
+            let keytar: object;
+            try {
+                keytar = (await import("@zowe/secrets-for-zowe-sdk")).keyring;
+            } catch (err) {
+                log.warn(err.toString());
+            }
             if (!initialized && keytar) {
-                KeytarCredentialManager.keytar = keytar as unknown as KeytarModule;
+                KeytarCredentialManager.keytar = keytar as KeytarModule;
                 await imperative.CredentialManagerFactory.initialize({
                     service: globals.SETTINGS_SCS_DEFAULT,
                     Manager: KeytarCredentialManager,

--- a/packages/zowe-explorer-api/src/security/KeytarApi.ts
+++ b/packages/zowe-explorer-api/src/security/KeytarApi.ts
@@ -24,7 +24,7 @@ export class KeytarApi {
         const profiles = new ProfilesCache(log, vscode.workspace.workspaceFolders?.[0]?.uri.fsPath);
         const scsActive = profiles.isSecureCredentialPluginActive();
         if (scsActive) {
-            const keytar = KeytarCredentialManager.getSecurityModules("@traeok/keytar-rs", isTheia);
+            const { keyring: keytar } = await import("@zowe/secrets-for-zowe-sdk");
             if (!initialized && keytar) {
                 KeytarCredentialManager.keytar = keytar as unknown as KeytarModule;
                 await imperative.CredentialManagerFactory.initialize({

--- a/packages/zowe-explorer-api/src/security/KeytarCredentialManager.ts
+++ b/packages/zowe-explorer-api/src/security/KeytarCredentialManager.ts
@@ -212,9 +212,7 @@ export class KeytarCredentialManager extends imperative.AbstractCredentialManage
  */
 export function getSecurityModules(moduleName: string, isTheia: boolean): NodeModule | undefined {
     const r = typeof __webpack_require__ === "function" ? __non_webpack_require__ : require;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return r(moduleName);
-    /*// Workaround for Theia issue (https://github.com/eclipse-theia/theia/issues/4935)
+    // Workaround for Theia issue (https://github.com/eclipse-theia/theia/issues/4935)
     const appRoot = isTheia ? process.cwd() : vscode.env.appRoot;
     try {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
@@ -228,5 +226,5 @@ export function getSecurityModules(moduleName: string, isTheia: boolean): NodeMo
     } catch (err) {
         imperative.Logger.getAppLogger().warn(err as string);
     }
-    return undefined;*/
+    return undefined;
 }

--- a/packages/zowe-explorer-api/src/security/KeytarCredentialManager.ts
+++ b/packages/zowe-explorer-api/src/security/KeytarCredentialManager.ts
@@ -212,7 +212,9 @@ export class KeytarCredentialManager extends imperative.AbstractCredentialManage
  */
 export function getSecurityModules(moduleName: string, isTheia: boolean): NodeModule | undefined {
     const r = typeof __webpack_require__ === "function" ? __non_webpack_require__ : require;
-    // Workaround for Theia issue (https://github.com/eclipse-theia/theia/issues/4935)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return r(moduleName);
+    /*// Workaround for Theia issue (https://github.com/eclipse-theia/theia/issues/4935)
     const appRoot = isTheia ? process.cwd() : vscode.env.appRoot;
     try {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
@@ -226,5 +228,5 @@ export function getSecurityModules(moduleName: string, isTheia: boolean): NodeMo
     } catch (err) {
         imperative.Logger.getAppLogger().warn(err as string);
     }
-    return undefined;
+    return undefined;*/
 }

--- a/packages/zowe-explorer-ftp-extension/CHANGELOG.md
+++ b/packages/zowe-explorer-ftp-extension/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the "zowe-explorer-ftp-extension" extension will be docum
 ### New features and enhancements
 
 - Enhance throw error in zowe ftp extension. [#2143](https://github.com/zowe/vscode-extension-for-zowe/issues/2143)
+- Removed `keytar` from list of external Webpack modules. Its usage has been replaced with the `keyring` module from [`@zowe/secrets-for-zowe-sdk`](https://github.com/zowe/zowe-cli/tree/master/packages/secrets). [#2358](https://github.com/zowe/vscode-extension-for-zowe/issues/2358)
 
 ### Bug fixes
 

--- a/packages/zowe-explorer-ftp-extension/package.json
+++ b/packages/zowe-explorer-ftp-extension/package.json
@@ -51,9 +51,6 @@
     "@zowe/zowe-explorer-api": "2.10.0-SNAPSHOT",
     "tmp": "0.2.1"
   },
-  "resolutions": {
-    "**/@zowe/imperative": "file:../imperative"
-  },
   "devDependencies": {
     "@types/tmp": "0.2.0",
     "concurrently": "^5.2.0",

--- a/packages/zowe-explorer-ftp-extension/package.json
+++ b/packages/zowe-explorer-ftp-extension/package.json
@@ -51,6 +51,9 @@
     "@zowe/zowe-explorer-api": "2.10.0-SNAPSHOT",
     "tmp": "0.2.1"
   },
+  "resolutions": {
+    "**/@zowe/imperative": "file:../imperative"
+  },
   "devDependencies": {
     "@types/tmp": "0.2.0",
     "concurrently": "^5.2.0",

--- a/packages/zowe-explorer-ftp-extension/webpack.config.js
+++ b/packages/zowe-explorer-ftp-extension/webpack.config.js
@@ -40,7 +40,6 @@ const config = {
     externals: {
         // Add modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
         vscode: "commonjs vscode", // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
-        keytar: "commonjs keytar",
         "spdx-exceptions": "commonjs spdx-exceptions",
         "spdx-license-ids": "commonjs spdx-license-ids",
         "spdx-license-ids/deprecated": "commonjs spdx-license-ids/deprecated",

--- a/packages/zowe-explorer/.prettierignore
+++ b/packages/zowe-explorer/.prettierignore
@@ -1,2 +1,3 @@
 out
 results
+scripts

--- a/packages/zowe-explorer/.vscodeignore
+++ b/packages/zowe-explorer/.vscodeignore
@@ -7,6 +7,7 @@
 !out/src/nls.metadata*.json
 !resources/**/*.png
 !resources/**/*.svg
+!prebuilds/**
 
 !CHANGELOG.md
 !LICENSE

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### New features and enhancements
 
+- Replaced `keytar` dependency with `keyring` module from [`@zowe/secrets-for-zowe-sdk`](https://github.com/zowe/zowe-cli/tree/master/packages/secrets). [#2358](https://github.com/zowe/vscode-extension-for-zowe/issues/2358)
+
 ### Bug fixes
 
 - Fix the USS refresh icon (replacing "download" with "refresh")

--- a/packages/zowe-explorer/__tests__/__unit__/utils/ProfilesUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/ProfilesUtils.unit.test.ts
@@ -698,11 +698,13 @@ describe("ProfilesUtils unit tests", () => {
 
         it("should retrieve the default credential manager if no custom credential manager is found", async () => {
             jest.spyOn(profUtils.ProfilesUtils, "getCredentialManagerOverride").mockReturnValueOnce(undefined);
+            const defaultCredMgrSpy = jest.spyOn(zowe.imperative.ProfileCredentials, "defaultCredMgrWithKeytar");
             jest.spyOn(vscode.extensions, "getExtension").mockReturnValueOnce(undefined);
             jest.spyOn(SettingsConfig, "getDirectValue").mockReturnValueOnce(true);
             const updateCredentialManagerSettingSpy = jest.spyOn(profUtils.ProfilesUtils, "updateCredentialManagerSetting").mockImplementation();
             await expect(profUtils.ProfilesUtils.getProfileInfo(true)).resolves.toEqual({});
             expect(updateCredentialManagerSettingSpy).toBeCalledWith(globals.ZOWE_CLI_SCM);
+            expect(defaultCredMgrSpy).toHaveBeenCalledWith(ProfilesCache.requireKeyring);
         });
     });
 });

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -1905,12 +1905,12 @@
     ]
   },
   "scripts": {
-    "build": "gulp build && yarn license && ts-node ./scripts/getSecretsPrebuilds.ts && webpack --mode development",
+    "build": "gulp build && yarn license && webpack --mode development",
     "build:integration": "yarn createTestProfileData && yarn license && tsc --pretty --project tsconfig-tests.json",
     "test:unit": "jest \".*__tests__.*\\.unit\\.test\\.ts\" --coverage",
     "test:theia": "mocha ./out/__tests__/__theia__/*.theia.test.js --timeout 50000 --reporter mocha-multi-reporters --reporter-options configFile=.mocharc.json",
     "test": "yarn test:unit",
-    "vscode:prepublish": "gulp build && ts-node ./scripts/getSecretsPrebuilds.ts && webpack --mode production && yarn updateStrings && yarn run compile-web",
+    "vscode:prepublish": "gulp build && webpack --mode production && yarn updateStrings && yarn run compile-web",
     "updateStrings": "node ../../scripts/stringUpdateScript.js && prettier --write --loglevel warn ./i18n package.nls*",
     "package": "vsce package --allow-star-activation --yarn && node ../../scripts/mv-pack.js vscode-extension-for-zowe vsix",
     "license": "node ../../scripts/updateLicenses.js",
@@ -1944,6 +1944,7 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "chalk": "^2.4.1",
+    "copy-webpack-plugin": "^6.4.1",
     "cross-env": "^5.2.0",
     "del": "^4.1.1",
     "eslint-plugin-zowe-explorer": "2.10.0-SNAPSHOT",

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -1933,7 +1933,8 @@
     "vscode": "^1.53.2"
   },
   "devDependencies": {
-    "@traeok/keytar-rs": "https://github.com/traeok/keytar-rs.git",
+    "@napi-rs/cli": "^2.16.1",
+    "@traeok/keytar-rs": "github:traeok/keytar-rs",
     "@types/chai": "^4.2.6",
     "@types/chai-as-promised": "^7.1.0",
     "@types/expect": "^1.20.3",

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -1971,7 +1971,7 @@
     "webpack-cli": "^3.3.11"
   },
   "dependencies": {
-    "@zowe/secrets-for-zowe-sdk": "7.18.0-next.1",
+    "@zowe/secrets-for-zowe-sdk": "7.18.0-next.4",
     "@zowe/zowe-explorer-api": "2.10.0-SNAPSHOT",
     "fs-extra": "8.0.1",
     "isbinaryfile": "4.0.4",

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -1971,7 +1971,7 @@
     "webpack-cli": "^3.3.11"
   },
   "dependencies": {
-    "@zowe/secrets-for-zowe-sdk": "7.18.0",
+    "@zowe/secrets-for-zowe-sdk": "7.18.1",
     "@zowe/zowe-explorer-api": "2.10.0-SNAPSHOT",
     "fs-extra": "8.0.1",
     "isbinaryfile": "4.0.4",

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -1905,12 +1905,12 @@
     ]
   },
   "scripts": {
-    "build": "gulp build && yarn license && webpack --mode development",
+    "build": "gulp build && yarn license && ts-node ./scripts/getSecretsPrebuilds.ts && webpack --mode development",
     "build:integration": "yarn createTestProfileData && yarn license && tsc --pretty --project tsconfig-tests.json",
     "test:unit": "jest \".*__tests__.*\\.unit\\.test\\.ts\" --coverage",
     "test:theia": "mocha ./out/__tests__/__theia__/*.theia.test.js --timeout 50000 --reporter mocha-multi-reporters --reporter-options configFile=.mocharc.json",
     "test": "yarn test:unit",
-    "vscode:prepublish": "gulp build && webpack --mode production && yarn updateStrings && yarn run compile-web",
+    "vscode:prepublish": "gulp build && ts-node ./scripts/getSecretsPrebuilds.ts && webpack --mode production && yarn updateStrings && yarn run compile-web",
     "updateStrings": "node ../../scripts/stringUpdateScript.js && prettier --write --loglevel warn ./i18n package.nls*",
     "package": "vsce package --allow-star-activation --yarn && node ../../scripts/mv-pack.js vscode-extension-for-zowe vsix",
     "license": "node ../../scripts/updateLicenses.js",
@@ -1934,7 +1934,6 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "^2.16.1",
-    "@traeok/keytar-rs": "github:traeok/keytar-rs",
     "@types/chai": "^4.2.6",
     "@types/chai-as-promised": "^7.1.0",
     "@types/expect": "^1.20.3",
@@ -1972,6 +1971,7 @@
     "webpack-cli": "^3.3.11"
   },
   "dependencies": {
+    "@zowe/secrets-for-zowe-sdk": "7.18.0-next.1",
     "@zowe/zowe-explorer-api": "2.10.0-SNAPSHOT",
     "fs-extra": "8.0.1",
     "isbinaryfile": "4.0.4",

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -1971,7 +1971,7 @@
     "webpack-cli": "^3.3.11"
   },
   "dependencies": {
-    "@zowe/secrets-for-zowe-sdk": "7.18.0-next.4",
+    "@zowe/secrets-for-zowe-sdk": "7.18.0",
     "@zowe/zowe-explorer-api": "2.10.0-SNAPSHOT",
     "fs-extra": "8.0.1",
     "isbinaryfile": "4.0.4",

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -1933,6 +1933,7 @@
     "vscode": "^1.53.2"
   },
   "devDependencies": {
+    "@traeok/keytar-rs": "https://github.com/traeok/keytar-rs.git",
     "@types/chai": "^4.2.6",
     "@types/chai-as-promised": "^7.1.0",
     "@types/expect": "^1.20.3",
@@ -1958,7 +1959,6 @@
     "gulp-typescript": "^5.0.1",
     "jsdoc": "^3.6.3",
     "jsdom": "^16.0.0",
-    "keytar": "^7.2.0",
     "log4js": "^6.4.6",
     "markdownlint-cli": "^0.33.0",
     "mem": "^6.0.1",

--- a/packages/zowe-explorer/scripts/getSecretsPrebuilds.ts
+++ b/packages/zowe-explorer/scripts/getSecretsPrebuilds.ts
@@ -1,0 +1,4 @@
+import { copySync } from "fs-extra";
+import { join, resolve } from "path";
+const secretsPkgDir = resolve(require.resolve("@zowe/secrets-for-zowe-sdk"), "..");
+copySync(join(secretsPkgDir, "prebuilds"), resolve(__dirname, "..", "prebuilds"));

--- a/packages/zowe-explorer/scripts/getSecretsPrebuilds.ts
+++ b/packages/zowe-explorer/scripts/getSecretsPrebuilds.ts
@@ -1,4 +1,4 @@
 import { copySync } from "fs-extra";
 import { join, resolve } from "path";
-const secretsPkgDir = resolve(require.resolve("@zowe/secrets-for-zowe-sdk"), "..");
+const secretsPkgDir = resolve(require.resolve("@zowe/secrets-for-zowe-sdk"), "..", "..");
 copySync(join(secretsPkgDir, "prebuilds"), resolve(__dirname, "..", "prebuilds"));

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -16,7 +16,7 @@ import * as globals from "../globals";
 import * as path from "path";
 import * as fs from "fs";
 import * as util from "util";
-import { IZoweTreeNode, ZoweTreeNode, getZoweDir, getFullPath, Gui } from "@zowe/zowe-explorer-api";
+import { IZoweTreeNode, ZoweTreeNode, getZoweDir, getFullPath, Gui, ProfilesCache } from "@zowe/zowe-explorer-api";
 import { Profiles } from "../Profiles";
 import * as nls from "vscode-nls";
 import { imperative, getImperativeConfig } from "@zowe/cli";
@@ -274,7 +274,7 @@ export class ProfilesUtils {
         await ProfilesUtils.updateCredentialManagerSetting(globals.ZOWE_CLI_SCM);
         return new imperative.ProfileInfo("zowe", {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-            credMgrOverride: imperative.ProfileCredentials.defaultCredMgrWithKeytar(() => require("@zowe/secrets-for-zowe-sdk").keyring),
+            credMgrOverride: imperative.ProfileCredentials.defaultCredMgrWithKeytar(ProfilesCache.requireKeyring),
         });
     }
 

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -274,7 +274,7 @@ export class ProfilesUtils {
         ZoweLogger.info(localize("ProfilesUtils.getProfileInfo.usingDefault", "No custom credential managers found, using the default instead."));
         await ProfilesUtils.updateCredentialManagerSetting(globals.ZOWE_CLI_SCM);
         return new imperative.ProfileInfo("zowe", {
-            credMgrOverride: imperative.ProfileCredentials.defaultCredMgrWithKeytar(() => getSecurityModules("keytar", envTheia)),
+            credMgrOverride: imperative.ProfileCredentials.defaultCredMgrWithKeytar(() => getSecurityModules("@traeok/keytar-rs", envTheia)),
         });
     }
 

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -16,7 +16,7 @@ import * as globals from "../globals";
 import * as path from "path";
 import * as fs from "fs";
 import * as util from "util";
-import { getSecurityModules, IZoweTreeNode, ZoweTreeNode, getZoweDir, getFullPath, Gui } from "@zowe/zowe-explorer-api";
+import { IZoweTreeNode, ZoweTreeNode, getZoweDir, getFullPath, Gui } from "@zowe/zowe-explorer-api";
 import { Profiles } from "../Profiles";
 import * as nls from "vscode-nls";
 import { imperative, getImperativeConfig } from "@zowe/cli";
@@ -274,7 +274,8 @@ export class ProfilesUtils {
         ZoweLogger.info(localize("ProfilesUtils.getProfileInfo.usingDefault", "No custom credential managers found, using the default instead."));
         await ProfilesUtils.updateCredentialManagerSetting(globals.ZOWE_CLI_SCM);
         return new imperative.ProfileInfo("zowe", {
-            credMgrOverride: imperative.ProfileCredentials.defaultCredMgrWithKeytar(() => getSecurityModules("@traeok/keytar-rs", envTheia)),
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+            credMgrOverride: imperative.ProfileCredentials.defaultCredMgrWithKeytar(() => require("@zowe/secrets-for-zowe-sdk").keyring),
         });
     }
 

--- a/packages/zowe-explorer/webpack.config.js
+++ b/packages/zowe-explorer/webpack.config.js
@@ -25,6 +25,8 @@ const path = require("path");
 var webpack = require("webpack");
 var fs = require("fs");
 
+const CopyPlugin = require("copy-webpack-plugin");
+
 /**@type {import('webpack').Configuration}*/
 const config = {
     target: "node", // vscode extensions run in a Node.js-context 📖 -> https://webpack.js.org/configuration/node/
@@ -80,7 +82,12 @@ const config = {
             },
         ],
     },
-    plugins: [new webpack.BannerPlugin(fs.readFileSync("../../scripts/LICENSE_HEADER", "utf-8"))],
+    plugins: [
+        new webpack.BannerPlugin(fs.readFileSync("../../scripts/LICENSE_HEADER", "utf-8")),
+        new CopyPlugin({
+            patterns: [{ from: "./node_modules/@zowe/secrets-for-zowe-sdk/prebuilds", to: "../../prebuilds/" }],
+        }),
+    ],
 };
 
 module.exports = config;

--- a/packages/zowe-explorer/webpack.config.js
+++ b/packages/zowe-explorer/webpack.config.js
@@ -40,7 +40,6 @@ const config = {
     externals: {
         // Add modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
         vscode: "commonjs vscode", // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
-        keytar: "commonjs keytar",
         "spdx-exceptions": "commonjs spdx-exceptions",
         "spdx-license-ids": "commonjs spdx-license-ids",
         "spdx-license-ids/deprecated": "commonjs spdx-license-ids/deprecated",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2244,43 +2244,43 @@
   resolved "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-"@zowe/cli@7.16.2", "@zowe/cli@^7.16.2":
-  version "7.16.2"
-  resolved "https://registry.npmjs.org/@zowe/cli/-/cli-7.16.2.tgz#a0f92c51043a77dc7c401b50d3cdb88150ff2ee5"
-  integrity sha512-AHw92hRhWTEhRLZYCjSiQLb0+v3QvqzMo0U1WeZf9Ou9vYNKpR4I5B3VCG6+dmfxKRAz9o6V/kHA1sMDARLUdQ==
+"@zowe/cli@7.18.0", "@zowe/cli@^7.18.0":
+  version "7.18.0"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/cli/-/@zowe/cli-7.18.0.tgz#ee1fa4456856a77094cc09676e5844e9a6486a24"
+  integrity sha512-2nvHtsQ5Z2vHilQhKUhRwKvbz5YOzqDTOFRAy4PiA7+NePgq4J0a10U+pd+GxnsG7Hl/Gna26hc9+61Iy8Z1WQ==
   dependencies:
-    "@zowe/core-for-zowe-sdk" "7.16.1"
-    "@zowe/imperative" "5.13.2"
+    "@zowe/core-for-zowe-sdk" "7.18.0"
+    "@zowe/imperative" "5.18.0"
     "@zowe/perf-timing" "1.0.7"
-    "@zowe/provisioning-for-zowe-sdk" "7.16.1"
-    "@zowe/zos-console-for-zowe-sdk" "7.16.1"
-    "@zowe/zos-files-for-zowe-sdk" "7.16.1"
-    "@zowe/zos-jobs-for-zowe-sdk" "7.16.1"
-    "@zowe/zos-logs-for-zowe-sdk" "7.16.1"
-    "@zowe/zos-tso-for-zowe-sdk" "7.16.1"
-    "@zowe/zos-uss-for-zowe-sdk" "7.16.1"
-    "@zowe/zos-workflows-for-zowe-sdk" "7.16.1"
-    "@zowe/zosmf-for-zowe-sdk" "7.16.1"
+    "@zowe/provisioning-for-zowe-sdk" "7.18.0"
+    "@zowe/zos-console-for-zowe-sdk" "7.18.0"
+    "@zowe/zos-files-for-zowe-sdk" "7.18.0"
+    "@zowe/zos-jobs-for-zowe-sdk" "7.18.0"
+    "@zowe/zos-logs-for-zowe-sdk" "7.18.0"
+    "@zowe/zos-tso-for-zowe-sdk" "7.18.0"
+    "@zowe/zos-uss-for-zowe-sdk" "7.18.0"
+    "@zowe/zos-workflows-for-zowe-sdk" "7.18.0"
+    "@zowe/zosmf-for-zowe-sdk" "7.18.0"
     find-process "1.4.7"
     get-stream "6.0.1"
     lodash "4.17.21"
     minimatch "5.0.1"
     tar "6.1.14"
   optionalDependencies:
-    keytar "7.9.0"
+    "@zowe/secrets-for-zowe-sdk" "7.18.0"
 
-"@zowe/core-for-zowe-sdk@7.16.1":
-  version "7.16.1"
-  resolved "https://registry.npmjs.org/@zowe/core-for-zowe-sdk/-/core-for-zowe-sdk-7.16.1.tgz#3631108ac8bd5ce6cab1dadfa73b41d612646a6c"
-  integrity sha512-MYeA5B56F9fFnltFuLelfvLLbt1pgXV7mtqC8ZYScjgbVq3HNdlysbXAOIXvSNtn/Em7JbWK2KVy2I4Me900Ww==
+"@zowe/core-for-zowe-sdk@7.18.0":
+  version "7.18.0"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/core-for-zowe-sdk/-/@zowe/core-for-zowe-sdk-7.18.0.tgz#eaa7d97eb6b3d96c18df1776a28e0bcd89e465d4"
+  integrity sha512-a5yMfDkoEGiOnREitNWIydnc+JnWEb2TElFiwcoPV5ewKEZZ6t9SPa2c1NKzsxZgM2OePBVvpBqMOi7lEVNMsg==
   dependencies:
     comment-json "4.1.1"
     string-width "4.2.3"
 
-"@zowe/imperative@5.13.2":
-  version "5.13.2"
-  resolved "https://registry.npmjs.org/@zowe/imperative/-/imperative-5.13.2.tgz#2019292140ebf67da03144f315e0be4ab17ed481"
-  integrity sha512-doA7KcmKm/VW9ZtVSRbSFBknfyzoGawuiV//+q6vBb08qiIPXn1Gg1Mn/6ECpEouBxXqRJGuXj28f+HZX9YZCA==
+"@zowe/imperative@5.18.0":
+  version "5.18.0"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.18.0.tgz#d3035a291601d21554b871cd6f98990411d8cd92"
+  integrity sha512-SE0WfySTkaxJa1s26lexQuN1efUPhKe2P2A9MXjzHl7+OOLg+QU0gGS8SpVS1yEXQi+yZfGPorPEqEn2DC+n5A==
   dependencies:
     "@types/yargs" "13.0.4"
     "@zowe/perf-timing" "1.0.7"
@@ -2312,7 +2312,7 @@
     progress "2.0.3"
     read "1.0.7"
     readline-sync "1.4.10"
-    semver "5.7.0"
+    semver "7.5.2"
     stack-trace "0.0.10"
     strip-ansi "6.0.1"
     which "3.0.0"
@@ -2328,28 +2328,29 @@
     fs-extra "8.1.0"
     pkg-up "2.0.0"
 
-"@zowe/provisioning-for-zowe-sdk@7.16.1":
-  version "7.16.1"
-  resolved "https://registry.npmjs.org/@zowe/provisioning-for-zowe-sdk/-/provisioning-for-zowe-sdk-7.16.1.tgz#75e08763f93a92be5152c72ed578f4936ef71503"
-  integrity sha512-8R9Wah76/0inDnbX7lO2K/o2cPnzlfX7y8AoRrJCmla7bwfCGWInuDi5Wey0DGGS08GfyRscd8y0VEopzAwdXA==
+"@zowe/provisioning-for-zowe-sdk@7.18.0":
+  version "7.18.0"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/provisioning-for-zowe-sdk/-/@zowe/provisioning-for-zowe-sdk-7.18.0.tgz#85348a9d539748a65e9693fa0857c52462e551ef"
+  integrity sha512-ZqfNuQOQ0ohMBJjFI4itF+mH3V8EKiQw9n+pgf9qjyAXMfuvq6B0QmtzO5pvKy9IrFwokDQH3C2tfsY5EGL62A==
   dependencies:
     js-yaml "4.1.0"
 
-"@zowe/secrets-for-zowe-sdk@7.18.0-next.4":
-  version "7.18.0-next.4"
-  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/secrets-for-zowe-sdk/-/@zowe/secrets-for-zowe-sdk-7.18.0-next.4.tgz#c488432feb42ef12ffbc8e3db0104850fa882989"
-  integrity sha512-H3UElOA7UxZL+Ee3Q2cHCwF/T0s+SEv8Wof9kyzC0TiP71awBHZiPONY7bZIe3vbpRlckt2ECcG/os6qrDrjJw==
+"@zowe/secrets-for-zowe-sdk@7.18.0":
+  version "7.18.0"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/secrets-for-zowe-sdk/-/@zowe/secrets-for-zowe-sdk-7.18.0.tgz#2741de10f4c16811b25bdf4944f669a0d15e3788"
+  integrity sha512-QyZQh45pZEj9PWkqaTfMFIFDiHpMI4aCaZSbsbhanz54h/kN1s6nT4ri43EjQ3J3aUsG2wEjKkotjBZdGg3cHw==
 
-"@zowe/zos-console-for-zowe-sdk@7.16.1":
-  version "7.16.1"
-  resolved "https://registry.npmjs.org/@zowe/zos-console-for-zowe-sdk/-/zos-console-for-zowe-sdk-7.16.1.tgz#a793daa0d93d9323127a2e844b0cb425bcb3c023"
-  integrity sha512-Yu9sKPjwYL1+3OAAxql1iJ0wMhn+lnnCw1B1WMXDDaY4kDV8pNKCOG/plbbXhEeUJ/UtUYh9Srr+S0Z0wKQWPA==
+"@zowe/zos-console-for-zowe-sdk@7.18.0":
+  version "7.18.0"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/zos-console-for-zowe-sdk/-/@zowe/zos-console-for-zowe-sdk-7.18.0.tgz#ea399a6cd80fbddfa3ba00a89dac681cdc908fa1"
+  integrity sha512-sVWHNuJFncHqN75nKan8Ybx1wvAWo8fqPjk3CLbChWXOS9iSFIjArirrqFODWMvgQ0p+3+ns2v88OOJ/WIQsiQ==
 
-"@zowe/zos-files-for-zowe-sdk@7.16.1":
-  version "7.16.1"
-  resolved "https://registry.npmjs.org/@zowe/zos-files-for-zowe-sdk/-/zos-files-for-zowe-sdk-7.16.1.tgz#39405d4ea13e1501a52fb039be046ad7c1a5b10d"
-  integrity sha512-lFVWpLTkjtbd6Xw7OGsfMmNqhYVZYK+iSVXNW3w+qoJGVeC0GtzFlZBqD/a4SzjLSBK00tAc3SEaiiqiprHJIA==
+"@zowe/zos-files-for-zowe-sdk@7.18.0":
+  version "7.18.0"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/zos-files-for-zowe-sdk/-/@zowe/zos-files-for-zowe-sdk-7.18.0.tgz#af512179746538fc2f8945ae68240763e3d9d523"
+  integrity sha512-D25+TaUj+2d8h9JRxiy6pzkLFst0t0tbGK433LZsF4O1TzrbQsM4VRdcLYKrzBbQkSsYOyyasxAs4HUjKWdr4w==
   dependencies:
+    get-stream "6.0.1"
     minimatch "5.0.1"
 
 "@zowe/zos-ftp-for-zowe-cli@2.1.2":
@@ -2359,43 +2360,43 @@
   dependencies:
     zos-node-accessor "1.0.14"
 
-"@zowe/zos-jobs-for-zowe-sdk@7.16.1":
-  version "7.16.1"
-  resolved "https://registry.npmjs.org/@zowe/zos-jobs-for-zowe-sdk/-/zos-jobs-for-zowe-sdk-7.16.1.tgz#b5868a884564863074c9a96ea792fd0dcab07693"
-  integrity sha512-inU+MHkr/bOBUMT/jYyzlhXBMPe3xeuYaAAiOdzCTad83ECmVPMcV+ycrvvpBc0gV57Yibke8FkrJs+O4ZtBkQ==
+"@zowe/zos-jobs-for-zowe-sdk@7.18.0":
+  version "7.18.0"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/zos-jobs-for-zowe-sdk/-/@zowe/zos-jobs-for-zowe-sdk-7.18.0.tgz#53981bebc184e39b227f2e639216363aa0e3e885"
+  integrity sha512-PX2AMeyJjJjkJDq+a4HxrY9PypmMq7Z0NFAmJCCv/wp+DXaGyYYK3Kc5SNU/SSVqyJYv03blkFR78GEAhJK+4A==
   dependencies:
-    "@zowe/zos-files-for-zowe-sdk" "7.16.1"
+    "@zowe/zos-files-for-zowe-sdk" "7.18.0"
 
-"@zowe/zos-logs-for-zowe-sdk@7.16.1":
-  version "7.16.1"
-  resolved "https://registry.npmjs.org/@zowe/zos-logs-for-zowe-sdk/-/zos-logs-for-zowe-sdk-7.16.1.tgz#d516d73136ba9d61f94bba78e03a1a7c399abfcd"
-  integrity sha512-Fkma+Lkjcm5zjooQRMJByPi8Zdb0FyU9f+8uVNwkb0a+4Fwxe/AMZIYoT82FkQfBjlq7gVu7ntPcEP3Y02yl7w==
+"@zowe/zos-logs-for-zowe-sdk@7.18.0":
+  version "7.18.0"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/zos-logs-for-zowe-sdk/-/@zowe/zos-logs-for-zowe-sdk-7.18.0.tgz#100c2fb629eee55cadbd6eff56a0c472e88f1495"
+  integrity sha512-88lNA85LX8OYRvuTYrqJhjMGwc+BcudGM4wQ2JQwVshg/y622fWAV1w5O0vCFPEXxBi5pCT0YdKMYmLeGc4vkQ==
 
-"@zowe/zos-tso-for-zowe-sdk@7.16.1":
-  version "7.16.1"
-  resolved "https://registry.npmjs.org/@zowe/zos-tso-for-zowe-sdk/-/zos-tso-for-zowe-sdk-7.16.1.tgz#be1a9748ef4e67f8993da37478fdf1699d7a7fd7"
-  integrity sha512-yhc97iNhmBtOxGy9CcaeJi8AbcItlz/mW5dVAT4WlyMrpLr1hbtj0iVXIEuDBlfeXnvbTYpBNdsqlRP2IaCKhg==
+"@zowe/zos-tso-for-zowe-sdk@7.18.0":
+  version "7.18.0"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/zos-tso-for-zowe-sdk/-/@zowe/zos-tso-for-zowe-sdk-7.18.0.tgz#7e9fba8a644f96780c84e3e0583b36d84d5fa81c"
+  integrity sha512-7hZb9pgngwU7PuCoyFXIUgldnZCM1dJiAxWG1VNlH+5zwOljzaveBz4cjvtqIuJTBYA7V3+gq4xj6/QNXNC97Q==
   dependencies:
-    "@zowe/zosmf-for-zowe-sdk" "7.16.1"
+    "@zowe/zosmf-for-zowe-sdk" "7.18.0"
 
-"@zowe/zos-uss-for-zowe-sdk@7.16.1":
-  version "7.16.1"
-  resolved "https://registry.npmjs.org/@zowe/zos-uss-for-zowe-sdk/-/zos-uss-for-zowe-sdk-7.16.1.tgz#69b4b1ac79c33058f37e720c4516cf0b74915422"
-  integrity sha512-8rAOjPR803gKm1um8YpTNd0OySlLilw9twT6N03KVT+I+hhKi3ztvDtJWzejptifHQl0E+YRFKDOj14UkqRmbA==
+"@zowe/zos-uss-for-zowe-sdk@7.18.0":
+  version "7.18.0"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/zos-uss-for-zowe-sdk/-/@zowe/zos-uss-for-zowe-sdk-7.18.0.tgz#ba2850c5bbac04b23f66127dede4e894b8632162"
+  integrity sha512-cK+Y8uN5qGfxsaR3UYxThOC9Deb5m0YP4UzA7QX2rWnPvetdzGddmJhXxLcZ2qbbVhqOpdqFxSPkOsp0E/l8Kw==
   dependencies:
     ssh2 "1.11.0"
 
-"@zowe/zos-workflows-for-zowe-sdk@7.16.1":
-  version "7.16.1"
-  resolved "https://registry.npmjs.org/@zowe/zos-workflows-for-zowe-sdk/-/zos-workflows-for-zowe-sdk-7.16.1.tgz#f782358cda4e22d356c639f4f88be4eebf976b2b"
-  integrity sha512-EncI38qyFK0Ib6gERXVqNj9OMk0hSHekwf2GT4oY6ECaRG5WO5nlRZs7tamTowJXmrG7PJ1rRbmiigzeuQZj6w==
+"@zowe/zos-workflows-for-zowe-sdk@7.18.0":
+  version "7.18.0"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/zos-workflows-for-zowe-sdk/-/@zowe/zos-workflows-for-zowe-sdk-7.18.0.tgz#4c28b4e2a3754669c9617639cc4f598e4eef3abc"
+  integrity sha512-fwohyemEHrc5q9UQTToYRB8+YX1NjpsyoKYt4dEEEkiEOwHZ/99vPqM6dpVm/mj7iZyTfpgHuxB4lPEZNdD21A==
   dependencies:
-    "@zowe/zos-files-for-zowe-sdk" "7.16.1"
+    "@zowe/zos-files-for-zowe-sdk" "7.18.0"
 
-"@zowe/zosmf-for-zowe-sdk@7.16.1":
-  version "7.16.1"
-  resolved "https://registry.npmjs.org/@zowe/zosmf-for-zowe-sdk/-/zosmf-for-zowe-sdk-7.16.1.tgz#6bc0b08e30ffcaedd6670b5de3196233c603a041"
-  integrity sha512-K4ZKVpgfJ5Th8qjZqcHnE36zOvkjUuRITybejxjDxwtary+jKy6ZBFsNbRTWtboc4Zx8S1fm+0RdJS/3X1yW/Q==
+"@zowe/zosmf-for-zowe-sdk@7.18.0":
+  version "7.18.0"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/zosmf-for-zowe-sdk/-/@zowe/zosmf-for-zowe-sdk-7.18.0.tgz#fd31eb10032adc233561b224895296c275083ce0"
+  integrity sha512-nxB9zmWHamXYcCLKOlJtsAEhl6maLHRtSbAuPupytbNgtH6z5bt6WuHefJbq03wy0D2smWMiNk+zuTE4Lim/6A==
 
 abab@^2.0.3, abab@^2.0.5:
   version "2.0.6"
@@ -7175,7 +7176,7 @@ just-extend@^4.0.2:
   resolved "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz#ef5e589afb61e5d66b24eca749409a8939a8c744"
   integrity sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==
 
-keytar@7.9.0, keytar@^7.7.0:
+keytar@^7.7.0:
   version "7.9.0"
   resolved "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz#4c6225708f51b50cbf77c5aae81721964c2918cb"
   integrity sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==
@@ -9583,7 +9584,7 @@ semver-greatest-satisfied-range@^1.1.0:
   dependencies:
     sver-compat "^1.5.0"
 
-"semver@2 || 3 || 4 || 5", semver@5.7.0, semver@7.0.0, semver@7.x, semver@^5.1.0, semver@^5.5.0, semver@^5.6.0, semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0, semver@^7.0.0, semver@^7.1.1, semver@^7.1.3, semver@^7.2.1, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.2, semver@^7.5.3:
+"semver@2 || 3 || 4 || 5", semver@7.0.0, semver@7.5.2, semver@7.x, semver@^5.1.0, semver@^5.5.0, semver@^5.6.0, semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0, semver@^7.0.0, semver@^7.1.1, semver@^7.1.3, semver@^7.2.1, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.2, semver@^7.5.3:
   version "7.5.3"
   resolved "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz#161ce8c2c6b4b3bdca6caadc9fa3317a4c4fe88e"
   integrity sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1616,6 +1616,11 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@napi-rs/cli@^2.16.1":
+  version "2.16.1"
+  resolved "https://registry.npmjs.org/@napi-rs/cli/-/cli-2.16.1.tgz#912e1169be6ff8bb5e1e22bb702adcc5e73e232b"
+  integrity sha512-L0Gr5iEQIDEbvWdDr1HUaBOxBSHL1VZhWSk1oryawoT8qJIY+KGfLFelU+Qma64ivCPbxYpkfPoKYVG3rcoGIA==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -1756,11 +1761,7 @@
 
 "@traeok/keytar-rs@github:traeok/keytar-rs":
   version "0.0.0"
-  resolved "https://codeload.github.com/traeok/keytar-rs/tar.gz/0b00af3fb1ae1b70ef68b049071d5c392218dbc5"
-
-"@traeok/keytar-rs@https://github.com/traeok/keytar-rs.git":
-  version "0.0.0"
-  resolved "https://github.com/traeok/keytar-rs.git#0b00af3fb1ae1b70ef68b049071d5c392218dbc5"
+  resolved "https://codeload.github.com/traeok/keytar-rs/tar.gz/4d4f1aa222b85357242fa1df85089e467c2e1d6b"
 
 "@types/babel__core@^7.1.14":
   version "7.1.20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1879,6 +1879,11 @@
     expect "^29.0.0"
     pretty-format "^29.0.0"
 
+"@types/json-schema@^7.0.8":
+  version "7.0.12"
+  resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz#d70faba7039d5fca54c83c7dbab41051d2b6f6cb"
+  integrity sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==
+
 "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
@@ -2490,12 +2495,12 @@ ajv-errors@^1.0.0:
   resolved "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
 
-ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
+ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.4:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.4, ajv@^6.12.5:
   version "6.12.6"
   resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -3863,6 +3868,23 @@ copy-props@^2.0.1:
     each-props "^1.3.2"
     is-plain-object "^5.0.0"
 
+copy-webpack-plugin@^6.4.1:
+  version "6.4.1"
+  resolved "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-6.4.1.tgz#138cd9b436dbca0a6d071720d5414848992ec47e"
+  integrity sha512-MXyPCjdPVx5iiWyl40Va3JGh27bKzOTNY3NjUTrosD2q7dR/cLD0013uqJ3BpFbUjyONINjb6qI7nDIJujrMbA==
+  dependencies:
+    cacache "^15.0.5"
+    fast-glob "^3.2.4"
+    find-cache-dir "^3.3.1"
+    glob-parent "^5.1.1"
+    globby "^11.0.1"
+    loader-utils "^2.0.0"
+    normalize-path "^3.0.0"
+    p-limit "^3.0.2"
+    schema-utils "^3.0.0"
+    serialize-javascript "^5.0.1"
+    webpack-sources "^1.4.3"
+
 core-js-compat@^3.21.0, core-js-compat@^3.22.1:
   version "3.22.4"
   resolved "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.4.tgz#d700f451e50f1d7672dcad0ac85d910e6691e579"
@@ -4977,6 +4999,17 @@ fast-glob@3.2.7:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
+fast-glob@^3.2.4:
+  version "3.3.1"
+  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz#784b4e897340f3dbbef17413b3f11acf03c874c4"
+  integrity sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-glob@^3.2.9:
   version "3.2.11"
   resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
@@ -5071,6 +5104,15 @@ find-cache-dir@^2.1.0:
     commondir "^1.0.1"
     make-dir "^2.0.0"
     pkg-dir "^3.0.0"
+
+find-cache-dir@^3.3.1:
+  version "3.3.2"
+  resolved "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz#b30c5b6eff0730731aea9bbd9dbecbd80256d64b"
+  integrity sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^3.0.2"
+    pkg-dir "^4.1.0"
 
 find-process@1.4.7:
   version "1.4.7"
@@ -5412,7 +5454,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob-parent@^5.1.2, glob-parent@~5.1.2:
+glob-parent@^5.1.1, glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -5526,7 +5568,7 @@ globals@^13.19.0, globals@^13.6.0, globals@^13.9.0:
   dependencies:
     type-fest "^0.20.2"
 
-globby@^11.1.0:
+globby@^11.0.1, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
@@ -7132,7 +7174,7 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.2.1:
+json5@^2.1.2, json5@^2.2.1:
   version "2.2.3"
   resolved "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
@@ -7355,6 +7397,15 @@ loader-utils@^1.0.2, loader-utils@^1.2.3, loader-utils@^1.4.0:
     emojis-list "^3.0.0"
     json5 "^1.0.1"
 
+loader-utils@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
+  integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^2.1.2"
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -7499,7 +7550,7 @@ make-dir@^2.0.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-make-dir@^3.0.0:
+make-dir@^3.0.0, make-dir@^3.0.2:
   version "3.1.0"
   resolved "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
@@ -8824,7 +8875,7 @@ pkg-dir@^3.0.0:
   dependencies:
     find-up "^3.0.0"
 
-pkg-dir@^4.2.0:
+pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
@@ -9604,6 +9655,15 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
+schema-utils@^3.0.0:
+  version "3.3.0"
+  resolved "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz#f50a88877c3c01652a15b622ae9e9795df7a60fe"
+  integrity sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==
+  dependencies:
+    "@types/json-schema" "^7.0.8"
+    ajv "^6.12.5"
+    ajv-keywords "^3.5.2"
+
 selenium-webdriver@^3.6.0:
   version "3.6.0"
   resolved "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-3.6.0.tgz#2ba87a1662c020b8988c981ae62cb2a01298eafc"
@@ -9661,6 +9721,13 @@ serialize-javascript@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
   integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
+  dependencies:
+    randombytes "^2.1.0"
+
+serialize-javascript@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"
+  integrity sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==
   dependencies:
     randombytes "^2.1.0"
 
@@ -11116,7 +11183,7 @@ webpack-cli@^3.3.11:
     v8-compile-cache "^2.1.1"
     yargs "^13.3.2"
 
-webpack-sources@^1.4.0, webpack-sources@^1.4.1:
+webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
   version "1.4.3"
   resolved "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
   integrity sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1622,9 +1622,9 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@napi-rs/cli@^2.16.1":
-  version "2.16.1"
-  resolved "https://registry.npmjs.org/@napi-rs/cli/-/cli-2.16.1.tgz#912e1169be6ff8bb5e1e22bb702adcc5e73e232b"
-  integrity sha512-L0Gr5iEQIDEbvWdDr1HUaBOxBSHL1VZhWSk1oryawoT8qJIY+KGfLFelU+Qma64ivCPbxYpkfPoKYVG3rcoGIA==
+  version "2.16.2"
+  resolved "https://registry.npmjs.org/@napi-rs/cli/-/cli-2.16.2.tgz#4783ccbf51c39023c2945b3e59aba71b443dc9e1"
+  integrity sha512-U2aZfnr0s9KkXpZlYC0l5WxWCXL7vJUNpCnWMwq3T9GG9rhYAAUM9CTZsi1Z+0iR2LcHbfq9EfMgoqnuTyUjfg==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -1763,10 +1763,6 @@
   version "1.1.2"
   resolved "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
-
-"@traeok/keytar-rs@github:traeok/keytar-rs":
-  version "0.0.0"
-  resolved "https://codeload.github.com/traeok/keytar-rs/tar.gz/4d4f1aa222b85357242fa1df85089e467c2e1d6b"
 
 "@types/babel__core@^7.1.14":
   version "7.1.20"
@@ -2248,28 +2244,30 @@
   resolved "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-"@zowe/cli@7.16.2", "@zowe/cli@^7.16.2", "@zowe/cli@file:../zowe-cli/packages/cli":
-  version "7.16.4"
+"@zowe/cli@7.16.2", "@zowe/cli@^7.16.2":
+  version "7.16.2"
+  resolved "https://registry.npmjs.org/@zowe/cli/-/cli-7.16.2.tgz#a0f92c51043a77dc7c401b50d3cdb88150ff2ee5"
+  integrity sha512-AHw92hRhWTEhRLZYCjSiQLb0+v3QvqzMo0U1WeZf9Ou9vYNKpR4I5B3VCG6+dmfxKRAz9o6V/kHA1sMDARLUdQ==
   dependencies:
-    "@zowe/core-for-zowe-sdk" "7.16.4"
-    "@zowe/imperative" "5.14.2"
+    "@zowe/core-for-zowe-sdk" "7.16.1"
+    "@zowe/imperative" "5.13.2"
     "@zowe/perf-timing" "1.0.7"
-    "@zowe/provisioning-for-zowe-sdk" "7.16.4"
-    "@zowe/zos-console-for-zowe-sdk" "7.16.4"
-    "@zowe/zos-files-for-zowe-sdk" "7.16.4"
-    "@zowe/zos-jobs-for-zowe-sdk" "7.16.4"
-    "@zowe/zos-logs-for-zowe-sdk" "7.16.4"
-    "@zowe/zos-tso-for-zowe-sdk" "7.16.4"
-    "@zowe/zos-uss-for-zowe-sdk" "7.16.4"
-    "@zowe/zos-workflows-for-zowe-sdk" "7.16.4"
-    "@zowe/zosmf-for-zowe-sdk" "7.16.4"
+    "@zowe/provisioning-for-zowe-sdk" "7.16.1"
+    "@zowe/zos-console-for-zowe-sdk" "7.16.1"
+    "@zowe/zos-files-for-zowe-sdk" "7.16.1"
+    "@zowe/zos-jobs-for-zowe-sdk" "7.16.1"
+    "@zowe/zos-logs-for-zowe-sdk" "7.16.1"
+    "@zowe/zos-tso-for-zowe-sdk" "7.16.1"
+    "@zowe/zos-uss-for-zowe-sdk" "7.16.1"
+    "@zowe/zos-workflows-for-zowe-sdk" "7.16.1"
+    "@zowe/zosmf-for-zowe-sdk" "7.16.1"
     find-process "1.4.7"
     get-stream "6.0.1"
     lodash "4.17.21"
     minimatch "5.0.1"
     tar "6.1.14"
   optionalDependencies:
-    "@traeok/keytar-rs" "github:traeok/keytar-rs"
+    keytar "7.9.0"
 
 "@zowe/core-for-zowe-sdk@7.16.1":
   version "7.16.1"
@@ -2279,18 +2277,11 @@
     comment-json "4.1.1"
     string-width "4.2.3"
 
-"@zowe/core-for-zowe-sdk@7.16.4":
-  version "7.16.4"
-  resolved "https://registry.npmjs.org/@zowe/core-for-zowe-sdk/-/core-for-zowe-sdk-7.16.4.tgz#7d2e5e20418562356d7e3afe32c5a307e79a258a"
-  integrity sha512-R9P1IoYLJpQ8lmBKIs436Ye397q+h8y87gYGJxlkEb/1pXyySx5ydQnAICWI7Iy6hh0aUo394INTEA0HQEc3XA==
+"@zowe/imperative@5.13.2":
+  version "5.13.2"
+  resolved "https://registry.npmjs.org/@zowe/imperative/-/imperative-5.13.2.tgz#2019292140ebf67da03144f315e0be4ab17ed481"
+  integrity sha512-doA7KcmKm/VW9ZtVSRbSFBknfyzoGawuiV//+q6vBb08qiIPXn1Gg1Mn/6ECpEouBxXqRJGuXj28f+HZX9YZCA==
   dependencies:
-    comment-json "4.1.1"
-    string-width "4.2.3"
-
-"@zowe/imperative@5.13.2", "@zowe/imperative@5.14.2", "@zowe/imperative@file:../imperative":
-  version "5.14.2"
-  dependencies:
-    "@traeok/keytar-rs" "github:traeok/keytar-rs"
     "@types/yargs" "13.0.4"
     "@zowe/perf-timing" "1.0.7"
     chalk "2.4.2"
@@ -2344,34 +2335,20 @@
   dependencies:
     js-yaml "4.1.0"
 
-"@zowe/provisioning-for-zowe-sdk@7.16.4":
-  version "7.16.4"
-  resolved "https://registry.npmjs.org/@zowe/provisioning-for-zowe-sdk/-/provisioning-for-zowe-sdk-7.16.4.tgz#ac240c80cc8c82eff501b55b4f27bbe207d7f84b"
-  integrity sha512-+xyyqWzbG9umznRJqtwaS3bkXp2KUy+71OhWMHfOijx/R+pomI7PhnmmQrpjMlTkvBvbDh82peUx9S+sxmYh/w==
-  dependencies:
-    js-yaml "4.1.0"
+"@zowe/secrets-for-zowe-sdk@7.18.0-next.4":
+  version "7.18.0-next.4"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/secrets-for-zowe-sdk/-/@zowe/secrets-for-zowe-sdk-7.18.0-next.4.tgz#c488432feb42ef12ffbc8e3db0104850fa882989"
+  integrity sha512-H3UElOA7UxZL+Ee3Q2cHCwF/T0s+SEv8Wof9kyzC0TiP71awBHZiPONY7bZIe3vbpRlckt2ECcG/os6qrDrjJw==
 
 "@zowe/zos-console-for-zowe-sdk@7.16.1":
   version "7.16.1"
   resolved "https://registry.npmjs.org/@zowe/zos-console-for-zowe-sdk/-/zos-console-for-zowe-sdk-7.16.1.tgz#a793daa0d93d9323127a2e844b0cb425bcb3c023"
   integrity sha512-Yu9sKPjwYL1+3OAAxql1iJ0wMhn+lnnCw1B1WMXDDaY4kDV8pNKCOG/plbbXhEeUJ/UtUYh9Srr+S0Z0wKQWPA==
 
-"@zowe/zos-console-for-zowe-sdk@7.16.4":
-  version "7.16.4"
-  resolved "https://registry.npmjs.org/@zowe/zos-console-for-zowe-sdk/-/zos-console-for-zowe-sdk-7.16.4.tgz#c0d54cc4d9d824f1d7b05605ee898c80fe51ada8"
-  integrity sha512-rM4bfEZigWyfS/mzRfmMLiAi407kKmbVAzl6XllHQQg7Vtc+BVPmGA8JvQDBtMswnAc5c/EIp3IeJ7vdjt3TCA==
-
 "@zowe/zos-files-for-zowe-sdk@7.16.1":
   version "7.16.1"
   resolved "https://registry.npmjs.org/@zowe/zos-files-for-zowe-sdk/-/zos-files-for-zowe-sdk-7.16.1.tgz#39405d4ea13e1501a52fb039be046ad7c1a5b10d"
   integrity sha512-lFVWpLTkjtbd6Xw7OGsfMmNqhYVZYK+iSVXNW3w+qoJGVeC0GtzFlZBqD/a4SzjLSBK00tAc3SEaiiqiprHJIA==
-  dependencies:
-    minimatch "5.0.1"
-
-"@zowe/zos-files-for-zowe-sdk@7.16.4":
-  version "7.16.4"
-  resolved "https://registry.npmjs.org/@zowe/zos-files-for-zowe-sdk/-/zos-files-for-zowe-sdk-7.16.4.tgz#5b297e75ec73b90d717bddfe5249f6ea5ef462d7"
-  integrity sha512-7mNoikQRu3taBWS7W0mEto8PE8uPheBrFYntrvq6QiVlCx4/YgFK+IB1Vzp93/G/YYS9iEbEQTKplS1W7KTSIA==
   dependencies:
     minimatch "5.0.1"
 
@@ -2389,22 +2366,10 @@
   dependencies:
     "@zowe/zos-files-for-zowe-sdk" "7.16.1"
 
-"@zowe/zos-jobs-for-zowe-sdk@7.16.4":
-  version "7.16.4"
-  resolved "https://registry.npmjs.org/@zowe/zos-jobs-for-zowe-sdk/-/zos-jobs-for-zowe-sdk-7.16.4.tgz#bb8d6aacef6c199a3988b2af5e765222bcd26855"
-  integrity sha512-FfdrAkblCHV9yp3SYNPd/fxzggjILTalWHpo88XJrpp++7LSLYG124i0J26FxD0LEfmV5TZzttpb1UYt2OrU6A==
-  dependencies:
-    "@zowe/zos-files-for-zowe-sdk" "7.16.4"
-
 "@zowe/zos-logs-for-zowe-sdk@7.16.1":
   version "7.16.1"
   resolved "https://registry.npmjs.org/@zowe/zos-logs-for-zowe-sdk/-/zos-logs-for-zowe-sdk-7.16.1.tgz#d516d73136ba9d61f94bba78e03a1a7c399abfcd"
   integrity sha512-Fkma+Lkjcm5zjooQRMJByPi8Zdb0FyU9f+8uVNwkb0a+4Fwxe/AMZIYoT82FkQfBjlq7gVu7ntPcEP3Y02yl7w==
-
-"@zowe/zos-logs-for-zowe-sdk@7.16.4":
-  version "7.16.4"
-  resolved "https://registry.npmjs.org/@zowe/zos-logs-for-zowe-sdk/-/zos-logs-for-zowe-sdk-7.16.4.tgz#8bd7f6cdfc02d1a5d1c98aae7d6edb2b227c9f0f"
-  integrity sha512-6MQCIzLll02P0iqqRHfujt854Q8A9O0/5EnkR3eyWAQw4bMIEYCBub9TYCmurNepXhTNaQR6E2ayyThjolMDHw==
 
 "@zowe/zos-tso-for-zowe-sdk@7.16.1":
   version "7.16.1"
@@ -2413,24 +2378,10 @@
   dependencies:
     "@zowe/zosmf-for-zowe-sdk" "7.16.1"
 
-"@zowe/zos-tso-for-zowe-sdk@7.16.4":
-  version "7.16.4"
-  resolved "https://registry.npmjs.org/@zowe/zos-tso-for-zowe-sdk/-/zos-tso-for-zowe-sdk-7.16.4.tgz#4ed4585922ad8475a158057a2abc0fba88fda0e6"
-  integrity sha512-v3SgI9uL30y3YT3mi6AOlmMtCp76w+/jDCAZw0nLsulSKxz40pKGuxiVmpHlQmrMrQPXTSRzu1KE7/7LTRrWkg==
-  dependencies:
-    "@zowe/zosmf-for-zowe-sdk" "7.16.4"
-
 "@zowe/zos-uss-for-zowe-sdk@7.16.1":
   version "7.16.1"
   resolved "https://registry.npmjs.org/@zowe/zos-uss-for-zowe-sdk/-/zos-uss-for-zowe-sdk-7.16.1.tgz#69b4b1ac79c33058f37e720c4516cf0b74915422"
   integrity sha512-8rAOjPR803gKm1um8YpTNd0OySlLilw9twT6N03KVT+I+hhKi3ztvDtJWzejptifHQl0E+YRFKDOj14UkqRmbA==
-  dependencies:
-    ssh2 "1.11.0"
-
-"@zowe/zos-uss-for-zowe-sdk@7.16.4":
-  version "7.16.4"
-  resolved "https://registry.npmjs.org/@zowe/zos-uss-for-zowe-sdk/-/zos-uss-for-zowe-sdk-7.16.4.tgz#831746f813714dc26e4e5167959cd9c94da14e66"
-  integrity sha512-IldSdbuTDItQBD206ExpfLBsB6Y8xDb/Ft5t7FBLDffZXghub8saHvGsrFU2L0vdNwSJBmDxAzzJ7UlTH70ygw==
   dependencies:
     ssh2 "1.11.0"
 
@@ -2441,22 +2392,10 @@
   dependencies:
     "@zowe/zos-files-for-zowe-sdk" "7.16.1"
 
-"@zowe/zos-workflows-for-zowe-sdk@7.16.4":
-  version "7.16.4"
-  resolved "https://registry.npmjs.org/@zowe/zos-workflows-for-zowe-sdk/-/zos-workflows-for-zowe-sdk-7.16.4.tgz#0cd0f0a051cad0e7ff271bbc60ea402d7fc43203"
-  integrity sha512-SRsv8il7qoLHDdy8AT0jQS5mi5vMewcHrUV6rpMB0Nox2GPvfkGYQiOcmnXb6dsa9RUPfTyNX/NMkLDgx48qkQ==
-  dependencies:
-    "@zowe/zos-files-for-zowe-sdk" "7.16.4"
-
 "@zowe/zosmf-for-zowe-sdk@7.16.1":
   version "7.16.1"
   resolved "https://registry.npmjs.org/@zowe/zosmf-for-zowe-sdk/-/zosmf-for-zowe-sdk-7.16.1.tgz#6bc0b08e30ffcaedd6670b5de3196233c603a041"
   integrity sha512-K4ZKVpgfJ5Th8qjZqcHnE36zOvkjUuRITybejxjDxwtary+jKy6ZBFsNbRTWtboc4Zx8S1fm+0RdJS/3X1yW/Q==
-
-"@zowe/zosmf-for-zowe-sdk@7.16.4":
-  version "7.16.4"
-  resolved "https://registry.npmjs.org/@zowe/zosmf-for-zowe-sdk/-/zosmf-for-zowe-sdk-7.16.4.tgz#ac293d74c5c40393cce66e9cafa2ae158a28caa3"
-  integrity sha512-n4wIeN1IO9AFnTuxujYCZ4m2hRysGvK6O6DIDYRkswS0AcqkLxJ+0p4R/FmMdr10WAFAB0X0rJtW35ZP4hJooA==
 
 abab@^2.0.3, abab@^2.0.5:
   version "2.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1621,6 +1621,11 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@napi-rs/cli@^2.16.1":
+  version "2.16.2"
+  resolved "https://registry.npmjs.org/@napi-rs/cli/-/cli-2.16.2.tgz#4783ccbf51c39023c2945b3e59aba71b443dc9e1"
+  integrity sha512-U2aZfnr0s9KkXpZlYC0l5WxWCXL7vJUNpCnWMwq3T9GG9rhYAAUM9CTZsi1Z+0iR2LcHbfq9EfMgoqnuTyUjfg==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -2239,43 +2244,43 @@
   resolved "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-"@zowe/cli@7.16.6", "@zowe/cli@^7.16.6":
-  version "7.16.6"
-  resolved "https://registry.npmjs.org/@zowe/cli/-/cli-7.16.6.tgz#6f6a15ce88fb3b3a66a1027712d50289afd81d45"
-  integrity sha512-7hadi0qJ5z34peKNi0d3NlWljoEdQY6EiQQBxlLjP0/Gzegj40plgPXFyqVowRXOmHnfqDZTKrOH2ssqJY2+PA==
+"@zowe/cli@7.18.0", "@zowe/cli@^7.18.0":
+  version "7.18.0"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/cli/-/@zowe/cli-7.18.0.tgz#ee1fa4456856a77094cc09676e5844e9a6486a24"
+  integrity sha512-2nvHtsQ5Z2vHilQhKUhRwKvbz5YOzqDTOFRAy4PiA7+NePgq4J0a10U+pd+GxnsG7Hl/Gna26hc9+61Iy8Z1WQ==
   dependencies:
-    "@zowe/core-for-zowe-sdk" "7.16.5"
-    "@zowe/imperative" "5.15.1"
+    "@zowe/core-for-zowe-sdk" "7.18.0"
+    "@zowe/imperative" "5.18.0"
     "@zowe/perf-timing" "1.0.7"
-    "@zowe/provisioning-for-zowe-sdk" "7.16.5"
-    "@zowe/zos-console-for-zowe-sdk" "7.16.5"
-    "@zowe/zos-files-for-zowe-sdk" "7.16.6"
-    "@zowe/zos-jobs-for-zowe-sdk" "7.16.6"
-    "@zowe/zos-logs-for-zowe-sdk" "7.16.5"
-    "@zowe/zos-tso-for-zowe-sdk" "7.16.5"
-    "@zowe/zos-uss-for-zowe-sdk" "7.16.5"
-    "@zowe/zos-workflows-for-zowe-sdk" "7.16.6"
-    "@zowe/zosmf-for-zowe-sdk" "7.16.5"
+    "@zowe/provisioning-for-zowe-sdk" "7.18.0"
+    "@zowe/zos-console-for-zowe-sdk" "7.18.0"
+    "@zowe/zos-files-for-zowe-sdk" "7.18.0"
+    "@zowe/zos-jobs-for-zowe-sdk" "7.18.0"
+    "@zowe/zos-logs-for-zowe-sdk" "7.18.0"
+    "@zowe/zos-tso-for-zowe-sdk" "7.18.0"
+    "@zowe/zos-uss-for-zowe-sdk" "7.18.0"
+    "@zowe/zos-workflows-for-zowe-sdk" "7.18.0"
+    "@zowe/zosmf-for-zowe-sdk" "7.18.0"
     find-process "1.4.7"
     get-stream "6.0.1"
     lodash "4.17.21"
     minimatch "5.0.1"
     tar "6.1.14"
   optionalDependencies:
-    keytar "7.9.0"
+    "@zowe/secrets-for-zowe-sdk" "7.18.0"
 
-"@zowe/core-for-zowe-sdk@7.16.5":
-  version "7.16.5"
-  resolved "https://registry.npmjs.org/@zowe/core-for-zowe-sdk/-/core-for-zowe-sdk-7.16.5.tgz#b8a559858a8feb7b9108647080a3c9e9745480f5"
-  integrity sha512-CRFIZXHY4BnV4e0fmT8//wkZA/dXNiJ10mHqCjZtiDzzVtT/qUm2/mX+8D2jHjLkWoQpkucVdYc9eLaKAwewPw==
+"@zowe/core-for-zowe-sdk@7.18.0":
+  version "7.18.0"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/core-for-zowe-sdk/-/@zowe/core-for-zowe-sdk-7.18.0.tgz#eaa7d97eb6b3d96c18df1776a28e0bcd89e465d4"
+  integrity sha512-a5yMfDkoEGiOnREitNWIydnc+JnWEb2TElFiwcoPV5ewKEZZ6t9SPa2c1NKzsxZgM2OePBVvpBqMOi7lEVNMsg==
   dependencies:
     comment-json "4.1.1"
     string-width "4.2.3"
 
-"@zowe/imperative@5.15.1":
-  version "5.15.1"
-  resolved "https://registry.npmjs.org/@zowe/imperative/-/imperative-5.15.1.tgz#a5ff3fdafda93a37c67f36801b8f94e98fbd7d4e"
-  integrity sha512-T/TGh9WGFgwpWh80cj3mRLGKoUW2CT+W56Da2uXTAsSqVBz25i4iLcfl2w/G7Q+WVa0udXQfCVBCLlAG/WqvyA==
+"@zowe/imperative@5.18.0":
+  version "5.18.0"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.18.0.tgz#d3035a291601d21554b871cd6f98990411d8cd92"
+  integrity sha512-SE0WfySTkaxJa1s26lexQuN1efUPhKe2P2A9MXjzHl7+OOLg+QU0gGS8SpVS1yEXQi+yZfGPorPEqEn2DC+n5A==
   dependencies:
     "@types/yargs" "13.0.4"
     "@zowe/perf-timing" "1.0.7"
@@ -2323,23 +2328,29 @@
     fs-extra "8.1.0"
     pkg-up "2.0.0"
 
-"@zowe/provisioning-for-zowe-sdk@7.16.5":
-  version "7.16.5"
-  resolved "https://registry.npmjs.org/@zowe/provisioning-for-zowe-sdk/-/provisioning-for-zowe-sdk-7.16.5.tgz#f98561f46cb1844025b3df5e991f9a51131932c6"
-  integrity sha512-FTn29mGvLac2dMYgw1yXMqmocBS9cX6vHyUIQiWjPDLlKTlb2QcQ27Y79gHt/xaT1gkyelx7HP78Aq5J4poCaA==
+"@zowe/provisioning-for-zowe-sdk@7.18.0":
+  version "7.18.0"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/provisioning-for-zowe-sdk/-/@zowe/provisioning-for-zowe-sdk-7.18.0.tgz#85348a9d539748a65e9693fa0857c52462e551ef"
+  integrity sha512-ZqfNuQOQ0ohMBJjFI4itF+mH3V8EKiQw9n+pgf9qjyAXMfuvq6B0QmtzO5pvKy9IrFwokDQH3C2tfsY5EGL62A==
   dependencies:
     js-yaml "4.1.0"
 
-"@zowe/zos-console-for-zowe-sdk@7.16.5":
-  version "7.16.5"
-  resolved "https://registry.npmjs.org/@zowe/zos-console-for-zowe-sdk/-/zos-console-for-zowe-sdk-7.16.5.tgz#ab6b08ec456a1d2435d6d6718424495405a2a575"
-  integrity sha512-Mup/GpK2vmTmq4OtRY8q4m+Lul2NIZLoqDNFRWuQbazJ03Bqud3hEav+Yv+heP3afU+nsXpb+yxg+PvJJyJbsA==
+"@zowe/secrets-for-zowe-sdk@7.18.0":
+  version "7.18.0"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/secrets-for-zowe-sdk/-/@zowe/secrets-for-zowe-sdk-7.18.0.tgz#2741de10f4c16811b25bdf4944f669a0d15e3788"
+  integrity sha512-QyZQh45pZEj9PWkqaTfMFIFDiHpMI4aCaZSbsbhanz54h/kN1s6nT4ri43EjQ3J3aUsG2wEjKkotjBZdGg3cHw==
 
-"@zowe/zos-files-for-zowe-sdk@7.16.6":
-  version "7.16.6"
-  resolved "https://registry.npmjs.org/@zowe/zos-files-for-zowe-sdk/-/zos-files-for-zowe-sdk-7.16.6.tgz#7de7268ef9360da1aba03f7b83cb5b83eb091823"
-  integrity sha512-+BT3vPFkX0WfEi7hu+HtJs0QnkXt5YbqxfAIE2VwTMELRoOdQCOIFsoe9cGVtZrJ3zluzlqbXbqpX8ymEKcevQ==
+"@zowe/zos-console-for-zowe-sdk@7.18.0":
+  version "7.18.0"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/zos-console-for-zowe-sdk/-/@zowe/zos-console-for-zowe-sdk-7.18.0.tgz#ea399a6cd80fbddfa3ba00a89dac681cdc908fa1"
+  integrity sha512-sVWHNuJFncHqN75nKan8Ybx1wvAWo8fqPjk3CLbChWXOS9iSFIjArirrqFODWMvgQ0p+3+ns2v88OOJ/WIQsiQ==
+
+"@zowe/zos-files-for-zowe-sdk@7.18.0":
+  version "7.18.0"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/zos-files-for-zowe-sdk/-/@zowe/zos-files-for-zowe-sdk-7.18.0.tgz#af512179746538fc2f8945ae68240763e3d9d523"
+  integrity sha512-D25+TaUj+2d8h9JRxiy6pzkLFst0t0tbGK433LZsF4O1TzrbQsM4VRdcLYKrzBbQkSsYOyyasxAs4HUjKWdr4w==
   dependencies:
+    get-stream "6.0.1"
     minimatch "5.0.1"
 
 "@zowe/zos-ftp-for-zowe-cli@2.1.2":
@@ -2349,43 +2360,43 @@
   dependencies:
     zos-node-accessor "1.0.14"
 
-"@zowe/zos-jobs-for-zowe-sdk@7.16.6":
-  version "7.16.6"
-  resolved "https://registry.npmjs.org/@zowe/zos-jobs-for-zowe-sdk/-/zos-jobs-for-zowe-sdk-7.16.6.tgz#2a9abba84152962796db8ae046a250c18600ec72"
-  integrity sha512-qjhJy6kjQlf99S3PFXxWmhiC0Jt8tvbBJiW75KJ/d0UK6P/LMqxXMGIHdtsd2bBcbByrzy9kmFYsDziOsnAhtQ==
+"@zowe/zos-jobs-for-zowe-sdk@7.18.0":
+  version "7.18.0"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/zos-jobs-for-zowe-sdk/-/@zowe/zos-jobs-for-zowe-sdk-7.18.0.tgz#53981bebc184e39b227f2e639216363aa0e3e885"
+  integrity sha512-PX2AMeyJjJjkJDq+a4HxrY9PypmMq7Z0NFAmJCCv/wp+DXaGyYYK3Kc5SNU/SSVqyJYv03blkFR78GEAhJK+4A==
   dependencies:
-    "@zowe/zos-files-for-zowe-sdk" "7.16.6"
+    "@zowe/zos-files-for-zowe-sdk" "7.18.0"
 
-"@zowe/zos-logs-for-zowe-sdk@7.16.5":
-  version "7.16.5"
-  resolved "https://registry.npmjs.org/@zowe/zos-logs-for-zowe-sdk/-/zos-logs-for-zowe-sdk-7.16.5.tgz#ceff7fb5d5cae222bffbbfcf016d8630f2e90e69"
-  integrity sha512-ZW8ysfHEsOzxoH1+wnzSlL+bkR3A8k9HNefX6ZmsWBcQ8mU9PssdjwNq7CMDYZktTR6K3nHRFGQf015/DcyQ0Q==
+"@zowe/zos-logs-for-zowe-sdk@7.18.0":
+  version "7.18.0"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/zos-logs-for-zowe-sdk/-/@zowe/zos-logs-for-zowe-sdk-7.18.0.tgz#100c2fb629eee55cadbd6eff56a0c472e88f1495"
+  integrity sha512-88lNA85LX8OYRvuTYrqJhjMGwc+BcudGM4wQ2JQwVshg/y622fWAV1w5O0vCFPEXxBi5pCT0YdKMYmLeGc4vkQ==
 
-"@zowe/zos-tso-for-zowe-sdk@7.16.5":
-  version "7.16.5"
-  resolved "https://registry.npmjs.org/@zowe/zos-tso-for-zowe-sdk/-/zos-tso-for-zowe-sdk-7.16.5.tgz#ac130fac945a88adc38efcb86a65397ee193973d"
-  integrity sha512-ao4QY7BMJ/NhNbfyD2LaacErC8gUFhuyuXemWRSyxbmxaL/YzVPzOwYC/m6mLEttM7zmuFeby2He8qemcD/AqA==
+"@zowe/zos-tso-for-zowe-sdk@7.18.0":
+  version "7.18.0"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/zos-tso-for-zowe-sdk/-/@zowe/zos-tso-for-zowe-sdk-7.18.0.tgz#7e9fba8a644f96780c84e3e0583b36d84d5fa81c"
+  integrity sha512-7hZb9pgngwU7PuCoyFXIUgldnZCM1dJiAxWG1VNlH+5zwOljzaveBz4cjvtqIuJTBYA7V3+gq4xj6/QNXNC97Q==
   dependencies:
-    "@zowe/zosmf-for-zowe-sdk" "7.16.5"
+    "@zowe/zosmf-for-zowe-sdk" "7.18.0"
 
-"@zowe/zos-uss-for-zowe-sdk@7.16.5":
-  version "7.16.5"
-  resolved "https://registry.npmjs.org/@zowe/zos-uss-for-zowe-sdk/-/zos-uss-for-zowe-sdk-7.16.5.tgz#2186dec61b7f2cba52a5174d83078f1a19f427b4"
-  integrity sha512-I+50cbYD6OqbzRR2OtCNoAsIZn55hv3K016wt29Z+G1bi15+kW+i2jvmWbBbA2CHXEmqxFN7yNeFDqoi9342ow==
+"@zowe/zos-uss-for-zowe-sdk@7.18.0":
+  version "7.18.0"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/zos-uss-for-zowe-sdk/-/@zowe/zos-uss-for-zowe-sdk-7.18.0.tgz#ba2850c5bbac04b23f66127dede4e894b8632162"
+  integrity sha512-cK+Y8uN5qGfxsaR3UYxThOC9Deb5m0YP4UzA7QX2rWnPvetdzGddmJhXxLcZ2qbbVhqOpdqFxSPkOsp0E/l8Kw==
   dependencies:
     ssh2 "1.11.0"
 
-"@zowe/zos-workflows-for-zowe-sdk@7.16.6":
-  version "7.16.6"
-  resolved "https://registry.npmjs.org/@zowe/zos-workflows-for-zowe-sdk/-/zos-workflows-for-zowe-sdk-7.16.6.tgz#e00222a861e3031024b0a61a329aa8143b8a1a81"
-  integrity sha512-h0EEK/tgwjJtfN1T7oYove6hr7MsuSJFwHHvp2M5fdQiubme4MXf2XTeNBO8ScxMthoHPzm3Ef6wHEedPGkQfA==
+"@zowe/zos-workflows-for-zowe-sdk@7.18.0":
+  version "7.18.0"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/zos-workflows-for-zowe-sdk/-/@zowe/zos-workflows-for-zowe-sdk-7.18.0.tgz#4c28b4e2a3754669c9617639cc4f598e4eef3abc"
+  integrity sha512-fwohyemEHrc5q9UQTToYRB8+YX1NjpsyoKYt4dEEEkiEOwHZ/99vPqM6dpVm/mj7iZyTfpgHuxB4lPEZNdD21A==
   dependencies:
-    "@zowe/zos-files-for-zowe-sdk" "7.16.6"
+    "@zowe/zos-files-for-zowe-sdk" "7.18.0"
 
-"@zowe/zosmf-for-zowe-sdk@7.16.5":
-  version "7.16.5"
-  resolved "https://registry.npmjs.org/@zowe/zosmf-for-zowe-sdk/-/zosmf-for-zowe-sdk-7.16.5.tgz#7423cd173f70b7696829d450bee1c4832687fbc1"
-  integrity sha512-ieT79IrplPgOkSc51LB8A4FDRokqP0Q5oomHsIFnm5/HnjD1I/UaLTuSs0ZuI2H2zlPnc4sZ3per+cFxv/mX1w==
+"@zowe/zosmf-for-zowe-sdk@7.18.0":
+  version "7.18.0"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/zosmf-for-zowe-sdk/-/@zowe/zosmf-for-zowe-sdk-7.18.0.tgz#fd31eb10032adc233561b224895296c275083ce0"
+  integrity sha512-nxB9zmWHamXYcCLKOlJtsAEhl6maLHRtSbAuPupytbNgtH6z5bt6WuHefJbq03wy0D2smWMiNk+zuTE4Lim/6A==
 
 abab@^2.0.3, abab@^2.0.5:
   version "2.0.6"
@@ -7172,7 +7183,7 @@ just-extend@^4.0.2:
   resolved "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz#ef5e589afb61e5d66b24eca749409a8939a8c744"
   integrity sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==
 
-keytar@7.9.0, keytar@^7.2.0, keytar@^7.7.0:
+keytar@^7.7.0:
   version "7.9.0"
   resolved "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz#4c6225708f51b50cbf77c5aae81721964c2918cb"
   integrity sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2340,6 +2340,11 @@
   resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/secrets-for-zowe-sdk/-/@zowe/secrets-for-zowe-sdk-7.18.0.tgz#2741de10f4c16811b25bdf4944f669a0d15e3788"
   integrity sha512-QyZQh45pZEj9PWkqaTfMFIFDiHpMI4aCaZSbsbhanz54h/kN1s6nT4ri43EjQ3J3aUsG2wEjKkotjBZdGg3cHw==
 
+"@zowe/secrets-for-zowe-sdk@7.18.1":
+  version "7.18.1"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/secrets-for-zowe-sdk/-/@zowe/secrets-for-zowe-sdk-7.18.1.tgz#79b2cb314028366c8f4b33eb2158c7e985e7989a"
+  integrity sha512-4rGo+KgYWhsfggaBBsb3xC7XZ50/GPrmtA2jOVKGrIYCjlqgJ21suMzyCzVioqlS+qNnbg9vxP/4C2Bew9wuUA==
+
 "@zowe/zos-console-for-zowe-sdk@7.18.0":
   version "7.18.0"
   resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/zos-console-for-zowe-sdk/-/@zowe/zos-console-for-zowe-sdk-7.18.0.tgz#ea399a6cd80fbddfa3ba00a89dac681cdc908fa1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1754,6 +1754,14 @@
   resolved "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@traeok/keytar-rs@github:traeok/keytar-rs":
+  version "0.0.0"
+  resolved "https://codeload.github.com/traeok/keytar-rs/tar.gz/0b00af3fb1ae1b70ef68b049071d5c392218dbc5"
+
+"@traeok/keytar-rs@https://github.com/traeok/keytar-rs.git":
+  version "0.0.0"
+  resolved "https://github.com/traeok/keytar-rs.git#0b00af3fb1ae1b70ef68b049071d5c392218dbc5"
+
 "@types/babel__core@^7.1.14":
   version "7.1.20"
   resolved "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.20.tgz#e168cdd612c92a2d335029ed62ac94c95b362359"
@@ -2234,30 +2242,28 @@
   resolved "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-"@zowe/cli@7.16.2", "@zowe/cli@^7.16.2":
-  version "7.16.2"
-  resolved "https://registry.npmjs.org/@zowe/cli/-/cli-7.16.2.tgz#a0f92c51043a77dc7c401b50d3cdb88150ff2ee5"
-  integrity sha512-AHw92hRhWTEhRLZYCjSiQLb0+v3QvqzMo0U1WeZf9Ou9vYNKpR4I5B3VCG6+dmfxKRAz9o6V/kHA1sMDARLUdQ==
+"@zowe/cli@7.16.2", "@zowe/cli@^7.16.2", "@zowe/cli@file:../zowe-cli/packages/cli":
+  version "7.16.4"
   dependencies:
-    "@zowe/core-for-zowe-sdk" "7.16.1"
-    "@zowe/imperative" "5.13.2"
+    "@zowe/core-for-zowe-sdk" "7.16.4"
+    "@zowe/imperative" "5.14.2"
     "@zowe/perf-timing" "1.0.7"
-    "@zowe/provisioning-for-zowe-sdk" "7.16.1"
-    "@zowe/zos-console-for-zowe-sdk" "7.16.1"
-    "@zowe/zos-files-for-zowe-sdk" "7.16.1"
-    "@zowe/zos-jobs-for-zowe-sdk" "7.16.1"
-    "@zowe/zos-logs-for-zowe-sdk" "7.16.1"
-    "@zowe/zos-tso-for-zowe-sdk" "7.16.1"
-    "@zowe/zos-uss-for-zowe-sdk" "7.16.1"
-    "@zowe/zos-workflows-for-zowe-sdk" "7.16.1"
-    "@zowe/zosmf-for-zowe-sdk" "7.16.1"
+    "@zowe/provisioning-for-zowe-sdk" "7.16.4"
+    "@zowe/zos-console-for-zowe-sdk" "7.16.4"
+    "@zowe/zos-files-for-zowe-sdk" "7.16.4"
+    "@zowe/zos-jobs-for-zowe-sdk" "7.16.4"
+    "@zowe/zos-logs-for-zowe-sdk" "7.16.4"
+    "@zowe/zos-tso-for-zowe-sdk" "7.16.4"
+    "@zowe/zos-uss-for-zowe-sdk" "7.16.4"
+    "@zowe/zos-workflows-for-zowe-sdk" "7.16.4"
+    "@zowe/zosmf-for-zowe-sdk" "7.16.4"
     find-process "1.4.7"
     get-stream "6.0.1"
     lodash "4.17.21"
     minimatch "5.0.1"
     tar "6.1.14"
   optionalDependencies:
-    keytar "7.9.0"
+    "@traeok/keytar-rs" "github:traeok/keytar-rs"
 
 "@zowe/core-for-zowe-sdk@7.16.1":
   version "7.16.1"
@@ -2267,11 +2273,18 @@
     comment-json "4.1.1"
     string-width "4.2.3"
 
-"@zowe/imperative@5.13.2":
-  version "5.13.2"
-  resolved "https://registry.npmjs.org/@zowe/imperative/-/imperative-5.13.2.tgz#2019292140ebf67da03144f315e0be4ab17ed481"
-  integrity sha512-doA7KcmKm/VW9ZtVSRbSFBknfyzoGawuiV//+q6vBb08qiIPXn1Gg1Mn/6ECpEouBxXqRJGuXj28f+HZX9YZCA==
+"@zowe/core-for-zowe-sdk@7.16.4":
+  version "7.16.4"
+  resolved "https://registry.npmjs.org/@zowe/core-for-zowe-sdk/-/core-for-zowe-sdk-7.16.4.tgz#7d2e5e20418562356d7e3afe32c5a307e79a258a"
+  integrity sha512-R9P1IoYLJpQ8lmBKIs436Ye397q+h8y87gYGJxlkEb/1pXyySx5ydQnAICWI7Iy6hh0aUo394INTEA0HQEc3XA==
   dependencies:
+    comment-json "4.1.1"
+    string-width "4.2.3"
+
+"@zowe/imperative@5.13.2", "@zowe/imperative@5.14.2", "@zowe/imperative@file:../imperative":
+  version "5.14.2"
+  dependencies:
+    "@traeok/keytar-rs" "github:traeok/keytar-rs"
     "@types/yargs" "13.0.4"
     "@zowe/perf-timing" "1.0.7"
     chalk "2.4.2"
@@ -2325,15 +2338,34 @@
   dependencies:
     js-yaml "4.1.0"
 
+"@zowe/provisioning-for-zowe-sdk@7.16.4":
+  version "7.16.4"
+  resolved "https://registry.npmjs.org/@zowe/provisioning-for-zowe-sdk/-/provisioning-for-zowe-sdk-7.16.4.tgz#ac240c80cc8c82eff501b55b4f27bbe207d7f84b"
+  integrity sha512-+xyyqWzbG9umznRJqtwaS3bkXp2KUy+71OhWMHfOijx/R+pomI7PhnmmQrpjMlTkvBvbDh82peUx9S+sxmYh/w==
+  dependencies:
+    js-yaml "4.1.0"
+
 "@zowe/zos-console-for-zowe-sdk@7.16.1":
   version "7.16.1"
   resolved "https://registry.npmjs.org/@zowe/zos-console-for-zowe-sdk/-/zos-console-for-zowe-sdk-7.16.1.tgz#a793daa0d93d9323127a2e844b0cb425bcb3c023"
   integrity sha512-Yu9sKPjwYL1+3OAAxql1iJ0wMhn+lnnCw1B1WMXDDaY4kDV8pNKCOG/plbbXhEeUJ/UtUYh9Srr+S0Z0wKQWPA==
 
+"@zowe/zos-console-for-zowe-sdk@7.16.4":
+  version "7.16.4"
+  resolved "https://registry.npmjs.org/@zowe/zos-console-for-zowe-sdk/-/zos-console-for-zowe-sdk-7.16.4.tgz#c0d54cc4d9d824f1d7b05605ee898c80fe51ada8"
+  integrity sha512-rM4bfEZigWyfS/mzRfmMLiAi407kKmbVAzl6XllHQQg7Vtc+BVPmGA8JvQDBtMswnAc5c/EIp3IeJ7vdjt3TCA==
+
 "@zowe/zos-files-for-zowe-sdk@7.16.1":
   version "7.16.1"
   resolved "https://registry.npmjs.org/@zowe/zos-files-for-zowe-sdk/-/zos-files-for-zowe-sdk-7.16.1.tgz#39405d4ea13e1501a52fb039be046ad7c1a5b10d"
   integrity sha512-lFVWpLTkjtbd6Xw7OGsfMmNqhYVZYK+iSVXNW3w+qoJGVeC0GtzFlZBqD/a4SzjLSBK00tAc3SEaiiqiprHJIA==
+  dependencies:
+    minimatch "5.0.1"
+
+"@zowe/zos-files-for-zowe-sdk@7.16.4":
+  version "7.16.4"
+  resolved "https://registry.npmjs.org/@zowe/zos-files-for-zowe-sdk/-/zos-files-for-zowe-sdk-7.16.4.tgz#5b297e75ec73b90d717bddfe5249f6ea5ef462d7"
+  integrity sha512-7mNoikQRu3taBWS7W0mEto8PE8uPheBrFYntrvq6QiVlCx4/YgFK+IB1Vzp93/G/YYS9iEbEQTKplS1W7KTSIA==
   dependencies:
     minimatch "5.0.1"
 
@@ -2351,10 +2383,22 @@
   dependencies:
     "@zowe/zos-files-for-zowe-sdk" "7.16.1"
 
+"@zowe/zos-jobs-for-zowe-sdk@7.16.4":
+  version "7.16.4"
+  resolved "https://registry.npmjs.org/@zowe/zos-jobs-for-zowe-sdk/-/zos-jobs-for-zowe-sdk-7.16.4.tgz#bb8d6aacef6c199a3988b2af5e765222bcd26855"
+  integrity sha512-FfdrAkblCHV9yp3SYNPd/fxzggjILTalWHpo88XJrpp++7LSLYG124i0J26FxD0LEfmV5TZzttpb1UYt2OrU6A==
+  dependencies:
+    "@zowe/zos-files-for-zowe-sdk" "7.16.4"
+
 "@zowe/zos-logs-for-zowe-sdk@7.16.1":
   version "7.16.1"
   resolved "https://registry.npmjs.org/@zowe/zos-logs-for-zowe-sdk/-/zos-logs-for-zowe-sdk-7.16.1.tgz#d516d73136ba9d61f94bba78e03a1a7c399abfcd"
   integrity sha512-Fkma+Lkjcm5zjooQRMJByPi8Zdb0FyU9f+8uVNwkb0a+4Fwxe/AMZIYoT82FkQfBjlq7gVu7ntPcEP3Y02yl7w==
+
+"@zowe/zos-logs-for-zowe-sdk@7.16.4":
+  version "7.16.4"
+  resolved "https://registry.npmjs.org/@zowe/zos-logs-for-zowe-sdk/-/zos-logs-for-zowe-sdk-7.16.4.tgz#8bd7f6cdfc02d1a5d1c98aae7d6edb2b227c9f0f"
+  integrity sha512-6MQCIzLll02P0iqqRHfujt854Q8A9O0/5EnkR3eyWAQw4bMIEYCBub9TYCmurNepXhTNaQR6E2ayyThjolMDHw==
 
 "@zowe/zos-tso-for-zowe-sdk@7.16.1":
   version "7.16.1"
@@ -2363,10 +2407,24 @@
   dependencies:
     "@zowe/zosmf-for-zowe-sdk" "7.16.1"
 
+"@zowe/zos-tso-for-zowe-sdk@7.16.4":
+  version "7.16.4"
+  resolved "https://registry.npmjs.org/@zowe/zos-tso-for-zowe-sdk/-/zos-tso-for-zowe-sdk-7.16.4.tgz#4ed4585922ad8475a158057a2abc0fba88fda0e6"
+  integrity sha512-v3SgI9uL30y3YT3mi6AOlmMtCp76w+/jDCAZw0nLsulSKxz40pKGuxiVmpHlQmrMrQPXTSRzu1KE7/7LTRrWkg==
+  dependencies:
+    "@zowe/zosmf-for-zowe-sdk" "7.16.4"
+
 "@zowe/zos-uss-for-zowe-sdk@7.16.1":
   version "7.16.1"
   resolved "https://registry.npmjs.org/@zowe/zos-uss-for-zowe-sdk/-/zos-uss-for-zowe-sdk-7.16.1.tgz#69b4b1ac79c33058f37e720c4516cf0b74915422"
   integrity sha512-8rAOjPR803gKm1um8YpTNd0OySlLilw9twT6N03KVT+I+hhKi3ztvDtJWzejptifHQl0E+YRFKDOj14UkqRmbA==
+  dependencies:
+    ssh2 "1.11.0"
+
+"@zowe/zos-uss-for-zowe-sdk@7.16.4":
+  version "7.16.4"
+  resolved "https://registry.npmjs.org/@zowe/zos-uss-for-zowe-sdk/-/zos-uss-for-zowe-sdk-7.16.4.tgz#831746f813714dc26e4e5167959cd9c94da14e66"
+  integrity sha512-IldSdbuTDItQBD206ExpfLBsB6Y8xDb/Ft5t7FBLDffZXghub8saHvGsrFU2L0vdNwSJBmDxAzzJ7UlTH70ygw==
   dependencies:
     ssh2 "1.11.0"
 
@@ -2377,10 +2435,22 @@
   dependencies:
     "@zowe/zos-files-for-zowe-sdk" "7.16.1"
 
+"@zowe/zos-workflows-for-zowe-sdk@7.16.4":
+  version "7.16.4"
+  resolved "https://registry.npmjs.org/@zowe/zos-workflows-for-zowe-sdk/-/zos-workflows-for-zowe-sdk-7.16.4.tgz#0cd0f0a051cad0e7ff271bbc60ea402d7fc43203"
+  integrity sha512-SRsv8il7qoLHDdy8AT0jQS5mi5vMewcHrUV6rpMB0Nox2GPvfkGYQiOcmnXb6dsa9RUPfTyNX/NMkLDgx48qkQ==
+  dependencies:
+    "@zowe/zos-files-for-zowe-sdk" "7.16.4"
+
 "@zowe/zosmf-for-zowe-sdk@7.16.1":
   version "7.16.1"
   resolved "https://registry.npmjs.org/@zowe/zosmf-for-zowe-sdk/-/zosmf-for-zowe-sdk-7.16.1.tgz#6bc0b08e30ffcaedd6670b5de3196233c603a041"
   integrity sha512-K4ZKVpgfJ5Th8qjZqcHnE36zOvkjUuRITybejxjDxwtary+jKy6ZBFsNbRTWtboc4Zx8S1fm+0RdJS/3X1yW/Q==
+
+"@zowe/zosmf-for-zowe-sdk@7.16.4":
+  version "7.16.4"
+  resolved "https://registry.npmjs.org/@zowe/zosmf-for-zowe-sdk/-/zosmf-for-zowe-sdk-7.16.4.tgz#ac293d74c5c40393cce66e9cafa2ae158a28caa3"
+  integrity sha512-n4wIeN1IO9AFnTuxujYCZ4m2hRysGvK6O6DIDYRkswS0AcqkLxJ+0p4R/FmMdr10WAFAB0X0rJtW35ZP4hJooA==
 
 abab@^2.0.3, abab@^2.0.5:
   version "2.0.6"
@@ -7160,7 +7230,7 @@ just-extend@^4.0.2:
   resolved "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz#ef5e589afb61e5d66b24eca749409a8939a8c744"
   integrity sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==
 
-keytar@7.9.0, keytar@^7.2.0, keytar@^7.7.0:
+keytar@7.9.0, keytar@^7.7.0:
   version "7.9.0"
   resolved "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz#4c6225708f51b50cbf77c5aae81721964c2918cb"
   integrity sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==


### PR DESCRIPTION
## Proposed changes

This PR:
- implements the use of the `keyring` module from the new [`@zowe/secrets-for-zowe-sdk`](https://github.com/zowe/zowe-cli/tree/master/packages/secrets)
- removes old references to `node-keytar` in the codebase and tests
- updates old `node-keytar` references to the new `keyring` module

**Note** that tests will fail until the imperative PR (linked below) is merged and published.

## Release Notes

Milestone: 2.10.0

Changelog: TBD

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] New feature (non-breaking change which adds functionality)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [x] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [x] Any PR dependencies have been merged and published (if appropriate)
