### PR TITLE
Refresh Zowe Explorer after token auth logout

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
+- Fixed issue with endless credential prompt loop when logging out. [#2262](https://github.com/zowe/vscode-extension-for-zowe/issues/2262)
+
 ## `2.10.0`
 
 ### New features and enhancements

--- a/packages/zowe-explorer/__tests__/__unit__/Profiles.extended.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/Profiles.extended.unit.test.ts
@@ -1330,11 +1330,12 @@ describe("Profiles Unit Tests - function checkCurrentProfile", () => {
     };
 
     const setupProfilesCheck = (globalMocks): void => {
+        jest.spyOn(Profiles.getInstance(), "getDefaultProfile").mockReturnValue({ name: "base" } as any);
         jest.spyOn(Profiles.getInstance(), "getProfileInfo").mockResolvedValue({
             getTeamConfig: () => ({
                 properties: {
                     profiles: {
-                        sestest: globalMocks.testProfile.profile,
+                        sestest: { ...globalMocks.testProfile.profile, secure: [] },
                         base: {
                             type: "base",
                             host: "test",

--- a/packages/zowe-explorer/__tests__/__unit__/Profiles.extended.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/Profiles.extended.unit.test.ts
@@ -1350,6 +1350,7 @@ describe("Profiles Unit Tests - function checkCurrentProfile", () => {
             }),
         } as any);
         jest.spyOn(Profiles.getInstance(), "getLoadedProfConfig").mockResolvedValue(globalMocks.testProfile);
+        jest.spyOn(Profiles.getInstance(), "getSecurePropsForProfile").mockResolvedValue([]);
     };
 
     it("should show as active in status of profile", async () => {

--- a/packages/zowe-explorer/__tests__/__unit__/Profiles.extended.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/Profiles.extended.unit.test.ts
@@ -1373,6 +1373,13 @@ describe("Profiles Unit Tests - function checkCurrentProfile", () => {
         setupProfilesCheck(globalMocks);
         await expect(Profiles.getInstance().checkCurrentProfile(globalMocks.testProfile)).resolves.toEqual({ name: "sestest", status: "inactive" });
     });
+    it("should throw an error if using token auth and is logged out or has expired token", async () => {
+        const globalMocks = await createGlobalMocks();
+        jest.spyOn(utils, "errorHandling").mockImplementation();
+        jest.spyOn(utils, "isUsingTokenAuth").mockResolvedValue(true);
+        setupProfilesCheck(globalMocks);
+        await expect(Profiles.getInstance().checkCurrentProfile(globalMocks.testProfile)).resolves.toEqual({ name: "sestest", status: "unverified" });
+    });
 });
 
 describe("Profiles Unit Tests - function editSession", () => {
@@ -1767,5 +1774,28 @@ describe("Profiles Unit Tests - function loginCredentialPrompt", () => {
         const showMessageSpy = jest.spyOn(Gui, "showMessage").mockImplementation();
         await expect(privateProfile.loginCredentialPrompt()).resolves.toEqual(undefined);
         expect(showMessageSpy).toBeCalledTimes(1);
+    });
+});
+
+describe("Profiles Unit Tests - function getSecurePropsForProfile", () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+        jest.resetAllMocks();
+    });
+    it("should retrieve the secure properties of a profile", async () => {
+        const globalMocks = await createGlobalMocks();
+        jest.spyOn(Profiles.getInstance(), "getProfileInfo").mockResolvedValue({
+            mergeArgsForProfile: () => ({
+                knownArgs: [
+                    {
+                        argName: "tokenValue",
+                        secure: true,
+                    } as any,
+                ],
+                missingArgs: [],
+            }),
+            getAllProfiles: () => [],
+        } as any);
+        await expect(Profiles.getInstance().getSecurePropsForProfile(globalMocks.testProfile.name ?? "")).resolves.toEqual(["tokenValue"]);
     });
 });

--- a/packages/zowe-explorer/__tests__/__unit__/abstract/TreeProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/abstract/TreeProvider.unit.test.ts
@@ -337,7 +337,7 @@ describe("ZoweJobNode unit tests - Function checkCurrentProfile", () => {
     it("Tests that checkCurrentProfile is executed successfully with inactive status", async () => {
         const globalMocks = await createGlobalMocks();
         const blockMocks = await createBlockMocks(globalMocks);
-        blockMocks.jobNode.contextValue = "SERVER";
+        blockMocks.jobNode.contextValue = "session";
         globalMocks.mockCheckCurrentProfile.mockReturnValueOnce({
             name: globalMocks.testProfile.name,
             status: "inactive",

--- a/packages/zowe-explorer/__tests__/__unit__/job/ZosJobsProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/ZosJobsProvider.unit.test.ts
@@ -280,7 +280,6 @@ describe("ZosJobsProvider unit tests - Function getChildren", () => {
         const testTree = new ZosJobsProvider();
         testTree.mSessionNodes.push(blockMocks.jobSessionNode);
         testTree.mSessionNodes[1].dirty = true;
-        const sessionElement = testTree.mSessionNodes[1];
 
         await expect(testTree.getChildren(testTree.mSessionNodes[1])).resolves.toEqual([]);
     });

--- a/packages/zowe-explorer/__tests__/__unit__/job/ZosJobsProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/ZosJobsProvider.unit.test.ts
@@ -272,6 +272,18 @@ describe("ZosJobsProvider unit tests - Function getChildren", () => {
 
         expect(elementGetChildrenSpy).toHaveBeenCalledTimes(1);
     });
+    it("Tests that getChildren returns the empty array if status of profile is unverified", async () => {
+        const globalMocks = await createGlobalMocks();
+        jest.spyOn(Profiles.getInstance(), "checkCurrentProfile").mockResolvedValueOnce({ status: "unverified" } as any);
+        const blockMocks = createBlockMocks(globalMocks);
+        mocked(vscode.window.createTreeView).mockReturnValueOnce(blockMocks.treeView);
+        const testTree = new ZosJobsProvider();
+        testTree.mSessionNodes.push(blockMocks.jobSessionNode);
+        testTree.mSessionNodes[1].dirty = true;
+        const sessionElement = testTree.mSessionNodes[1];
+
+        await expect(testTree.getChildren(testTree.mSessionNodes[1])).resolves.toEqual([]);
+    });
 });
 
 describe("ZosJobsProvider unit tests - Function initializeFavChildNodeForProfile", () => {

--- a/packages/zowe-explorer/__tests__/__unit__/uss/USSTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/USSTree.unit.test.ts
@@ -1424,6 +1424,27 @@ describe("USSTree Unit Tests - Function USSTree.getChildren()", () => {
 
         expect(loadProfilesForFavoritesSpy).toHaveBeenCalledWith(log, favProfileNode);
     });
+
+    it("Testing that getChildren() returns the empty array if the profile has unverified status", async () => {
+        const globalMocks = await createGlobalMocks();
+
+        const testDir = new ZoweUSSNode("aDir", vscode.TreeItemCollapsibleState.Collapsed, globalMocks.testTree.mSessionNodes[1], null, "test");
+        globalMocks.testTree.mSessionNodes[1].children.push(testDir);
+        const mockApiResponseItems = {
+            items: [
+                {
+                    mode: "d",
+                    mSessionName: "sestest",
+                    name: "aDir",
+                },
+            ],
+        };
+        const mockApiResponseWithItems = createFileResponse(mockApiResponseItems);
+        globalMocks.withProgress.mockReturnValue(mockApiResponseWithItems);
+        jest.spyOn(Profiles.getInstance(), "checkCurrentProfile").mockResolvedValueOnce({ status: "unverified" } as any);
+        const sessChildren = await globalMocks.testTree.getChildren(globalMocks.testTree.mSessionNodes[1]);
+        expect(sessChildren.length).toEqual(0);
+    });
 });
 
 // Idea is borrowed from: https://github.com/kulshekhar/ts-jest/blob/master/src/util/testing.ts

--- a/packages/zowe-explorer/__tests__/__unit__/utils/ProfilesUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/ProfilesUtils.unit.test.ts
@@ -21,6 +21,7 @@ import { Profiles } from "../../../src/Profiles";
 import { SettingsConfig } from "../../../src/utils/SettingsConfig";
 import { ZoweLogger } from "../../../src/utils/LoggerUtils";
 import { ZoweExplorerExtender } from "../../../src/ZoweExplorerExtender";
+import { createValidIProfile } from "../../../__mocks__/mockCreators/shared";
 
 jest.mock("fs");
 jest.mock("vscode");
@@ -61,6 +62,25 @@ describe("ProfilesUtils unit tests", () => {
     }
 
     describe("errorHandling", () => {
+        const profileInfoMock = () => ({
+            getTeamConfig: () => ({
+                properties: {
+                    profiles: {
+                        sestest: createValidIProfile().profile,
+                        base: {
+                            type: "base",
+                            host: "test",
+                            port: 1443,
+                            rejectUnauthorized: false,
+                            name: "base",
+                            tokenType: "",
+                            secure: [],
+                        },
+                    },
+                },
+            }),
+        });
+
         it("should log error details", async () => {
             createBlockMocks();
             const errorDetails = new Error("i haz error");
@@ -132,6 +152,8 @@ describe("ProfilesUtils unit tests", () => {
             Object.defineProperty(Profiles, "getInstance", {
                 value: () => ({
                     promptCredentials: promptCredsSpy,
+                    getProfileInfo: profileInfoMock,
+                    getLoadedProfConfig: () => ({ type: "zosmf" }),
                 }),
             });
             await profUtils.errorHandling(errorDetails, label, moreInfo);
@@ -155,6 +177,8 @@ describe("ProfilesUtils unit tests", () => {
             Object.defineProperty(Profiles, "getInstance", {
                 value: () => ({
                     ssoLogin: ssoLoginSpy,
+                    getProfileInfo: profileInfoMock,
+                    getLoadedProfConfig: () => ({ type: "zosmf" }),
                 }),
             });
             await profUtils.errorHandling(errorDetails, label, moreInfo);
@@ -185,6 +209,8 @@ describe("ProfilesUtils unit tests", () => {
             Object.defineProperty(Profiles, "getInstance", {
                 value: () => ({
                     ssoLogin: ssoLoginSpy,
+                    getProfileInfo: profileInfoMock,
+                    getLoadedProfConfig: () => ({ type: "zosmf" }),
                 }),
             });
             await profUtils.errorHandling(errorDetails, label, moreInfo);
@@ -215,6 +241,8 @@ describe("ProfilesUtils unit tests", () => {
             Object.defineProperty(Profiles, "getInstance", {
                 value: () => ({
                     promptCredentials: promptCredentialsSpy,
+                    getProfileInfo: profileInfoMock,
+                    getLoadedProfConfig: () => ({ type: "zosmf" }),
                 }),
             });
             await profUtils.errorHandling(errorDetails, label, moreInfo);
@@ -239,6 +267,8 @@ describe("ProfilesUtils unit tests", () => {
             Object.defineProperty(Profiles, "getInstance", {
                 value: () => ({
                     promptCredentials: promptCredentialsSpy,
+                    getProfileInfo: profileInfoMock,
+                    getLoadedProfConfig: () => ({ type: "zosmf" }),
                 }),
             });
             await profUtils.errorHandling(errorDetails, label, moreInfo);

--- a/packages/zowe-explorer/__tests__/__unit__/utils/ProfilesUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/ProfilesUtils.unit.test.ts
@@ -178,7 +178,8 @@ describe("ProfilesUtils unit tests", () => {
                 getProfileInfo: profileInfoMock,
                 getLoadedProfConfig: () => ({ type: "zosmf" }),
                 getDefaultProfile: () => ({}),
-                getSecurePropsForProfile: () => [],
+                getSecurePropsForProfile: () => ["tokenValue"],
+                ssoLogin: ssoLoginSpy,
             } as any);
             await profUtils.errorHandling(errorDetails, label, moreInfo);
             expect(showMessageSpy).toBeCalledTimes(1);
@@ -209,7 +210,8 @@ describe("ProfilesUtils unit tests", () => {
                 getProfileInfo: profileInfoMock,
                 getLoadedProfConfig: () => ({ type: "zosmf" }),
                 getDefaultProfile: () => ({}),
-                getSecurePropsForProfile: () => [],
+                getSecurePropsForProfile: () => ["tokenValue"],
+                ssoLogin: ssoLoginSpy,
             } as any);
             await profUtils.errorHandling(errorDetails, label, moreInfo);
             expect(showErrorSpy).toBeCalledTimes(1);

--- a/packages/zowe-explorer/__tests__/__unit__/utils/ProfilesUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/ProfilesUtils.unit.test.ts
@@ -154,6 +154,7 @@ describe("ProfilesUtils unit tests", () => {
                     promptCredentials: promptCredsSpy,
                     getProfileInfo: profileInfoMock,
                     getLoadedProfConfig: () => ({ type: "zosmf" }),
+                    getDefaultProfile: () => ({}),
                 }),
             });
             await profUtils.errorHandling(errorDetails, label, moreInfo);
@@ -179,6 +180,7 @@ describe("ProfilesUtils unit tests", () => {
                     ssoLogin: ssoLoginSpy,
                     getProfileInfo: profileInfoMock,
                     getLoadedProfConfig: () => ({ type: "zosmf" }),
+                    getDefaultProfile: () => ({}),
                 }),
             });
             await profUtils.errorHandling(errorDetails, label, moreInfo);
@@ -211,6 +213,7 @@ describe("ProfilesUtils unit tests", () => {
                     ssoLogin: ssoLoginSpy,
                     getProfileInfo: profileInfoMock,
                     getLoadedProfConfig: () => ({ type: "zosmf" }),
+                    getDefaultProfile: () => ({}),
                 }),
             });
             await profUtils.errorHandling(errorDetails, label, moreInfo);
@@ -243,6 +246,7 @@ describe("ProfilesUtils unit tests", () => {
                     promptCredentials: promptCredentialsSpy,
                     getProfileInfo: profileInfoMock,
                     getLoadedProfConfig: () => ({ type: "zosmf" }),
+                    getDefaultProfile: () => ({}),
                 }),
             });
             await profUtils.errorHandling(errorDetails, label, moreInfo);
@@ -269,6 +273,7 @@ describe("ProfilesUtils unit tests", () => {
                     promptCredentials: promptCredentialsSpy,
                     getProfileInfo: profileInfoMock,
                     getLoadedProfConfig: () => ({ type: "zosmf" }),
+                    getDefaultProfile: () => ({}),
                 }),
             });
             await profUtils.errorHandling(errorDetails, label, moreInfo);

--- a/packages/zowe-explorer/__tests__/__unit__/utils/ProfilesUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/ProfilesUtils.unit.test.ts
@@ -149,14 +149,13 @@ describe("ProfilesUtils unit tests", () => {
             jest.spyOn(profUtils, "isTheia").mockReturnValue(false);
             const showMessageSpy = jest.spyOn(Gui, "errorMessage").mockImplementation(() => Promise.resolve("Update Credentials"));
             const promptCredsSpy = jest.fn();
-            Object.defineProperty(Profiles, "getInstance", {
-                value: () => ({
-                    promptCredentials: promptCredsSpy,
-                    getProfileInfo: profileInfoMock,
-                    getLoadedProfConfig: () => ({ type: "zosmf" }),
-                    getDefaultProfile: () => ({}),
-                }),
-            });
+            jest.spyOn(Profiles, "getInstance").mockReturnValue({
+                promptCredentials: promptCredsSpy,
+                getProfileInfo: profileInfoMock,
+                getLoadedProfConfig: () => ({ type: "zosmf" }),
+                getDefaultProfile: () => ({}),
+                getSecurePropsForProfile: () => [],
+            } as any);
             await profUtils.errorHandling(errorDetails, label, moreInfo);
             expect(showMessageSpy).toBeCalledTimes(1);
             expect(promptCredsSpy).toBeCalledTimes(1);
@@ -175,14 +174,12 @@ describe("ProfilesUtils unit tests", () => {
             const showErrorSpy = jest.spyOn(Gui, "errorMessage");
             const showMessageSpy = jest.spyOn(Gui, "showMessage").mockImplementation(() => Promise.resolve("selection"));
             const ssoLoginSpy = jest.fn();
-            Object.defineProperty(Profiles, "getInstance", {
-                value: () => ({
-                    ssoLogin: ssoLoginSpy,
-                    getProfileInfo: profileInfoMock,
-                    getLoadedProfConfig: () => ({ type: "zosmf" }),
-                    getDefaultProfile: () => ({}),
-                }),
-            });
+            jest.spyOn(Profiles, "getInstance").mockReturnValue({
+                getProfileInfo: profileInfoMock,
+                getLoadedProfConfig: () => ({ type: "zosmf" }),
+                getDefaultProfile: () => ({}),
+                getSecurePropsForProfile: () => [],
+            } as any);
             await profUtils.errorHandling(errorDetails, label, moreInfo);
             expect(showMessageSpy).toBeCalledTimes(1);
             expect(ssoLoginSpy).toBeCalledTimes(1);
@@ -208,14 +205,12 @@ describe("ProfilesUtils unit tests", () => {
             const showErrorSpy = jest.spyOn(Gui, "errorMessage").mockImplementation(() => Promise.resolve(undefined));
             const showMessageSpy = jest.spyOn(Gui, "showMessage");
             const ssoLoginSpy = jest.fn();
-            Object.defineProperty(Profiles, "getInstance", {
-                value: () => ({
-                    ssoLogin: ssoLoginSpy,
-                    getProfileInfo: profileInfoMock,
-                    getLoadedProfConfig: () => ({ type: "zosmf" }),
-                    getDefaultProfile: () => ({}),
-                }),
-            });
+            jest.spyOn(Profiles, "getInstance").mockReturnValue({
+                getProfileInfo: profileInfoMock,
+                getLoadedProfConfig: () => ({ type: "zosmf" }),
+                getDefaultProfile: () => ({}),
+                getSecurePropsForProfile: () => [],
+            } as any);
             await profUtils.errorHandling(errorDetails, label, moreInfo);
             expect(showErrorSpy).toBeCalledTimes(1);
             expect(ssoLoginSpy).toBeCalledTimes(1);
@@ -241,14 +236,13 @@ describe("ProfilesUtils unit tests", () => {
             const showErrorSpy = jest.spyOn(Gui, "errorMessage").mockResolvedValue(undefined);
             const showMsgSpy = jest.spyOn(Gui, "showMessage");
             const promptCredentialsSpy = jest.fn();
-            Object.defineProperty(Profiles, "getInstance", {
-                value: () => ({
-                    promptCredentials: promptCredentialsSpy,
-                    getProfileInfo: profileInfoMock,
-                    getLoadedProfConfig: () => ({ type: "zosmf" }),
-                    getDefaultProfile: () => ({}),
-                }),
-            });
+            jest.spyOn(Profiles, "getInstance").mockReturnValue({
+                promptCredentials: promptCredentialsSpy,
+                getProfileInfo: profileInfoMock,
+                getLoadedProfConfig: () => ({ type: "zosmf" }),
+                getDefaultProfile: () => ({}),
+                getSecurePropsForProfile: () => [],
+            } as any);
             await profUtils.errorHandling(errorDetails, label, moreInfo);
             expect(showErrorSpy).toBeCalledTimes(1);
             expect(promptCredentialsSpy).not.toBeCalled();
@@ -268,14 +262,13 @@ describe("ProfilesUtils unit tests", () => {
             jest.spyOn(profUtils, "isTheia").mockReturnValue(true);
             const showErrorSpy = jest.spyOn(Gui, "errorMessage");
             const promptCredentialsSpy = jest.fn();
-            Object.defineProperty(Profiles, "getInstance", {
-                value: () => ({
-                    promptCredentials: promptCredentialsSpy,
-                    getProfileInfo: profileInfoMock,
-                    getLoadedProfConfig: () => ({ type: "zosmf" }),
-                    getDefaultProfile: () => ({}),
-                }),
-            });
+            jest.spyOn(Profiles, "getInstance").mockReturnValue({
+                promptCredentials: promptCredentialsSpy,
+                getProfileInfo: profileInfoMock,
+                getLoadedProfConfig: () => ({ type: "zosmf" }),
+                getDefaultProfile: () => ({}),
+                getSecurePropsForProfile: () => [],
+            } as any);
             await profUtils.errorHandling(errorDetails, label, moreInfo);
             expect(showErrorSpy).toBeCalledTimes(1);
             expect(promptCredentialsSpy).not.toBeCalled();

--- a/packages/zowe-explorer/__tests__/__unit__/utils/ProfilesUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/ProfilesUtils.unit.test.ts
@@ -737,4 +737,13 @@ describe("ProfilesUtils unit tests", () => {
             expect(defaultCredMgrSpy).toHaveBeenCalledWith(ProfilesCache.requireKeyring);
         });
     });
+
+    describe("isUsingTokenAuth", () => {
+        it("should check the profile in use if using token based auth instead of the base profile", async () => {
+            jest.spyOn(Profiles.getInstance(), "getDefaultProfile").mockReturnValueOnce({} as any);
+            jest.spyOn(Profiles.getInstance(), "getLoadedProfConfig").mockResolvedValue({ type: "test" } as any);
+            jest.spyOn(Profiles.getInstance(), "getSecurePropsForProfile").mockResolvedValue([]);
+            await expect(profUtils.isUsingTokenAuth("test")).resolves.toEqual(false);
+        });
+    });
 });

--- a/packages/zowe-explorer/i18n/sample/src/Profiles.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/Profiles.i18n.json
@@ -1,5 +1,7 @@
 {
   "profiles.operation.cancelled": "Operation Cancelled",
+  "checkCurrentProfile.tokenAuthError.msg": "Token auth error",
+  "checkCurrentProfile.tokenAuthError.additionalDetails": "Profile was found using token auth, please log in to continue.",
   "profiles.createNewConnection": "$(plus) Create a new connection to z/OS",
   "profiles.createTeamConfig": "$(plus) Create a new Team Configuration file",
   "profiles.editConfig": "$(pencil) Edit Team Configuration file",

--- a/packages/zowe-explorer/src/Profiles.ts
+++ b/packages/zowe-explorer/src/Profiles.ts
@@ -1234,10 +1234,12 @@ export class Profiles extends ProfilesCache {
                     await this.updateBaseProfileFileLogin(baseProfile, updBaseProfile);
                     const baseIndex = this.allProfiles.findIndex((profile) => profile.name === baseProfile.name);
                     this.allProfiles[baseIndex] = { ...baseProfile, profile: { ...baseProfile.profile, ...updBaseProfile } };
-                    node.setProfileToChoice({
-                        ...node.getProfile(),
-                        profile: { ...node.getProfile().profile, ...updBaseProfile },
-                    });
+                    if (node) {
+                        node.setProfileToChoice({
+                            ...node.getProfile(),
+                            profile: { ...node.getProfile().profile, ...updBaseProfile },
+                        });
+                    }
                 } catch (error) {
                     const errMsg = localize("ssoLogin.unableToLogin", "Unable to log in with {0}. {1}", serviceProfile.name, error?.message);
                     ZoweLogger.error(errMsg);

--- a/packages/zowe-explorer/src/Profiles.ts
+++ b/packages/zowe-explorer/src/Profiles.ts
@@ -1261,6 +1261,7 @@ export class Profiles extends ProfilesCache {
                 await this.updateBaseProfileFileLogout(baseProfile);
             }
             Gui.showMessage(localize("ssoLogout.successful", "Logout from authentication service was successful for {0}.", serviceProfile.name));
+            vscode.commands.executeCommand("zowe.extRefresh");
         } catch (error) {
             const message = localize("ssoLogout.error", "Unable to log out with {0}. {1}", serviceProfile.name, error?.message);
             ZoweLogger.error(message);

--- a/packages/zowe-explorer/src/Profiles.ts
+++ b/packages/zowe-explorer/src/Profiles.ts
@@ -1297,6 +1297,17 @@ export class Profiles extends ProfilesCache {
         await Gui.showTextDocument(document);
     }
 
+    /**
+     * gets secure properties for a profile
+     * @param profileName the name of the profile
+     * @returns {string[]} an array with the secure properties
+     */
+    public async getSecurePropsForProfile(profileName: string): Promise<string[]> {
+        const profAttrs = await this.getProfileFromConfig(profileName);
+        const mergedArgs = (await this.getProfileInfo()).mergeArgsForProfile(profAttrs);
+        return [...mergedArgs.knownArgs, ...mergedArgs.missingArgs].filter((arg) => arg.secure).map((arg) => arg.argName);
+    }
+
     private async getConfigLocationPrompt(action: string): Promise<string> {
         ZoweLogger.trace("Profiles.getConfigLocationPrompt called.");
         let placeHolderText: string;

--- a/packages/zowe-explorer/src/Profiles.ts
+++ b/packages/zowe-explorer/src/Profiles.ts
@@ -1296,7 +1296,7 @@ export class Profiles extends ProfilesCache {
         session.ISession.user = creds[0];
         session.ISession.password = creds[1];
         try {
-            const loginToken = await ZoweExplorerApiRegister.getInstance().getCommonApi(serviceProfile).login(session);
+            await ZoweExplorerApiRegister.getInstance().getCommonApi(serviceProfile).login(session);
             const profIndex = this.allProfiles.findIndex((profile) => profile.name === serviceProfile.name);
             this.allProfiles[profIndex] = { ...serviceProfile, profile: { ...serviceProfile, ...session } };
             if (node) {

--- a/packages/zowe-explorer/src/abstract/ZoweTreeProvider.ts
+++ b/packages/zowe-explorer/src/abstract/ZoweTreeProvider.ts
@@ -15,7 +15,7 @@ import { imperative } from "@zowe/cli";
 import { PersistentFilters } from "../PersistentFilters";
 import { getIconByNode, getIconById, IconId } from "../generators/icons";
 import * as contextually from "../shared/context";
-import { IZoweTreeNode, IZoweDatasetTreeNode, IZoweNodeType, IZoweTree, PersistenceSchemaEnum } from "@zowe/zowe-explorer-api";
+import { IZoweTreeNode, IZoweDatasetTreeNode, IZoweNodeType, IZoweTree, PersistenceSchemaEnum, ValidProfileEnum } from "@zowe/zowe-explorer-api";
 import { Profiles } from "../Profiles";
 import { setProfile, setSession, errorHandling } from "../utils/ProfilesUtils";
 
@@ -209,6 +209,7 @@ export class ZoweTreeProvider {
                 if (inactiveIcon) {
                     node.iconPath = inactiveIcon.path;
                 }
+                Profiles.getInstance().validProfile = ValidProfileEnum.INVALID;
             }
 
             await errorHandling(
@@ -230,6 +231,7 @@ export class ZoweTreeProvider {
                 if (activeIcon) {
                     node.iconPath = activeIcon.path;
                 }
+                Profiles.getInstance().validProfile = ValidProfileEnum.VALID;
             }
         } else if (profileStatus.status === "unverified") {
             if (
@@ -238,6 +240,7 @@ export class ZoweTreeProvider {
             ) {
                 node.contextValue = node.contextValue.replace(/(?<=.*)(_Active|_Inactive|_Unverified)$/, "");
                 node.contextValue = node.contextValue + globals.UNVERIFIED_CONTEXT;
+                Profiles.getInstance().validProfile = ValidProfileEnum.UNVERIFIED;
             }
         }
         await this.refresh();

--- a/packages/zowe-explorer/src/dataset/DatasetTree.ts
+++ b/packages/zowe-explorer/src/dataset/DatasetTree.ts
@@ -157,7 +157,11 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
                 const favsForProfile = this.loadProfilesForFavorites(this.log, element);
                 return favsForProfile;
             }
-            await Profiles.getInstance().checkCurrentProfile(element.getProfile());
+            const validationStatus = await Profiles.getInstance().checkCurrentProfile(element.getProfile());
+
+            if (validationStatus.status === "unverified") {
+                return [];
+            }
             const finalResponse: IZoweDatasetTreeNode[] = [];
             let response;
             try {

--- a/packages/zowe-explorer/src/job/ZosJobsProvider.ts
+++ b/packages/zowe-explorer/src/job/ZosJobsProvider.ts
@@ -197,6 +197,11 @@ export class ZosJobsProvider extends ZoweTreeProvider implements IZoweTree<IZowe
                 const favsForProfile = this.loadProfilesForFavorites(this.log, element);
                 return favsForProfile;
             }
+            const validationStatus = await Profiles.getInstance().checkCurrentProfile(element.getProfile());
+
+            if (validationStatus.status === "unverified") {
+                return [];
+            }
             return element.getChildren();
         }
         return this.mSessionNodes;

--- a/packages/zowe-explorer/src/uss/USSTree.ts
+++ b/packages/zowe-explorer/src/uss/USSTree.ts
@@ -296,6 +296,10 @@ export class USSTree extends ZoweTreeProvider implements IZoweTree<IZoweUSSTreeN
                 const favsForProfile = await this.loadProfilesForFavorites(this.log, element);
                 return favsForProfile;
             }
+            const validationStatus = await Profiles.getInstance().checkCurrentProfile(element.getProfile());
+            if (validationStatus.status === "unverified") {
+                return [];
+            }
             return element.getChildren();
         }
         return this.mSessionNodes;

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -137,20 +137,15 @@ export function isTheia(): boolean {
  * @returns {Promise<boolean>} a boolean representing whether token based auth is being used or not
  */
 export async function isUsingTokenAuth(profileName: string): Promise<boolean> {
-    const config = (await Profiles.getInstance().getProfileInfo()).getTeamConfig();
-    const baseProfile = config.properties.profiles[Profiles.getInstance().getDefaultProfile("base")?.name];
-    const profile = config.properties.profiles[profileName];
+    const baseProfile = Profiles.getInstance().getDefaultProfile("base");
     const isUsingZosmf = (await Profiles.getInstance().getLoadedProfConfig(profileName)).type === "zosmf";
-    if (isUsingZosmf && baseProfile && profile?.secure && baseProfile?.secure) {
-        return profile.secure.includes("tokenValue") || baseProfile.secure.includes("tokenValue");
+    if (isUsingZosmf && baseProfile) {
+        return (
+            (await Profiles.getInstance().getSecurePropsForProfile(profileName)).includes("tokenValue") ||
+            (await Profiles.getInstance().getSecurePropsForProfile(baseProfile?.name)).includes("tokenValue")
+        );
     }
-    if (isUsingZosmf && baseProfile && baseProfile?.secure) {
-        return baseProfile.secure.includes("tokenValue");
-    }
-    if (profile?.secure) {
-        return profile.secure.includes("tokenValue");
-    }
-    return false;
+    return (await Profiles.getInstance().getSecurePropsForProfile(profileName)).includes("tokenValue");
 }
 
 /**

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -131,18 +131,26 @@ export function isTheia(): boolean {
     return false;
 }
 
+/**
+ * Function that checks whether a profile is using token based authentication
+ * @param profileName the name of the profile to check
+ * @returns {Promise<boolean>} a boolean representing whether token based auth is being used or not
+ */
 export async function isUsingTokenAuth(profileName: string): Promise<boolean> {
     const config = (await Profiles.getInstance().getProfileInfo()).getTeamConfig();
-    const defaultBaseProfileName = Profiles.getInstance().getDefaultProfile("base").name;
-    const baseProfile = config.properties.profiles[defaultBaseProfileName];
+    const baseProfile = config.properties.profiles[Profiles.getInstance().getDefaultProfile("base")?.name];
     const profile = config.properties.profiles[profileName];
     const isUsingZosmf = (await Profiles.getInstance().getLoadedProfConfig(profileName)).type === "zosmf";
-
-    if (isUsingZosmf && baseProfile) {
+    if (isUsingZosmf && baseProfile && profile?.secure && baseProfile?.secure) {
         return profile.secure.includes("tokenValue") || baseProfile.secure.includes("tokenValue");
     }
-
-    return profile.secure.includes("tokenValue");
+    if (isUsingZosmf && baseProfile && baseProfile?.secure) {
+        return baseProfile.secure.includes("tokenValue");
+    }
+    if (profile?.secure) {
+        return profile.secure.includes("tokenValue");
+    }
+    return false;
 }
 
 /**

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -139,13 +139,12 @@ export function isTheia(): boolean {
 export async function isUsingTokenAuth(profileName: string): Promise<boolean> {
     const baseProfile = Profiles.getInstance().getDefaultProfile("base");
     const isUsingZosmf = (await Profiles.getInstance().getLoadedProfConfig(profileName)).type === "zosmf";
+    const secureProfileProps = await Profiles.getInstance().getSecurePropsForProfile(profileName);
+    const secureBaseProfileProps = await Profiles.getInstance().getSecurePropsForProfile(baseProfile?.name);
     if (isUsingZosmf && baseProfile) {
-        return (
-            (await Profiles.getInstance().getSecurePropsForProfile(profileName)).includes("tokenValue") ||
-            (await Profiles.getInstance().getSecurePropsForProfile(baseProfile?.name)).includes("tokenValue")
-        );
+        return secureProfileProps.includes("tokenValue") || secureBaseProfileProps.includes("tokenValue");
     }
-    return (await Profiles.getInstance().getSecurePropsForProfile(profileName)).includes("tokenValue");
+    return secureProfileProps.includes("tokenValue");
 }
 
 /**

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -74,7 +74,9 @@ export async function errorHandling(errorDetails: Error | string, label?: string
 
             if (imperativeError.mDetails.additionalDetails) {
                 const tokenError: string = imperativeError.mDetails.additionalDetails;
-                if (tokenError.includes("Token is not valid or expired.")) {
+                const isTokenAuth = await isUsingTokenAuth(label);
+
+                if (tokenError.includes("Token is not valid or expired.") || isTokenAuth) {
                     if (isTheia()) {
                         Gui.errorMessage(errToken);
                         await Profiles.getInstance().ssoLogin(null, label);
@@ -127,6 +129,17 @@ export function isTheia(): boolean {
         return true;
     }
     return false;
+}
+
+export async function isUsingTokenAuth(profileName: string): Promise<boolean> {
+    const config = (await Profiles.getInstance().getProfileInfo()).getTeamConfig();
+    const profile = await Profiles.getInstance().getLoadedProfConfig(profileName);
+
+    if (profile.type === "zosmf") {
+        return config.properties.profiles["base"].secure.includes("tokenValue");
+    }
+
+    return config.properties.profiles[profileName].secure.includes("tokenValue");
 }
 
 /**

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -133,13 +133,16 @@ export function isTheia(): boolean {
 
 export async function isUsingTokenAuth(profileName: string): Promise<boolean> {
     const config = (await Profiles.getInstance().getProfileInfo()).getTeamConfig();
-    const profile = await Profiles.getInstance().getLoadedProfConfig(profileName);
+    const defaultBaseProfileName = Profiles.getInstance().getDefaultProfile("base").name;
+    const baseProfile = config.properties.profiles[defaultBaseProfileName];
+    const profile = config.properties.profiles[profileName];
+    const isUsingZosmf = (await Profiles.getInstance().getLoadedProfConfig(profileName)).type === "zosmf";
 
-    if (profile.type === "zosmf") {
-        return config.properties.profiles["base"].secure.includes("tokenValue");
+    if (isUsingZosmf && baseProfile) {
+        return profile.secure.includes("tokenValue") || baseProfile.secure.includes("tokenValue");
     }
 
-    return config.properties.profiles[profileName].secure.includes("tokenValue");
+    return profile.secure.includes("tokenValue");
 }
 
 /**


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

Refresh Zowe Explorer after a logout is performed for token based auth

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog -->
<!-- If there is a linked issue, it should have the same milestone as this PR -->

Milestone: 2.10.1

Changelog: Fixed issue with endless credential prompt loop when logging out 

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [x] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [x] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
