### PR TITLE
fix(ds): wait until contents are received to show editor

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 ### New features and enhancements
 
+- Added optional `pendingActions` record to `IZoweTreeNode` to allow nodes to track pending promises.
+- Added optional `requestFailed` variable to `IZoweDatasetTreeNode` to track the result of the last fetch request made on a data set node.
+
 ### Bug fixes
 
 ## `2.10.0`

--- a/packages/zowe-explorer-api/package.json
+++ b/packages/zowe-explorer-api/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@types/vscode": "^1.53.2",
     "@zowe/cli": "^7.18.0",
-    "@zowe/secrets-for-zowe-sdk": "7.18.3",
+    "@zowe/secrets-for-zowe-sdk": "7.18.4",
     "handlebars": "^4.7.7",
     "semver": "^7.5.3"
   },

--- a/packages/zowe-explorer-api/src/tree/IZoweTreeNode.ts
+++ b/packages/zowe-explorer-api/src/tree/IZoweTreeNode.ts
@@ -124,6 +124,10 @@ export interface IZoweTreeNode {
  */
 export interface IZoweDatasetTreeNode extends IZoweTreeNode {
     /**
+     * whether the previous request for the dataset node failed
+     */
+    requestFailed?: boolean;
+    /**
      * Search criteria for a Dataset search
      */
     pattern?: string;

--- a/packages/zowe-explorer-api/src/tree/IZoweTreeNode.ts
+++ b/packages/zowe-explorer-api/src/tree/IZoweTreeNode.ts
@@ -75,6 +75,10 @@ export interface IZoweTreeNode {
      */
     pendingActions?: Record<NodeAction | string, Promise<any>>;
     /**
+     * whether the node was double-clicked
+     */
+    wasDoubleClicked?: boolean;
+    /**
      * Retrieves the node label
      */
     getLabel(): string | vscode.TreeItemLabel;
@@ -123,10 +127,6 @@ export interface IZoweTreeNode {
  * @interface export interface IZoweDatasetTreeNode extends IZoweTreeNode {
  */
 export interface IZoweDatasetTreeNode extends IZoweTreeNode {
-    /**
-     * whether the previous request for the dataset node failed
-     */
-    requestFailed?: boolean;
     /**
      * Search criteria for a Dataset search
      */

--- a/packages/zowe-explorer-api/src/tree/IZoweTreeNode.ts
+++ b/packages/zowe-explorer-api/src/tree/IZoweTreeNode.ts
@@ -16,6 +16,10 @@ import { FileAttributes } from "../utils/files";
 
 export type IZoweNodeType = IZoweDatasetTreeNode | IZoweUSSTreeNode | IZoweJobTreeNode;
 
+export enum NodeAction {
+    Download = "download",
+}
+
 /**
  * The base interface for Zowe tree nodes that are implemented by vscode.TreeItem.
  *
@@ -66,6 +70,10 @@ export interface IZoweTreeNode {
      * This will show action `extension.deleteFolder` only for items with `contextValue` is `folder`.
      */
     contextValue?: string;
+    /**
+     * Any pending actions that must be awaited before continuing
+     */
+    pendingActions?: Record<NodeAction | string, Promise<any>>;
     /**
      * Retrieves the node label
      */
@@ -123,7 +131,6 @@ export interface IZoweDatasetTreeNode extends IZoweTreeNode {
      * Search criteria for a Dataset member search
      */
     memberPattern?: string;
-
     /**
      * Retrieves child nodes of this IZoweDatasetTreeNode
      *

--- a/packages/zowe-explorer-api/src/tree/IZoweTreeNode.ts
+++ b/packages/zowe-explorer-api/src/tree/IZoweTreeNode.ts
@@ -71,9 +71,9 @@ export interface IZoweTreeNode {
      */
     contextValue?: string;
     /**
-     * Any pending actions that must be awaited before continuing
+     * Any ongoing actions that must be awaited before continuing
      */
-    pendingActions?: Record<NodeAction | string, Promise<any>>;
+    ongoingActions?: Record<NodeAction | string, Promise<any>>;
     /**
      * whether the node was double-clicked
      */

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
+- Fixed issue where data set content does not always appear as soon as the editor is opened. [#2427](https://github.com/zowe/vscode-extension-for-zowe/issues/2427)
+
 ## `2.10.0`
 
 ### New features and enhancements

--- a/packages/zowe-explorer/__tests__/__unit__/dataset/DatasetTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/dataset/DatasetTree.unit.test.ts
@@ -119,14 +119,12 @@ function createGlobalMocks() {
         }),
     });
     Object.defineProperty(zowe.Download, "dataSet", {
-        value: jest.fn(() => {
-            return {
-                success: true,
-                commandResponse: null,
-                apiResponse: {
-                    etag: "123",
-                },
-            };
+        value: jest.fn().mockResolvedValue({
+            success: true,
+            commandResponse: null,
+            apiResponse: {
+                etag: "123",
+            },
         }),
         configurable: true,
     });

--- a/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
@@ -3394,14 +3394,14 @@ describe("Dataset Actions Unit Tests - Function openPS", () => {
         }
     });
 
-    it("Check for invalid/null response without supporting pending actions", async () => {
+    it("Check for invalid/null response without supporting ongoing actions", async () => {
         globals.defineGlobals("");
         const globalMocks = createGlobalMocks();
         const blockMocks = createBlockMocks();
         globalMocks.getContentsSpy.mockResolvedValueOnce(null);
         mocked(Profiles.getInstance).mockReturnValue(blockMocks.profileInstance);
         const node = new ZoweDatasetNode("node", vscode.TreeItemCollapsibleState.None, blockMocks.datasetSessionNode, null);
-        node.pendingActions = undefined as any;
+        node.ongoingActions = undefined as any;
 
         try {
             await dsActions.openPS(node, true, blockMocks.testDatasetTree);

--- a/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
@@ -3379,21 +3379,6 @@ describe("Dataset Actions Unit Tests - Function openPS", () => {
         expect(mocked(Gui.errorMessage)).toBeCalledWith("Error: testError");
     });
 
-    it("Check for invalid/null response", async () => {
-        globals.defineGlobals("");
-        const globalMocks = createGlobalMocks();
-        const blockMocks = createBlockMocks();
-        globalMocks.getContentsSpy.mockResolvedValueOnce(null);
-        mocked(Profiles.getInstance).mockReturnValue(blockMocks.profileInstance);
-        const node = new ZoweDatasetNode("node", vscode.TreeItemCollapsibleState.None, blockMocks.datasetSessionNode, null);
-
-        try {
-            await dsActions.openPS(node, true, blockMocks.testDatasetTree);
-        } catch (err) {
-            expect(err.message).toBe("Response was null or invalid.");
-        }
-    });
-
     it("Check for invalid/null response without supporting ongoing actions", async () => {
         globals.defineGlobals("");
         const globalMocks = createGlobalMocks();

--- a/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
@@ -3378,6 +3378,38 @@ describe("Dataset Actions Unit Tests - Function openPS", () => {
 
         expect(mocked(Gui.errorMessage)).toBeCalledWith("Error: testError");
     });
+
+    it("Check for invalid/null response", async () => {
+        globals.defineGlobals("");
+        const globalMocks = createGlobalMocks();
+        const blockMocks = createBlockMocks();
+        globalMocks.getContentsSpy.mockResolvedValueOnce(null);
+        mocked(Profiles.getInstance).mockReturnValue(blockMocks.profileInstance);
+        const node = new ZoweDatasetNode("node", vscode.TreeItemCollapsibleState.None, blockMocks.datasetSessionNode, null);
+
+        try {
+            await dsActions.openPS(node, true, blockMocks.testDatasetTree);
+        } catch (err) {
+            expect(err.message).toBe("Response was null or invalid.");
+        }
+    });
+
+    it("Check for invalid/null response without supporting pending actions", async () => {
+        globals.defineGlobals("");
+        const globalMocks = createGlobalMocks();
+        const blockMocks = createBlockMocks();
+        globalMocks.getContentsSpy.mockResolvedValueOnce(null);
+        mocked(Profiles.getInstance).mockReturnValue(blockMocks.profileInstance);
+        const node = new ZoweDatasetNode("node", vscode.TreeItemCollapsibleState.None, blockMocks.datasetSessionNode, null);
+        node.pendingActions = undefined as any;
+
+        try {
+            await dsActions.openPS(node, true, blockMocks.testDatasetTree);
+        } catch (err) {
+            expect(err.message).toBe("Response was null or invalid.");
+        }
+    });
+
     it("Checking of opening for PDS Member", async () => {
         globals.defineGlobals("");
         createGlobalMocks();

--- a/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
@@ -3318,9 +3318,9 @@ describe("Dataset Actions Unit Tests - Function openPS", () => {
         createGlobalMocks();
         const blockMocks = createBlockMocks();
 
-        mocked(vscode.window.withProgress).mockResolvedValueOnce({
+        mocked(blockMocks.mvsApi.getContents).mockResolvedValueOnce({
             success: true,
-            commandResponse: null,
+            commandResponse: "",
             apiResponse: {
                 etag: "123",
             },
@@ -3339,9 +3339,9 @@ describe("Dataset Actions Unit Tests - Function openPS", () => {
         createGlobalMocks();
         const blockMocks = createBlockMocks();
 
-        mocked(vscode.window.withProgress).mockResolvedValueOnce({
+        mocked(blockMocks.mvsApi.getContents).mockResolvedValueOnce({
             success: true,
-            commandResponse: null,
+            commandResponse: "",
             apiResponse: {
                 etag: "123",
             },
@@ -3383,9 +3383,9 @@ describe("Dataset Actions Unit Tests - Function openPS", () => {
         createGlobalMocks();
         const blockMocks = createBlockMocks();
 
-        mocked(vscode.window.withProgress).mockResolvedValueOnce({
+        mocked(blockMocks.mvsApi.getContents).mockResolvedValueOnce({
             success: true,
-            commandResponse: null,
+            commandResponse: "",
             apiResponse: {
                 etag: "123",
             },
@@ -3410,9 +3410,9 @@ describe("Dataset Actions Unit Tests - Function openPS", () => {
         createGlobalMocks();
         const blockMocks = createBlockMocks();
 
-        mocked(vscode.window.withProgress).mockResolvedValueOnce({
+        mocked(blockMocks.mvsApi.getContents).mockResolvedValueOnce({
             success: true,
-            commandResponse: null,
+            commandResponse: "",
             apiResponse: {
                 etag: "123",
             },
@@ -3437,9 +3437,9 @@ describe("Dataset Actions Unit Tests - Function openPS", () => {
         createGlobalMocks();
         const blockMocks = createBlockMocks();
 
-        mocked(vscode.window.withProgress).mockResolvedValueOnce({
+        mocked(blockMocks.mvsApi.getContents).mockResolvedValueOnce({
             success: true,
-            commandResponse: null,
+            commandResponse: "",
             apiResponse: {
                 etag: "123",
             },

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -1992,6 +1992,7 @@
     "isbinaryfile": "4.0.4",
     "js-yaml": "3.13.1",
     "promise-queue": "2.2.5",
+    "promise-status-async": "^1.2.10",
     "yamljs": "0.3.0"
   },
   "jest": {

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -1986,7 +1986,7 @@
     "webpack-cli": "^3.3.11"
   },
   "dependencies": {
-    "@zowe/secrets-for-zowe-sdk": "7.18.3",
+    "@zowe/secrets-for-zowe-sdk": "7.18.4",
     "@zowe/zowe-explorer-api": "2.10.1-SNAPSHOT",
     "fs-extra": "8.0.1",
     "isbinaryfile": "4.0.4",

--- a/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
@@ -41,7 +41,7 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
     public dirty = true;
     public children: ZoweDatasetNode[] = [];
     public errorDetails: zowe.imperative.ImperativeError;
-    public pendingActions: Record<NodeAction | string, Promise<any>> = {};
+    public ongoingActions: Record<NodeAction | string, Promise<any>> = {};
     public wasDoubleClicked: boolean = false;
 
     /**

--- a/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
@@ -42,6 +42,7 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
     public children: ZoweDatasetNode[] = [];
     public errorDetails: zowe.imperative.ImperativeError;
     public pendingActions: Record<NodeAction | string, Promise<any>> = {};
+    public wasDoubleClicked: boolean = false;
 
     /**
      * Creates an instance of ZoweDatasetNode

--- a/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
@@ -12,8 +12,8 @@
 import * as zowe from "@zowe/cli";
 import * as vscode from "vscode";
 import * as globals from "../globals";
-import { errorHandling, syncSessionNode } from "../utils/ProfilesUtils";
-import { Gui, IZoweDatasetTreeNode, ZoweTreeNode } from "@zowe/zowe-explorer-api";
+import { errorHandling } from "../utils/ProfilesUtils";
+import { Gui, NodeAction, IZoweDatasetTreeNode, ZoweTreeNode } from "@zowe/zowe-explorer-api";
 import { ZoweExplorerApiRegister } from "../ZoweExplorerApiRegister";
 import { getIconByNode } from "../generators/icons";
 import * as contextually from "../shared/context";
@@ -41,6 +41,7 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
     public dirty = true;
     public children: ZoweDatasetNode[] = [];
     public errorDetails: zowe.imperative.ImperativeError;
+    public pendingActions: Record<NodeAction | string, Promise<any>> = {};
 
     /**
      * Creates an instance of ZoweDatasetNode

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -499,7 +499,6 @@ export async function openPS(
             }
 
             if (responsePromise == null) {
-                node.requestFailed = true;
                 throw Error("Response was null or invalid.");
             }
 

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -496,8 +496,8 @@ export async function openPS(
 
             const documentFilePath = getDocumentFilePath(label, node);
             let responsePromise = node.ongoingActions ? node.ongoingActions[api.NodeAction.Download] : null;
-            // If the local copy does not exist or the last action was rejected/discarded, fetch contents
-            if (!fs.existsSync(documentFilePath) || lastActionStatus == PromiseStatuses.PROMISE_REJECTED) {
+            // If the local copy does not exist, fetch contents
+            if (!fs.existsSync(documentFilePath)) {
                 const prof = node.getProfile();
                 ZoweLogger.info(localize("openPS.openDataSet", "Opening {0}", label));
                 if (node.ongoingActions) {

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -454,11 +454,11 @@ export async function openPS(
     }
 
     // Status of last "open action" promise
-    // If the node doesn't support pending actions, assume last action was rejected to pull new contents
+    // If the node doesn't support pending actions, assume last action was resolved to pull new contents
     const lastActionStatus =
         node.ongoingActions?.[api.NodeAction.Download] != null
             ? await promiseStatus(node.ongoingActions[api.NodeAction.Download])
-            : PromiseStatuses.PROMISE_REJECTED;
+            : PromiseStatuses.PROMISE_RESOLVED;
 
     // Cache status of double click if the node has the "wasDoubleClicked" property:
     // allows subsequent clicks to register as double-click if node is not done fetching contents

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -522,7 +522,7 @@ export async function openPS(
             node.setEtag(response?.apiResponse?.etag);
             statusMsg.dispose();
             const document = await vscode.workspace.openTextDocument(getDocumentFilePath(label, node));
-            await api.Gui.showTextDocument(document, { preview: node.wasDoubleClicked ? !node.wasDoubleClicked : shouldPreview });
+            await api.Gui.showTextDocument(document, { preview: node.wasDoubleClicked != null ? !node.wasDoubleClicked : shouldPreview });
             // discard ongoing action to allow new requests on this node
             if (node.ongoingActions) {
                 node.ongoingActions[api.NodeAction.Download] = null;

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -454,6 +454,7 @@ export async function openPS(
     const doubleClicked = api.Gui.utils.wasDoubleClicked(node, datasetProvider);
     const shouldPreview = doubleClicked ? false : previewMember;
     if (Profiles.getInstance().validProfile !== api.ValidProfileEnum.INVALID) {
+        const statusMsg = api.Gui.setStatusBarMessage(localize("dataSet.opening", "$(sync~spin) Opening data set..."));
         try {
             let label: string;
             const defaultMessage = localize("openPS.error", "Invalid data set or member.");
@@ -474,7 +475,6 @@ export async function openPS(
             }
             // if local copy exists, open that instead of pulling from mainframe
             const documentFilePath = getDocumentFilePath(label, node);
-            const statusMsg = api.Gui.setStatusBarMessage(localize("dataSet.opening", "$(sync~spin) Opening data set..."));
             let responsePromise = node.pendingActions ? node.pendingActions[api.NodeAction.Download] : null;
             if (!fs.existsSync(documentFilePath)) {
                 const prof = node.getProfile();
@@ -498,7 +498,7 @@ export async function openPS(
             }
 
             if (responsePromise == null) {
-                throw new Error("Response was null or invalid.");
+                throw Error("Response was null or invalid.");
             }
 
             const response = await responsePromise;
@@ -510,6 +510,7 @@ export async function openPS(
                 datasetProvider.addFileHistory(`[${node.getProfileName()}]: ${label}`);
             }
         } catch (err) {
+            statusMsg.dispose();
             await errorHandling(err, node.getProfileName());
             throw err;
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2345,10 +2345,10 @@
   resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/secrets-for-zowe-sdk/-/@zowe/secrets-for-zowe-sdk-7.18.0.tgz#2741de10f4c16811b25bdf4944f669a0d15e3788"
   integrity sha512-QyZQh45pZEj9PWkqaTfMFIFDiHpMI4aCaZSbsbhanz54h/kN1s6nT4ri43EjQ3J3aUsG2wEjKkotjBZdGg3cHw==
 
-"@zowe/secrets-for-zowe-sdk@7.18.3":
-  version "7.18.3"
-  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/secrets-for-zowe-sdk/-/@zowe/secrets-for-zowe-sdk-7.18.3.tgz#a5fce6282f6835d58e0ec757cd9badee2defea14"
-  integrity sha512-3/TyFgpZimOUreDLQSlRfZK+GAgRr4zl31YvPD1wOB95wIgcX7dDONmsMuf/Z721eJOkVMuae7W4Ke92oyJECQ==
+"@zowe/secrets-for-zowe-sdk@7.18.4":
+  version "7.18.4"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/secrets-for-zowe-sdk/-/@zowe/secrets-for-zowe-sdk-7.18.4.tgz#844dd459fb6152c1a60a951a7ce9bb7ebe966d0f"
+  integrity sha512-MCJBHSCbf2TdN9/5pbJNC6LWrWgnmYt0zVINs6g8Tlf/UmVBh08TlrROzPfL5aYi7FWPa64BHur40x/e1eNalg==
 
 "@zowe/zos-console-for-zowe-sdk@7.18.0":
   version "7.18.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9077,6 +9077,11 @@ promise-retry@^2.0.1:
     err-code "^2.0.2"
     retry "^0.12.0"
 
+promise-status-async@^1.2.10:
+  version "1.2.10"
+  resolved "https://registry.npmjs.org/promise-status-async/-/promise-status-async-1.2.10.tgz#59bae260d4889d037313f4395162f038ffd7c22a"
+  integrity sha512-MECA3pc+uWN+D6IiATrNVzXtBU6WrsKvWmxS9Syd6d14roJqfEpxh/1Ocr4lpWqZ4zorxXJ+bqMTTrqqZ302yg==
+
 prompts@^2.0.1:
   version "2.4.2"
   resolved "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"


### PR DESCRIPTION
## Proposed changes

In some scenarios, if data set content did not finish downloading, any subsequent clicks on the data set node will cause the editor to appear without any content. The content is then added to the local document, but because of this, it can break extensions such as the COBOL language support extension. This PR adds some logic that will wait for the dataset node to finish fetching contents before opening the editor.

This also bumps the Secrets SDK to 7.18.4 because some bug fixes were not released as intended w/ 7.18.3.

## Release Notes

Milestone: 2.11.0

Changelog:

- Fixed issue where data set content does not always appear as soon as the editor is opened. [#2427](https://github.com/zowe/vscode-extension-for-zowe/issues/2427)

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [x] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
