### PR TITLE
Skip creating snapshot version after publish for next

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -67,7 +67,7 @@ jobs:
           git add packages/*/CHANGELOG.md
 
       - name: Create Snapshot Version
-        if: steps.octorelease.outcome == 'success'
+        if: ${{ github.ref_name != 'next' && steps.octorelease.outcome == 'success' }}
         uses: zowe-actions/octorelease/script@v1
         env:
           VERSION_STRING: "%s-SNAPSHOT"


### PR DESCRIPTION
The prerelease published successfully with this workflow:
https://github.com/zowe/vscode-extension-for-zowe/actions/runs/6161558200

But the post-publish step to create a snapshot version failed. I think we can disable it for the "next" branch because it doesn't make sense to be creating "SNAPSHOT" versions on a prerelease branch.