### PR TITLE
feat: allow deleting migrated datasets

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### New features and enhancements
 
+- Allow deleting migrated datasets [#2447](https://github.com/zowe/vscode-extension-for-zowe/issues/2447)
+
 ### Bug fixes
 
 - Remove the 'Show Attributes' context menu action for migrated datasets. [#2033](https://github.com/zowe/vscode-extension-for-zowe/issues/2033)

--- a/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
@@ -415,6 +415,15 @@ describe("Dataset Actions Unit Tests - Function deleteDatasetPrompt", () => {
             undefined,
             globalMocks.imperativeProfile
         );
+        const testMigrNode = new ZoweDatasetNode(
+            "HLQ.TEST.MIGR",
+            vscode.TreeItemCollapsibleState.None,
+            globalMocks.datasetSessionNode,
+            globalMocks.session,
+            globals.DS_MIGRATED_FILE_CONTEXT,
+            undefined,
+            globalMocks.imperativeProfile
+        );
         const testMemberNode = new ZoweDatasetNode(
             "MEMB",
             vscode.TreeItemCollapsibleState.None,
@@ -447,6 +456,7 @@ describe("Dataset Actions Unit Tests - Function deleteDatasetPrompt", () => {
         testFavoritedNode.children.push(testFavMemberNode);
         globalMocks.datasetSessionNode.children.push(testDatasetNode);
         globalMocks.datasetSessionNode.children.push(testVsamNode);
+        globalMocks.datasetSessionNode.children.push(testMigrNode);
         globalMocks.datasetSessionFavNode.children.push(testFavoritedNode);
 
         mocked(vscode.window.withProgress).mockImplementation((progLocation, callback) => {
@@ -466,6 +476,7 @@ describe("Dataset Actions Unit Tests - Function deleteDatasetPrompt", () => {
             testDatasetTree,
             testDatasetNode,
             testVsamNode,
+            testMigrNode,
             testMemberNode,
             testFavMemberNode,
             testFavoritedNode,
@@ -516,6 +527,20 @@ describe("Dataset Actions Unit Tests - Function deleteDatasetPrompt", () => {
         await dsActions.deleteDatasetPrompt(blockMocks.testDatasetTree);
 
         expect(mocked(Gui.showMessage)).toBeCalledWith(`The following 1 item(s) were deleted: ${blockMocks.testVsamNode.getLabel()}`);
+    });
+
+    it("Should delete one migrated dataset", async () => {
+        const globalMocks = createGlobalMocks();
+        const blockMocks = createBlockMocks(globalMocks);
+
+        const selectedNodes = [blockMocks.testMigrNode];
+        const treeView = createTreeView(selectedNodes);
+        blockMocks.testDatasetTree.getTreeView.mockReturnValueOnce(treeView);
+        globalMocks.mockShowWarningMessage.mockResolvedValueOnce("Delete");
+
+        await dsActions.deleteDatasetPrompt(blockMocks.testDatasetTree);
+
+        expect(mocked(Gui.showMessage)).toBeCalledWith(`The following 1 item(s) were deleted: ${blockMocks.testMigrNode.getLabel()}`);
     });
 
     it("Should delete two datasets", async () => {

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -1149,6 +1149,11 @@
           "group": "099_zowe_dsModification@5"
         },
         {
+          "when": "view == zowe.ds.explorer && viewItem =~ /^migr.*/",
+          "command": "zowe.ds.deleteDataset",
+          "group": "099_zowe_dsModification@5"
+        },
+        {
           "when": "view == zowe.ds.explorer && viewItem =~ /_validate/ && !listMultiSelection",
           "command": "zowe.ds.disableValidation",
           "group": "098_zowe_dsProfileAuthentication@6"


### PR DESCRIPTION
## Proposed changes

Adding support to delete migrated datasets by providing a `Delete` context menu action item for migrated datasets

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog -->
<!-- If there is a linked issue, it should have the same milestone as this PR -->

Milestone: 10.0.1

Changelog: Allow deleting migrated datasets.

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
