### PR TITLE
chore(secrets): Bump Secrets SDK to 7.18.3

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 ### Bug fixes
 
+- Bump `@zowe/secrets-for-zowe-sdk` to 7.18.3 to handle install errors gracefully and to allow running without MSVC redistributables.
+
 ## `2.10.0`
 
 ### New features and enhancements

--- a/packages/zowe-explorer-api/__mocks__/fs.ts
+++ b/packages/zowe-explorer-api/__mocks__/fs.ts
@@ -10,6 +10,7 @@
  */
 
 const fs = jest.genMockFromModule("fs") as any;
+const origExistsSync = jest.requireActual("fs").existsSync;
 const origReadFileSync = jest.requireActual("fs").readFileSync;
 const mockReadFileSync = fs.readFileSync;
 
@@ -28,5 +29,6 @@ function realpathSync(path: string): string {
 fs.readFileSync = readFileSync;
 fs.realpathSync = realpathSync;
 fs.realpathSync.native = realpathSync;
+fs.existsSync = origExistsSync;
 
 module.exports = fs;

--- a/packages/zowe-explorer-api/__tests__/__unit__/profiles/ProfilesCache.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/profiles/ProfilesCache.unit.test.ts
@@ -131,6 +131,7 @@ describe("ProfilesCache", () => {
     });
 
     it("getProfileInfo should initialize ProfileInfo API", async () => {
+        const existsSync = jest.spyOn(fs, "existsSync").mockImplementation();
         const profInfo = await new ProfilesCache(fakeLogger as unknown as zowe.imperative.Logger, __dirname).getProfileInfo();
         expect(readProfilesFromDiskSpy).toHaveBeenCalledTimes(1);
         expect(defaultCredMgrWithKeytarSpy).toHaveBeenCalledTimes(1);
@@ -143,6 +144,7 @@ describe("ProfilesCache", () => {
             path.join(fakeZoweDir, teamConfig.userConfigName),
             path.join(fakeZoweDir, teamConfig.configName),
         ]);
+        existsSync.mockRestore();
     });
 
     it("requireKeyring returns keyring module from Secrets SDK", async () => {

--- a/packages/zowe-explorer-api/package.json
+++ b/packages/zowe-explorer-api/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@types/vscode": "^1.53.2",
     "@zowe/cli": "^7.18.0",
-    "@zowe/secrets-for-zowe-sdk": "7.18.1",
+    "@zowe/secrets-for-zowe-sdk": "7.18.3",
     "handlebars": "^4.7.7",
     "semver": "^7.5.3"
   },

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
+- Bump `@zowe/secrets-for-zowe-sdk` to 7.18.3 to handle install errors gracefully and to allow running without MSVC redistributables.
+
 ## `2.10.0`
 
 ### New features and enhancements

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -1986,7 +1986,7 @@
     "webpack-cli": "^3.3.11"
   },
   "dependencies": {
-    "@zowe/secrets-for-zowe-sdk": "7.18.1",
+    "@zowe/secrets-for-zowe-sdk": "7.18.3",
     "@zowe/zowe-explorer-api": "2.10.1-SNAPSHOT",
     "fs-extra": "8.0.1",
     "isbinaryfile": "4.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2345,10 +2345,10 @@
   resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/secrets-for-zowe-sdk/-/@zowe/secrets-for-zowe-sdk-7.18.0.tgz#2741de10f4c16811b25bdf4944f669a0d15e3788"
   integrity sha512-QyZQh45pZEj9PWkqaTfMFIFDiHpMI4aCaZSbsbhanz54h/kN1s6nT4ri43EjQ3J3aUsG2wEjKkotjBZdGg3cHw==
 
-"@zowe/secrets-for-zowe-sdk@7.18.1":
-  version "7.18.1"
-  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/secrets-for-zowe-sdk/-/@zowe/secrets-for-zowe-sdk-7.18.1.tgz#79b2cb314028366c8f4b33eb2158c7e985e7989a"
-  integrity sha512-4rGo+KgYWhsfggaBBsb3xC7XZ50/GPrmtA2jOVKGrIYCjlqgJ21suMzyCzVioqlS+qNnbg9vxP/4C2Bew9wuUA==
+"@zowe/secrets-for-zowe-sdk@7.18.3":
+  version "7.18.3"
+  resolved "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/secrets-for-zowe-sdk/-/@zowe/secrets-for-zowe-sdk-7.18.3.tgz#a5fce6282f6835d58e0ec757cd9badee2defea14"
+  integrity sha512-3/TyFgpZimOUreDLQSlRfZK+GAgRr4zl31YvPD1wOB95wIgcX7dDONmsMuf/Z721eJOkVMuae7W4Ke92oyJECQ==
 
 "@zowe/zos-console-for-zowe-sdk@7.18.0":
   version "7.18.0"


### PR DESCRIPTION
## Proposed changes

This PR bumps `@zowe/secrets-for-zowe-sdk` to 7.18.3. This version resolves the following issues:
- Windows binaries were packaged without a static C runtime (required MSVC redistributables)
- Package install failed if `libsecret` or other Linux dependencies were missing in the user's environment

I've also fixed a couple of tests that were broken because of the `existsSync` check added to the Secrets SDK - since we mock the `fs` module, I had to make some adjustments to get the tests passing again.

## Release Notes

Milestone: 2.11.0

Changelog:

- Bump `@zowe/secrets-for-zowe-sdk` to 7.18.3 to handle install errors gracefully and to allow running without MSVC redistributables.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
