### PR TITLE
feat(v1/secrets): Port Secrets SDK changes to v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ debug.log
 npm-shrinkwrap.json
 vscode-extension-for-zowe*.vsix
 .vscode/settings.json
+.vscode/*.env
+.vscode-test
 .history
 .DS_Store
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ temp
 *.vsix
 *.tgz
 .tmp
+prebuilds/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,9 @@
       "args": ["--extensionDevelopmentPath=${workspaceFolder}/packages/zowe-explorer", "--verbose"],
       "outFiles": ["${workspaceFolder}/packages/zowe-explorer/out/**/*.js"],
       "preLaunchTask": "build dev watch",
-      "smartStep": true
+      "smartStep": true,
+      "skipFiles": ["<node_internals>/**"],
+      "envFile": "${workspaceFolder}/.vscode/.env"
     },
     {
       "name": "Run Zowe Explorer VS Code Extension (Theia)",

--- a/.vscode/sample_env
+++ b/.vscode/sample_env
@@ -1,0 +1,6 @@
+# Create a ".env" file with the contents of this file
+
+# Make sure to get a valid DBus Session Address
+# by unlocking the keyring on a terminal, and
+# copy the contents of "echo $DBUS_SESSION_BUS_ADDRESS"
+DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/0/bus

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "yarn": "1.22.10"
   },
   "resolutions": {
-    "**/xml2js": "^0.5.0"
+    "**/xml2js": "^0.5.0",
+    "**/semver": "^7.5.3"
   },
   "scripts": {
     "prepare": "husky install && yarn build",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "vscode": "^1.43.0"
   },
   "dependencies": {
-    "@zowe/cli": "6.40.15",
+    "@zowe/cli": "6.40.18",
     "vscode-nls": "4.1.2"
   },
   "devDependencies": {

--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 ## TBD Release
 
+### New features and enhancements
+
+- Replaced `keytar` dependency with `keyring` module from [`@zowe/secrets-for-zowe-sdk`](https://github.com/zowe/zowe-cli/tree/master/packages/secrets). [#2358](https://github.com/zowe/vscode-extension-for-zowe/issues/2358)
+
 ### Bug fixes
 
 ## `1.22.3`

--- a/packages/zowe-explorer-api/package.json
+++ b/packages/zowe-explorer-api/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@zowe/cli": "6.40.18",
-    "@zowe/secrets-for-zowe-sdk": "7.18.3",
+    "@zowe/secrets-for-zowe-sdk": "7.18.4",
     "semver": "^7.5.3"
   },
   "scripts": {

--- a/packages/zowe-explorer-api/package.json
+++ b/packages/zowe-explorer-api/package.json
@@ -13,12 +13,12 @@
     "lib"
   ],
   "devDependencies": {
-    "@types/semver": "^7.3.6"
+    "@types/semver": "^7.5.0"
   },
   "dependencies": {
     "@zowe/cli": "6.40.15",
     "@zowe/secrets-for-zowe-sdk": "7.18.1",
-    "semver": "^7.3.5"
+    "semver": "^7.5.3"
   },
   "scripts": {
     "build": "yarn clean && tsc -p ./",

--- a/packages/zowe-explorer-api/package.json
+++ b/packages/zowe-explorer-api/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@zowe/cli": "6.40.15",
+    "@zowe/secrets-for-zowe-sdk": "7.18.1",
     "semver": "^7.3.5"
   },
   "scripts": {

--- a/packages/zowe-explorer-api/package.json
+++ b/packages/zowe-explorer-api/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@zowe/cli": "6.40.18",
-    "@zowe/secrets-for-zowe-sdk": "7.18.1",
+    "@zowe/secrets-for-zowe-sdk": "7.18.3",
     "semver": "^7.5.3"
   },
   "scripts": {

--- a/packages/zowe-explorer-api/package.json
+++ b/packages/zowe-explorer-api/package.json
@@ -16,7 +16,7 @@
     "@types/semver": "^7.5.0"
   },
   "dependencies": {
-    "@zowe/cli": "6.40.15",
+    "@zowe/cli": "6.40.18",
     "@zowe/secrets-for-zowe-sdk": "7.18.1",
     "semver": "^7.5.3"
   },

--- a/packages/zowe-explorer-api/src/security/KeytarApi.ts
+++ b/packages/zowe-explorer-api/src/security/KeytarApi.ts
@@ -17,12 +17,12 @@ import { KeytarCredentialManager } from "./KeytarCredentialManager";
 export class KeytarApi {
     public constructor(protected log: imperative.Logger) {}
 
-    public async activateKeytar(initialized: boolean, isTheia: boolean): Promise<void> {
+    public async activateKeytar(initialized: boolean, _isTheia: boolean): Promise<void> {
         const log = imperative.Logger.getAppLogger();
         const profiles = new ProfilesCache(log);
         const scsActive = profiles.isSecureCredentialPluginActive();
         if (scsActive) {
-            const keytar: NodeRequire | undefined = KeytarCredentialManager.getSecurityModules("keytar", isTheia);
+            const keytar = (await import("@zowe/secrets-for-zowe-sdk")).keyring;
             if (!initialized && keytar) {
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                 KeytarCredentialManager.keytar = keytar;

--- a/packages/zowe-explorer/.vscodeignore
+++ b/packages/zowe-explorer/.vscodeignore
@@ -30,3 +30,4 @@ docs
 i18n
 scripts
 node_modules/**
+!prebuilds/**

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ## TBD Release
 
+### New features and enhancements
+
+- Replaced `keytar` dependency with `keyring` module from [`@zowe/secrets-for-zowe-sdk`](https://github.com/zowe/zowe-cli/tree/master/packages/secrets). [#2358](https://github.com/zowe/vscode-extension-for-zowe/issues/2358)
+
 ### Bug fixes
 
 ## `1.22.3`

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -1696,6 +1696,7 @@
     "vscode": "^1.43.0"
   },
   "devDependencies": {
+    "@napi-rs/cli": "^2.16.1",
     "@types/chai": "^4.2.6",
     "@types/chai-as-promised": "^7.1.0",
     "@types/expect": "^1.20.3",
@@ -1709,6 +1710,7 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "chalk": "^2.4.1",
+    "copy-webpack-plugin": "^6.4.1",
     "cross-env": "^5.2.0",
     "del": "^4.1.1",
     "eslint": "^6.8.0",
@@ -1729,7 +1731,6 @@
     "jest-stare": "^2.2.0",
     "jsdoc": "^3.6.3",
     "jsdom": "^16.0.0",
-    "keytar": "^7.2.0",
     "log4js": "^3.0.5",
     "markdownlint-cli": "^0.16.0",
     "mem": "^6.0.1",
@@ -1744,6 +1745,7 @@
     "webpack-cli": "^3.3.11"
   },
   "dependencies": {
+    "@zowe/secrets-for-zowe-sdk": "7.18.1",
     "@zowe/zowe-explorer-api": "1.22.4-SNAPSHOT",
     "fs-extra": "8.0.1",
     "isbinaryfile": "4.0.4",

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -1745,7 +1745,7 @@
     "webpack-cli": "^3.3.11"
   },
   "dependencies": {
-    "@zowe/secrets-for-zowe-sdk": "7.18.3",
+    "@zowe/secrets-for-zowe-sdk": "7.18.4",
     "@zowe/zowe-explorer-api": "1.22.4-SNAPSHOT",
     "fs-extra": "8.0.1",
     "isbinaryfile": "4.0.4",

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -1745,7 +1745,7 @@
     "webpack-cli": "^3.3.11"
   },
   "dependencies": {
-    "@zowe/secrets-for-zowe-sdk": "7.18.1",
+    "@zowe/secrets-for-zowe-sdk": "7.18.3",
     "@zowe/zowe-explorer-api": "1.22.4-SNAPSHOT",
     "fs-extra": "8.0.1",
     "isbinaryfile": "4.0.4",

--- a/packages/zowe-explorer/webpack.config.js
+++ b/packages/zowe-explorer/webpack.config.js
@@ -25,6 +25,8 @@ const path = require("path");
 var webpack = require("webpack");
 var fs = require("fs");
 
+const CopyPlugin = require("copy-webpack-plugin");
+
 /**@type {import('webpack').Configuration}*/
 const config = {
     target: "node", // vscode extensions run in a Node.js-context 📖 -> https://webpack.js.org/configuration/node/
@@ -81,7 +83,17 @@ const config = {
             },
         ],
     },
-    plugins: [new webpack.BannerPlugin(fs.readFileSync("../../scripts/banner.txt", "utf8"))],
+    plugins: [
+        new webpack.BannerPlugin(fs.readFileSync("../../scripts/banner.txt", "utf8")),
+        new CopyPlugin({
+            patterns: [
+                {
+                    from: "../../node_modules/@zowe/secrets-for-zowe-sdk/prebuilds",
+                    to: "../../prebuilds",
+                },
+            ],
+        }),
+    ],
 };
 
 module.exports = config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,6 +1151,11 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@napi-rs/cli@^2.16.1":
+  version "2.16.3"
+  resolved "https://registry.npmjs.org/@napi-rs/cli/-/cli-2.16.3.tgz#6943d0614bbb4900a97b18ae074f735864f78c4b"
+  integrity sha512-3mLNPlbbOhpbIUKicLrJtIearlHXUuXL3UeueYyRRplpVMNkdn8xCyzY6PcYZi3JXR8bmCOiWgkVmLnrSL7DKw==
+
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
   resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
@@ -1414,6 +1419,11 @@
   version "7.0.6"
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
+
+"@types/json-schema@^7.0.8":
+  version "7.0.12"
+  resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz#d70faba7039d5fca54c83c7dbab41051d2b6f6cb"
+  integrity sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==
 
 "@types/minimatch@*":
   version "3.0.3"
@@ -1869,6 +1879,11 @@
   dependencies:
     js-yaml "3.14.1"
 
+"@zowe/secrets-for-zowe-sdk@7.18.1":
+  version "7.18.1"
+  resolved "https://registry.npmjs.org/@zowe/secrets-for-zowe-sdk/-/secrets-for-zowe-sdk-7.18.1.tgz#546a63f5ed880418f0e0496d0218c284c815c3ee"
+  integrity sha512-bcAnauDpTQXCPT8rMx2wrZwhg6xih1lDujG20h1sUGJC5eqvsNCq6gvpOtcahEpUF25oBJ931dKlIu1T99LQ7w==
+
 "@zowe/zos-console-for-zowe-sdk@6.40.15":
   version "6.40.15"
   resolved "https://registry.npmjs.org/@zowe/zos-console-for-zowe-sdk/-/zos-console-for-zowe-sdk-6.40.15.tgz#fab26e86e4ae49543c29ea7f8016c5b09f579b38"
@@ -2023,12 +2038,12 @@ ajv-errors@^1.0.0:
   resolved "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
 
-ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
+ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
   version "6.12.6"
   resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -2092,11 +2107,6 @@ ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
   integrity sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==
-
-ansi-regex@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz#123d6479e92ad45ad897d4054e3c7ca7db4944e1"
-  integrity sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==
 
 ansi-regex@^4.0.0, ansi-regex@^4.1.0:
   version "4.1.1"
@@ -2163,7 +2173,7 @@ append-buffer@^1.0.2:
   dependencies:
     buffer-equal "^1.0.0"
 
-aproba@^1.0.3, aproba@^1.1.1:
+aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
@@ -2172,14 +2182,6 @@ archy@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
   integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
-
-are-we-there-yet@~1.1.2:
-  version "1.1.5"
-  resolved "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21"
-  integrity sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==
-  dependencies:
-    delegates "^1.0.0"
-    readable-stream "^2.0.6"
 
 arg@^4.1.0:
   version "4.1.3"
@@ -2614,7 +2616,7 @@ braces@^2.3.1, braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-braces@^3.0.1, braces@~3.0.2:
+braces@^3.0.1, braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -3354,11 +3356,6 @@ console-browserify@^1.1.0:
   resolved "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
   integrity sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==
 
-console-control-strings@^1.0.0, console-control-strings@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
-  integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
-
 constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
@@ -3395,6 +3392,23 @@ copy-props@^2.0.1:
   dependencies:
     each-props "^1.3.2"
     is-plain-object "^5.0.0"
+
+copy-webpack-plugin@^6.4.1:
+  version "6.4.1"
+  resolved "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-6.4.1.tgz#138cd9b436dbca0a6d071720d5414848992ec47e"
+  integrity sha512-MXyPCjdPVx5iiWyl40Va3JGh27bKzOTNY3NjUTrosD2q7dR/cLD0013uqJ3BpFbUjyONINjb6qI7nDIJujrMbA==
+  dependencies:
+    cacache "^15.0.5"
+    fast-glob "^3.2.4"
+    find-cache-dir "^3.3.1"
+    glob-parent "^5.1.1"
+    globby "^11.0.1"
+    loader-utils "^2.0.0"
+    normalize-path "^3.0.0"
+    p-limit "^3.0.2"
+    schema-utils "^3.0.0"
+    serialize-javascript "^5.0.1"
+    webpack-sources "^1.4.3"
 
 core-js-compat@^3.6.2:
   version "3.6.5"
@@ -3673,13 +3687,6 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
-decompress-response@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-4.2.1.tgz#414023cc7a302da25ce2ec82d0d5238ccafd8986"
-  integrity sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==
-  dependencies:
-    mimic-response "^2.0.0"
-
 decompress-response@^6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
@@ -3778,11 +3785,6 @@ delayed-stream@~1.0.0:
   resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
-delegates@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
-  integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
-
 depd@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
@@ -3800,11 +3802,6 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
   integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
-
-detect-libc@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-libc@^2.0.0:
   version "2.0.1"
@@ -4589,6 +4586,17 @@ fast-glob@^3.1.1:
     micromatch "^4.0.2"
     picomatch "^2.2.1"
 
+fast-glob@^3.2.4:
+  version "3.3.1"
+  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz#784b4e897340f3dbbef17413b3f11acf03c874c4"
+  integrity sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -4679,6 +4687,15 @@ find-cache-dir@^2.1.0:
     commondir "^1.0.1"
     make-dir "^2.0.0"
     pkg-dir "^3.0.0"
+
+find-cache-dir@^3.3.1:
+  version "3.3.2"
+  resolved "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz#b30c5b6eff0730731aea9bbd9dbecbd80256d64b"
+  integrity sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^3.0.2"
+    pkg-dir "^4.1.0"
 
 find-up@4.1.0, find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
@@ -4921,20 +4938,6 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-gauge@~2.7.3:
-  version "2.7.4"
-  resolved "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
-  integrity sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=
-  dependencies:
-    aproba "^1.0.3"
-    console-control-strings "^1.0.0"
-    has-unicode "^2.0.0"
-    object-assign "^4.1.0"
-    signal-exit "^3.0.0"
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
-    wide-align "^1.1.0"
-
 geckodriver@^1.19.1:
   version "1.20.0"
   resolved "https://registry.npmjs.org/geckodriver/-/geckodriver-1.20.0.tgz#cd16edb177b88e31affcb54b18a238cae88950a7"
@@ -5044,7 +5047,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@~5.1.0, glob-parent@~5.1.2:
+glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@^5.1.1, glob-parent@^5.1.2, glob-parent@~5.1.0, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -5347,11 +5350,6 @@ has-symbols@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
   integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
-
-has-unicode@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
-  integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
 
 has-value@^0.3.1:
   version "0.3.1"
@@ -6833,14 +6831,6 @@ just-extend@^4.0.2:
   resolved "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz#158f1fdb01f128c411dc8b286a7b4837b3545282"
   integrity sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==
 
-keytar@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.npmjs.org/keytar/-/keytar-7.2.0.tgz#4db2bec4f9700743ffd9eda22eebb658965c8440"
-  integrity sha512-ECSaWvoLKI5SI0pGpZQeUV1/lpBYfkaxvoSp3zkiPOz05VavwSfLi8DdEaa9N2ekQZv3Chy+o7aP6n9mairBgw==
-  dependencies:
-    node-addon-api "^3.0.0"
-    prebuild-install "^6.0.0"
-
 keytar@^7.7.0:
   version "7.9.0"
   resolved "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz#4c6225708f51b50cbf77c5aae81721964c2918cb"
@@ -7005,6 +6995,15 @@ loader-utils@^1.0.2, loader-utils@^1.2.3, loader-utils@^1.4.0:
     emojis-list "^3.0.0"
     json5 "^1.0.1"
 
+loader-utils@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
+  integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^2.1.2"
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -7148,7 +7147,7 @@ make-dir@^2.0.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-make-dir@^3.0.0:
+make-dir@^3.0.0, make-dir@^3.0.2:
   version "3.1.0"
   resolved "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
@@ -7384,6 +7383,14 @@ micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
+micromatch@^4.0.4:
+  version "4.0.5"
+  resolved "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
+  integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
+  dependencies:
+    braces "^3.0.2"
+    picomatch "^2.3.1"
+
 miller-rabin@^4.0.0:
   version "4.0.1"
   resolved "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
@@ -7418,11 +7425,6 @@ mimic-fn@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz#65755145bbf3e36954b949c16450427451d5ca74"
   integrity sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==
-
-mimic-response@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
-  integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
 
 mimic-response@^3.1.0:
   version "3.1.0"
@@ -7764,24 +7766,12 @@ nise@^4.0.4:
     just-extend "^4.0.2"
     path-to-regexp "^1.7.0"
 
-node-abi@^2.7.0:
-  version "2.19.1"
-  resolved "https://registry.npmjs.org/node-abi/-/node-abi-2.19.1.tgz#6aa32561d0a5e2fdb6810d8c25641b657a8cea85"
-  integrity sha512-HbtmIuByq44yhAzK7b9j/FelKlHYISKQn0mtvcBrU5QBkhoCMp5bu8Hv5AI34DcKfOAcJBcOEMwLlwO62FFu9A==
-  dependencies:
-    semver "^5.4.1"
-
 node-abi@^3.3.0:
   version "3.40.0"
   resolved "https://registry.npmjs.org/node-abi/-/node-abi-3.40.0.tgz#51d8ed44534f70ff1357dfbc3a89717b1ceac1b4"
   integrity sha512-zNy02qivjjRosswoYmPi8hIKJRr8MpQyeKT6qlcq/OnOgA3Rhoae+IYOqsM9V5+JnHWmxKnWOT2GxvtqdtOCXA==
   dependencies:
     semver "^7.3.5"
-
-node-addon-api@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.0.2.tgz#04bc7b83fd845ba785bb6eae25bc857e1ef75681"
-  integrity sha512-+D4s2HCnxPd5PjjI0STKwncjXTUKKqm74MDMz9OPXavjsGmjkvwgLtA5yoxJUdmpj52+2u+RrXgPipahKczMKg==
 
 node-addon-api@^4.3.0:
   version "4.3.0"
@@ -7847,11 +7837,6 @@ node-status-codes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz#5ae5541d024645d32a58fcddc9ceecea7ae3ac2f"
   integrity sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=
-
-noop-logger@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
-  integrity sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=
 
 nopt@1.0.10:
   version "1.0.10"
@@ -7974,16 +7959,6 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.0.1:
-  version "4.1.2"
-  resolved "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
-  integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
-  dependencies:
-    are-we-there-yet "~1.1.2"
-    console-control-strings "~1.1.0"
-    gauge "~2.7.3"
-    set-blocking "~2.0.0"
-
 nth-check@^2.0.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
@@ -8006,7 +7981,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@4.X, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@4.X, object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -8503,6 +8478,11 @@ picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
+picomatch@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -8544,7 +8524,7 @@ pkg-dir@^3.0.0:
   dependencies:
     find-up "^3.0.0"
 
-pkg-dir@^4.2.0:
+pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
@@ -8600,27 +8580,6 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
-
-prebuild-install@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.0.tgz#669022bcde57c710a869e39c5ca6bf9cd207f316"
-  integrity sha512-h2ZJ1PXHKWZpp1caLw0oX9sagVpL2YTk+ZwInQbQ3QqNd4J03O6MpFNmMTJlkfgPENWqe5kP0WjQLqz5OjLfsw==
-  dependencies:
-    detect-libc "^1.0.3"
-    expand-template "^2.0.3"
-    github-from-package "0.0.0"
-    minimist "^1.2.3"
-    mkdirp-classic "^0.5.3"
-    napi-build-utils "^1.0.1"
-    node-abi "^2.7.0"
-    noop-logger "^0.1.1"
-    npmlog "^4.0.1"
-    pump "^3.0.0"
-    rc "^1.2.7"
-    simple-get "^3.0.3"
-    tar-fs "^2.0.0"
-    tunnel-agent "^0.6.0"
-    which-pm-runs "^1.0.0"
 
 prebuild-install@^7.0.1:
   version "7.1.1"
@@ -8951,7 +8910,7 @@ read@^1.0.7:
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -9444,6 +9403,15 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
+schema-utils@^3.0.0:
+  version "3.3.0"
+  resolved "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz#f50a88877c3c01652a15b622ae9e9795df7a60fe"
+  integrity sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==
+  dependencies:
+    "@types/json-schema" "^7.0.8"
+    ajv "^6.12.5"
+    ajv-keywords "^3.5.2"
+
 selenium-webdriver@^3.6.0:
   version "3.6.0"
   resolved "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-3.6.0.tgz#2ba87a1662c020b8988c981ae62cb2a01298eafc"
@@ -9514,7 +9482,14 @@ serialize-javascript@^4.0.0:
   dependencies:
     randombytes "^2.1.0"
 
-set-blocking@^2.0.0, set-blocking@~2.0.0:
+serialize-javascript@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"
+  integrity sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==
+  dependencies:
+    randombytes "^2.1.0"
+
+set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
@@ -9601,15 +9576,6 @@ simple-concat@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
   integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
-
-simple-get@^3.0.3:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-3.1.1.tgz#cc7ba77cfbe761036fbfce3d021af25fc5584d55"
-  integrity sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==
-  dependencies:
-    decompress-response "^4.2.0"
-    once "^1.3.1"
-    simple-concat "^1.0.0"
 
 simple-get@^4.0.0:
   version "4.0.1"
@@ -9983,14 +9949,6 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2":
-  version "2.1.1"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
-  integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
-  dependencies:
-    is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^4.0.0"
-
 string-width@^3.0.0, string-width@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
@@ -10041,13 +9999,6 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
-
-strip-ansi@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
-  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
-  dependencies:
-    ansi-regex "^3.0.0"
 
 strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
@@ -11032,7 +10983,7 @@ webpack-cli@^3.3.11:
     v8-compile-cache "^2.1.1"
     yargs "^13.3.2"
 
-webpack-sources@^1.4.0, webpack-sources@^1.4.1:
+webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
   version "1.4.3"
   resolved "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
   integrity sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==
@@ -11109,11 +11060,6 @@ which-module@^2.0.0:
   resolved "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which-pm-runs@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
-  integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
-
 which@3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/which/-/which-3.0.0.tgz#a9efd016db59728758a390d23f1687b6e8f59f8e"
@@ -11134,13 +11080,6 @@ which@^2.0.1, which@^2.0.2:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
-
-wide-align@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
-  integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
-  dependencies:
-    string-width "^1.0.2 || 2"
 
 word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1477,10 +1477,10 @@
   resolved "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-3.0.17.tgz#50bea0c3c2acc31c959c5b1e747798b3b3d06d4b"
   integrity sha512-tGomyEuzSC1H28y2zlW6XPCaDaXFaD6soTdb4GNdmte2qfHtrKqhy0ZFs4r/1hpazCfEZqeTSRLvSasmEx89uw==
 
-"@types/semver@^7.3.6":
-  version "7.3.6"
-  resolved "https://registry.npmjs.org/@types/semver/-/semver-7.3.6.tgz#e9831776f4512a7ba6da53e71c26e5fb67882d63"
-  integrity sha512-0caWDWmpCp0uifxFh+FaqK3CuZ2SkRR/ZRxAV5+zNdC3QVUi6wyOJnefhPvtNt8NQWXB5OA93BUvZsXpWat2Xw==
+"@types/semver@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz#591c1ce3a702c45ee15f47a42ade72c2fd78978a"
+  integrity sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==
 
 "@types/sinon@^7.5.2":
   version "7.5.2"
@@ -9467,6 +9467,13 @@ semver@^7.2.1, semver@^7.3.2:
   version "7.3.2"
   resolved "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+
+semver@^7.5.3:
+  version "7.5.4"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
 
 serialize-javascript@6.0.0:
   version "6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1879,10 +1879,10 @@
   dependencies:
     js-yaml "3.14.1"
 
-"@zowe/secrets-for-zowe-sdk@7.18.1":
-  version "7.18.1"
-  resolved "https://registry.npmjs.org/@zowe/secrets-for-zowe-sdk/-/secrets-for-zowe-sdk-7.18.1.tgz#546a63f5ed880418f0e0496d0218c284c815c3ee"
-  integrity sha512-bcAnauDpTQXCPT8rMx2wrZwhg6xih1lDujG20h1sUGJC5eqvsNCq6gvpOtcahEpUF25oBJ931dKlIu1T99LQ7w==
+"@zowe/secrets-for-zowe-sdk@7.18.3":
+  version "7.18.3"
+  resolved "https://registry.npmjs.org/@zowe/secrets-for-zowe-sdk/-/secrets-for-zowe-sdk-7.18.3.tgz#fa4a02ea0a72e6eaa651dcf9a0d653094f23c5fd"
+  integrity sha512-l/f9yzv7ijqs0epAL3UafCLI2/e+4lvs7s5eKzK9U4Bqr3hIy+Xnr31UDQSEsZaeGBjwrlD4W5koK/bHoAZqJQ==
 
 "@zowe/zos-console-for-zowe-sdk@6.40.18":
   version "6.40.18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9429,46 +9429,7 @@ semver-greatest-satisfied-range@^1.1.0:
   dependencies:
     sver-compat "^1.5.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
-  version "5.7.1"
-  resolved "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
-  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
-
-semver@5.7.2:
-  version "5.7.2"
-  resolved "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
-  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
-
-semver@6.x, semver@^6.0.0, semver@^6.1.2, semver@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
-  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
-  integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
-
-semver@^7.0.0, semver@^7.1.1, semver@^7.3.4, semver@^7.3.5:
-  version "7.3.5"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
-  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@^7.1.3:
-  version "7.3.7"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
-  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@^7.2.1, semver@^7.3.2:
-  version "7.3.2"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
-  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
-
-semver@^7.5.3:
+"semver@2 || 3 || 4 || 5", semver@5.7.2, semver@6.x, semver@7.0.0, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0, semver@^6.0.0, semver@^6.1.2, semver@^6.3.0, semver@^7.0.0, semver@^7.1.1, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.5.3:
   version "7.5.4"
   resolved "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1801,37 +1801,37 @@
   resolved "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-"@zowe/cli@6.40.15":
-  version "6.40.15"
-  resolved "https://registry.npmjs.org/@zowe/cli/-/cli-6.40.15.tgz#f85680eb190ba11b5f91229ce7ab662943209b1d"
-  integrity sha512-iuhDYtvDDokpmfNs1N+wq2jGkbnCxljrI4XvzYKaSxbYrHlmtvSlveYqC+377lHrNvmNhuwoMpVBNC7J+wtpYQ==
+"@zowe/cli@6.40.18":
+  version "6.40.18"
+  resolved "https://registry.npmjs.org/@zowe/cli/-/cli-6.40.18.tgz#da1c7d2c8fac3d5419715dd7ba8ee2bd27f817ef"
+  integrity sha512-DjSeLzPByFLlAVOMxpM5dfG0DZ9Xjd23X/pxouowSyXuBZ/5pTOpGPp+vCPCde7H4R5baacwFGxbHMpQ5E/brg==
   dependencies:
-    "@zowe/core-for-zowe-sdk" "6.40.15"
-    "@zowe/imperative" "4.18.14"
+    "@zowe/core-for-zowe-sdk" "6.40.18"
+    "@zowe/imperative" "4.18.17"
     "@zowe/perf-timing" "1.0.7"
-    "@zowe/provisioning-for-zowe-sdk" "6.40.15"
-    "@zowe/zos-console-for-zowe-sdk" "6.40.15"
-    "@zowe/zos-files-for-zowe-sdk" "6.40.15"
-    "@zowe/zos-jobs-for-zowe-sdk" "6.40.15"
-    "@zowe/zos-logs-for-zowe-sdk" "6.40.15"
-    "@zowe/zos-tso-for-zowe-sdk" "6.40.15"
-    "@zowe/zos-uss-for-zowe-sdk" "6.40.15"
-    "@zowe/zos-workflows-for-zowe-sdk" "6.40.15"
-    "@zowe/zosmf-for-zowe-sdk" "6.40.15"
+    "@zowe/provisioning-for-zowe-sdk" "6.40.18"
+    "@zowe/zos-console-for-zowe-sdk" "6.40.18"
+    "@zowe/zos-files-for-zowe-sdk" "6.40.18"
+    "@zowe/zos-jobs-for-zowe-sdk" "6.40.18"
+    "@zowe/zos-logs-for-zowe-sdk" "6.40.18"
+    "@zowe/zos-tso-for-zowe-sdk" "6.40.18"
+    "@zowe/zos-uss-for-zowe-sdk" "6.40.18"
+    "@zowe/zos-workflows-for-zowe-sdk" "6.40.18"
+    "@zowe/zosmf-for-zowe-sdk" "6.40.18"
     get-stdin "7.0.0"
     minimatch "3.1.2"
 
-"@zowe/core-for-zowe-sdk@6.40.15":
-  version "6.40.15"
-  resolved "https://registry.npmjs.org/@zowe/core-for-zowe-sdk/-/core-for-zowe-sdk-6.40.15.tgz#8907eda8f76415087f9c3e1af2833772d91bbc0e"
-  integrity sha512-IRkMrNSfkYL3WNbyjIh458o+NdCxF/NUuo0R5JhNuwbxWQ+qvh/wAoa4ruz+5sbwcfmmBDeUIALVIlX90799Zw==
+"@zowe/core-for-zowe-sdk@6.40.18":
+  version "6.40.18"
+  resolved "https://registry.npmjs.org/@zowe/core-for-zowe-sdk/-/core-for-zowe-sdk-6.40.18.tgz#b13b68a8012c2935b487a67a51adc92fb6d4b5f3"
+  integrity sha512-0nKk0X8dQUOZ/Xc/uakJUrynezbKpbfqKfpVwc9P15V9l+feP9zPHVdVZ5XWzeV6c6ZYvvEEyJxy0dBezd+k+A==
   dependencies:
     string-width "4.2.3"
 
-"@zowe/imperative@4.18.14":
-  version "4.18.14"
-  resolved "https://registry.npmjs.org/@zowe/imperative/-/imperative-4.18.14.tgz#2e36a7ece00d09dc35dfa911c47f1b80e93ac696"
-  integrity sha512-6xKj/dytOkzDjA6mPxrbNgUMWIsi0VOm/uqZPKTIFNvORUoyzTjRre99y4kzSJcYMPDaMaFlpdwIn5G+gPXvkA==
+"@zowe/imperative@4.18.17":
+  version "4.18.17"
+  resolved "https://registry.npmjs.org/@zowe/imperative/-/imperative-4.18.17.tgz#42cf9b3421e8afb73c7af8dc1ca132d766c3686b"
+  integrity sha512-TPuR/nDO9y66AEmEZHGKNo3Me3+aNJ+So+wD4FTdBJlrrM/p65mZR+qat2ic/76hihuFL5qE/S/zfxV0Zy80cQ==
   dependencies:
     "@types/yargs" "13.0.4"
     "@zowe/perf-timing" "1.0.7"
@@ -1857,7 +1857,7 @@
     prettyjson "1.2.2"
     progress "2.0.3"
     readline-sync "1.4.10"
-    semver "5.7.0"
+    semver "5.7.2"
     stack-trace "0.0.10"
     which "3.0.0"
     wrap-ansi "7.0.0"
@@ -1872,10 +1872,10 @@
     fs-extra "8.1.0"
     pkg-up "2.0.0"
 
-"@zowe/provisioning-for-zowe-sdk@6.40.15":
-  version "6.40.15"
-  resolved "https://registry.npmjs.org/@zowe/provisioning-for-zowe-sdk/-/provisioning-for-zowe-sdk-6.40.15.tgz#2079d350261a036a6d73a28c23e7ab2a2f737a5c"
-  integrity sha512-BBiXADvXLXl2gZ5853IzriRrTbDXWntsG3CHkS0ZaPnnqwRpZ1/zgRBB7gdwMmhJUyhQoILx2dSnXWbIUgkKKg==
+"@zowe/provisioning-for-zowe-sdk@6.40.18":
+  version "6.40.18"
+  resolved "https://registry.npmjs.org/@zowe/provisioning-for-zowe-sdk/-/provisioning-for-zowe-sdk-6.40.18.tgz#d5577df0d24e578244037f64b2ea27ee4c4958d6"
+  integrity sha512-iS8oQrus5BuySf4OvJ9iUxbHRrA5Bo8TENAt7H/PQQg0E945i0EGdd33IoEcjSTvxv1aoMdRgnXNpYzjHV94Bg==
   dependencies:
     js-yaml "3.14.1"
 
@@ -1884,15 +1884,15 @@
   resolved "https://registry.npmjs.org/@zowe/secrets-for-zowe-sdk/-/secrets-for-zowe-sdk-7.18.1.tgz#546a63f5ed880418f0e0496d0218c284c815c3ee"
   integrity sha512-bcAnauDpTQXCPT8rMx2wrZwhg6xih1lDujG20h1sUGJC5eqvsNCq6gvpOtcahEpUF25oBJ931dKlIu1T99LQ7w==
 
-"@zowe/zos-console-for-zowe-sdk@6.40.15":
-  version "6.40.15"
-  resolved "https://registry.npmjs.org/@zowe/zos-console-for-zowe-sdk/-/zos-console-for-zowe-sdk-6.40.15.tgz#fab26e86e4ae49543c29ea7f8016c5b09f579b38"
-  integrity sha512-lkRSegxPaKVe7YgbIxSUoIY9MovaCVm4FYOX8VkX9DYOAht4XLdYcpPfltJTTNiiVr9lsdhCc/cYqQlOaFQm8A==
+"@zowe/zos-console-for-zowe-sdk@6.40.18":
+  version "6.40.18"
+  resolved "https://registry.npmjs.org/@zowe/zos-console-for-zowe-sdk/-/zos-console-for-zowe-sdk-6.40.18.tgz#0b4122ba280adfaed67843cca987b844bc821fc2"
+  integrity sha512-d6UXknI23kOfmhgIwgeTk8VxzQ5Xz7qqN7SbZAPVMEl8zsdW0CNe4feEI/OjdOaXHk+9z68lsLLz4uhOr9+OEQ==
 
-"@zowe/zos-files-for-zowe-sdk@6.40.15":
-  version "6.40.15"
-  resolved "https://registry.npmjs.org/@zowe/zos-files-for-zowe-sdk/-/zos-files-for-zowe-sdk-6.40.15.tgz#ad990969a0757d8fd1dd26918940948ce3873994"
-  integrity sha512-rXfCFltkYLKTdG/ltkdEiWvjiWJsCNG44qr+sljkWSzo1+5DiI0CzfER4QNGH49b8mjOeYs1Y8gpzvAIVcmaDQ==
+"@zowe/zos-files-for-zowe-sdk@6.40.18":
+  version "6.40.18"
+  resolved "https://registry.npmjs.org/@zowe/zos-files-for-zowe-sdk/-/zos-files-for-zowe-sdk-6.40.18.tgz#cea494f94846d6ca3c424d98a7d4f81e51f05e66"
+  integrity sha512-ySZIKJBrF2LWBzoqAbK+eASGsqx7LUNTVMZUDU9sf+yTayu7fwpOJh/Le8as5jHztyF7ysdH1sK+wvyBnRD4lQ==
   dependencies:
     minimatch "3.1.2"
 
@@ -1903,43 +1903,43 @@
   dependencies:
     zos-node-accessor "^1.0.8"
 
-"@zowe/zos-jobs-for-zowe-sdk@6.40.15":
-  version "6.40.15"
-  resolved "https://registry.npmjs.org/@zowe/zos-jobs-for-zowe-sdk/-/zos-jobs-for-zowe-sdk-6.40.15.tgz#b4a9db05704e3ccb22639f19485ee10b3db13a69"
-  integrity sha512-duvAS7QBFNrzDgAVeZ3YdOSutsD/8gxrlW09tvz46ze6FQC+qfm/zmohbSxfkRdN/e72HfEU1dQG5zro7ShG/w==
+"@zowe/zos-jobs-for-zowe-sdk@6.40.18":
+  version "6.40.18"
+  resolved "https://registry.npmjs.org/@zowe/zos-jobs-for-zowe-sdk/-/zos-jobs-for-zowe-sdk-6.40.18.tgz#72dcab96fe320e960cbd5fbac2bd0df092a6e8ba"
+  integrity sha512-KUtp07S4IHGBKrWfwcj+cDisoFkSsRW2+aZQqj7Z7dvD7HLEXiAsQE13rgNFIbLUop21Hi7Fi/vJQIGYGUp2IQ==
   dependencies:
-    "@zowe/zos-files-for-zowe-sdk" "6.40.15"
+    "@zowe/zos-files-for-zowe-sdk" "6.40.18"
 
-"@zowe/zos-logs-for-zowe-sdk@6.40.15":
-  version "6.40.15"
-  resolved "https://registry.npmjs.org/@zowe/zos-logs-for-zowe-sdk/-/zos-logs-for-zowe-sdk-6.40.15.tgz#8f34a25a57a0b5419e24e2416019e64bd54db4e5"
-  integrity sha512-RmIKXF5BSIyt+D9Kb9UwJhR142+L9qxd0w2hFiexjxBu4A3tQFwyliIpmrwbWd8kAyt/0nndqrv8yXcvCJxiJQ==
+"@zowe/zos-logs-for-zowe-sdk@6.40.18":
+  version "6.40.18"
+  resolved "https://registry.npmjs.org/@zowe/zos-logs-for-zowe-sdk/-/zos-logs-for-zowe-sdk-6.40.18.tgz#d96f26069b597be62fbd6e83e2eb0b157ca255cd"
+  integrity sha512-tmIfKF1OAZSlpu+BOQswK4RsaNOeo4kkKkUC//Xj0B2dNu6fjG0FtTNFceOZDiyB+Wqe7gv6yO3mMqh8lHPB6w==
 
-"@zowe/zos-tso-for-zowe-sdk@6.40.15":
-  version "6.40.15"
-  resolved "https://registry.npmjs.org/@zowe/zos-tso-for-zowe-sdk/-/zos-tso-for-zowe-sdk-6.40.15.tgz#c101ac1555586c5118ba9bb3bdb15fc427ef25f4"
-  integrity sha512-YFmne5xDSqhmK2m1ZSN9rVECNImrKLqrNy1/wLYxCcQE2A7TpL4keJJfk43N9LrCSJ0WlLl5JL1BHFnsNWVluw==
+"@zowe/zos-tso-for-zowe-sdk@6.40.18":
+  version "6.40.18"
+  resolved "https://registry.npmjs.org/@zowe/zos-tso-for-zowe-sdk/-/zos-tso-for-zowe-sdk-6.40.18.tgz#7957d7d22ee73c7031159022ac6fccc438000617"
+  integrity sha512-3kuEbMrJd5DyCYlY8N9hMOGXHqEKACs8O0pQsLffX6od7FKQzh2WwKq55BVNeO9TALFsX9j5FY10NaRiqyUxjA==
   dependencies:
-    "@zowe/zosmf-for-zowe-sdk" "6.40.15"
+    "@zowe/zosmf-for-zowe-sdk" "6.40.18"
 
-"@zowe/zos-uss-for-zowe-sdk@6.40.15":
-  version "6.40.15"
-  resolved "https://registry.npmjs.org/@zowe/zos-uss-for-zowe-sdk/-/zos-uss-for-zowe-sdk-6.40.15.tgz#cccdb8df5ba62c9e825a12eaf9ce2d36fe242870"
-  integrity sha512-Dif/QdCKQHbcThuArZmAeSPEdd6Vla+5lukubk6W134Pv1PKotQbT1lg/Q97p58zxZsR7cqD7pbp+61kC2Kmlg==
+"@zowe/zos-uss-for-zowe-sdk@6.40.18":
+  version "6.40.18"
+  resolved "https://registry.npmjs.org/@zowe/zos-uss-for-zowe-sdk/-/zos-uss-for-zowe-sdk-6.40.18.tgz#981c8c16c4d229d02449debdbb92d3c94d1ca7ad"
+  integrity sha512-2OIB81F97EKHSRhtY3YBo1HJ5UQ31TlztItTclo7NHfe/GFt7CQBP1h7l1Dv5DxLFmMYC2y/tLuMSryY4+4gRg==
   dependencies:
     ssh2 "1.4.0"
 
-"@zowe/zos-workflows-for-zowe-sdk@6.40.15":
-  version "6.40.15"
-  resolved "https://registry.npmjs.org/@zowe/zos-workflows-for-zowe-sdk/-/zos-workflows-for-zowe-sdk-6.40.15.tgz#715ba0a883eeaf80312c7e59e1af4766c7a35540"
-  integrity sha512-xRHVkZbP2o6TE4AXYR+QS1rPDm71qZOcV6ZN+2lyokoaoRC/cLfB+HLC0k38vOyEUZWSz44WQSZovcOmV6Rpbw==
+"@zowe/zos-workflows-for-zowe-sdk@6.40.18":
+  version "6.40.18"
+  resolved "https://registry.npmjs.org/@zowe/zos-workflows-for-zowe-sdk/-/zos-workflows-for-zowe-sdk-6.40.18.tgz#fb81e8942673c7a6b5abfcd54ed8c872c0bb0cf2"
+  integrity sha512-P4FSOElSFqIrLq+Wcfk+l0KjHfGIlzY7eZTRuu8iG0DTLPfpQ8B1tqJvMQzxaoqTEmSVb8CvI8U6o0vSYF6BEA==
   dependencies:
-    "@zowe/zos-files-for-zowe-sdk" "6.40.15"
+    "@zowe/zos-files-for-zowe-sdk" "6.40.18"
 
-"@zowe/zosmf-for-zowe-sdk@6.40.15":
-  version "6.40.15"
-  resolved "https://registry.npmjs.org/@zowe/zosmf-for-zowe-sdk/-/zosmf-for-zowe-sdk-6.40.15.tgz#5a2a27912f5a5b5a91746299449794d36fefd0d1"
-  integrity sha512-UBSHiTdWBE/bpOgqmsrt7nkA1dyi1Ux9B/FDiDbHhf/u4KNIJ/7Kq5BFhvC9MyB6HrrozRiOtb1nl7mG0S5fhQ==
+"@zowe/zosmf-for-zowe-sdk@6.40.18":
+  version "6.40.18"
+  resolved "https://registry.npmjs.org/@zowe/zosmf-for-zowe-sdk/-/zosmf-for-zowe-sdk-6.40.18.tgz#84ac75afaf99b2409dc047862a748446cc89c685"
+  integrity sha512-uxyNYelaGfh5FtXXQcEBlZolUGLWjjPmVkiYZuoFAtEXUg48YTGHRUJ0QVa5YNsIbh86OJb23UuvmYmMXI+PXg==
 
 abab@^2.0.0, abab@^2.0.3:
   version "2.0.5"
@@ -9434,10 +9434,10 @@ semver-greatest-satisfied-range@^1.1.0:
   resolved "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@5.7.0:
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
-  integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
+semver@5.7.2:
+  version "5.7.2"
+  resolved "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
+  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
 semver@6.x, semver@^6.0.0, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"


### PR DESCRIPTION
## Proposed changes

This PR ports the Secrets SDK work from #2405 into the `v1-lts` branch.

To test, sign into a v1 profile with your credentials. The `.yaml` file with your v1 profile should update so that the username and passwords fields are set to `Managed by Zowe Explorer`.

## Release Notes

Milestone: 1.22.5

Changelog:

- Replaced `keytar` dependency with `keyring` module from [`@zowe/secrets-for-zowe-sdk`](https://github.com/zowe/zowe-cli/tree/master/packages/secrets). [#2358](https://github.com/zowe/vscode-extension-for-zowe/issues/2358)
- Bump `semver` to 7.5.3 to resolve audit

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found

## Further comments

Not as many changes were needed for v1, because we can simply use the Secrets SDK package within the v1 codebase.
