### PR TITLE
fix(ds,uss): Check if profile is invalid before searching

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Bump `@zowe/secrets-for-zowe-sdk` to 7.18.4 to handle install errors gracefully and to allow running without MSVC redistributables.
 - Fixed issue where data set content does not always appear as soon as the editor is opened. [#2427](https://github.com/zowe/vscode-extension-for-zowe/issues/2427)
 - Adjust scope of "Security: Secure Credentials Enabled" setting to `machine-overridable` so it appears again in certain cloud IDEs.
+- Fixed issue where disabling "Automatic Profile Validation" caused the search prompts to stop appearing for all tree views. [#2454](https://github.com/zowe/vscode-extension-for-zowe/issues/2454)
 
 ## `2.10.0`
 

--- a/packages/zowe-explorer/__tests__/__unit__/job/ZosJobsProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/ZosJobsProvider.unit.test.ts
@@ -272,17 +272,6 @@ describe("ZosJobsProvider unit tests - Function getChildren", () => {
 
         expect(elementGetChildrenSpy).toHaveBeenCalledTimes(1);
     });
-    it("Tests that getChildren returns the empty array if status of profile is unverified", async () => {
-        const globalMocks = await createGlobalMocks();
-        jest.spyOn(Profiles.getInstance(), "checkCurrentProfile").mockResolvedValueOnce({ status: "unverified" } as any);
-        const blockMocks = createBlockMocks(globalMocks);
-        mocked(vscode.window.createTreeView).mockReturnValueOnce(blockMocks.treeView);
-        const testTree = new ZosJobsProvider();
-        testTree.mSessionNodes.push(blockMocks.jobSessionNode);
-        testTree.mSessionNodes[1].dirty = true;
-
-        await expect(testTree.getChildren(testTree.mSessionNodes[1])).resolves.toEqual([]);
-    });
 });
 
 describe("ZosJobsProvider unit tests - Function initializeFavChildNodeForProfile", () => {

--- a/packages/zowe-explorer/__tests__/__unit__/uss/USSTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/USSTree.unit.test.ts
@@ -1424,29 +1424,7 @@ describe("USSTree Unit Tests - Function USSTree.getChildren()", () => {
 
         expect(loadProfilesForFavoritesSpy).toHaveBeenCalledWith(log, favProfileNode);
     });
-
-    it("Testing that getChildren() returns the empty array if the profile has unverified status", async () => {
-        const globalMocks = await createGlobalMocks();
-
-        const testDir = new ZoweUSSNode("aDir", vscode.TreeItemCollapsibleState.Collapsed, globalMocks.testTree.mSessionNodes[1], null, "test");
-        globalMocks.testTree.mSessionNodes[1].children.push(testDir);
-        const mockApiResponseItems = {
-            items: [
-                {
-                    mode: "d",
-                    mSessionName: "sestest",
-                    name: "aDir",
-                },
-            ],
-        };
-        const mockApiResponseWithItems = createFileResponse(mockApiResponseItems);
-        globalMocks.withProgress.mockReturnValue(mockApiResponseWithItems);
-        jest.spyOn(Profiles.getInstance(), "checkCurrentProfile").mockResolvedValueOnce({ status: "unverified" } as any);
-        const sessChildren = await globalMocks.testTree.getChildren(globalMocks.testTree.mSessionNodes[1]);
-        expect(sessChildren.length).toEqual(0);
-    });
 });
-
 // Idea is borrowed from: https://github.com/kulshekhar/ts-jest/blob/master/src/util/testing.ts
 const mocked = <T extends (...args: any[]) => any>(fn: T): jest.Mock<ReturnType<T>> => fn as any;
 

--- a/packages/zowe-explorer/src/dataset/DatasetTree.ts
+++ b/packages/zowe-explorer/src/dataset/DatasetTree.ts
@@ -157,11 +157,6 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
                 const favsForProfile = this.loadProfilesForFavorites(this.log, element);
                 return favsForProfile;
             }
-            const validationStatus = await Profiles.getInstance().checkCurrentProfile(element.getProfile());
-
-            if (SettingsConfig.getDirectValue(globals.SETTINGS_AUTOMATIC_PROFILE_VALIDATION) && validationStatus.status === "unverified") {
-                return [];
-            }
             const finalResponse: IZoweDatasetTreeNode[] = [];
             let response;
             try {

--- a/packages/zowe-explorer/src/dataset/DatasetTree.ts
+++ b/packages/zowe-explorer/src/dataset/DatasetTree.ts
@@ -890,7 +890,7 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
         await this.checkCurrentProfile(node);
         let nonFaveNode;
 
-        if (Profiles.getInstance().validProfile === ValidProfileEnum.VALID || !contextually.isValidationEnabled(node)) {
+        if (Profiles.getInstance().validProfile !== ValidProfileEnum.INVALID) {
             if (contextually.isSessionNotFav(node)) {
                 nonFaveNode = node;
                 if (this.mHistory.getSearchHistory().length > 0) {

--- a/packages/zowe-explorer/src/dataset/DatasetTree.ts
+++ b/packages/zowe-explorer/src/dataset/DatasetTree.ts
@@ -159,7 +159,7 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
             }
             const validationStatus = await Profiles.getInstance().checkCurrentProfile(element.getProfile());
 
-            if (validationStatus.status === "unverified") {
+            if (SettingsConfig.getDirectValue(globals.SETTINGS_AUTOMATIC_PROFILE_VALIDATION) && validationStatus.status === "unverified") {
                 return [];
             }
             const finalResponse: IZoweDatasetTreeNode[] = [];

--- a/packages/zowe-explorer/src/job/ZosJobsProvider.ts
+++ b/packages/zowe-explorer/src/job/ZosJobsProvider.ts
@@ -199,7 +199,7 @@ export class ZosJobsProvider extends ZoweTreeProvider implements IZoweTree<IZowe
             }
             const validationStatus = await Profiles.getInstance().checkCurrentProfile(element.getProfile());
 
-            if (validationStatus.status === "unverified") {
+            if (SettingsConfig.getDirectValue(globals.SETTINGS_AUTOMATIC_PROFILE_VALIDATION) && validationStatus.status === "unverified") {
                 return [];
             }
             return element.getChildren();

--- a/packages/zowe-explorer/src/job/ZosJobsProvider.ts
+++ b/packages/zowe-explorer/src/job/ZosJobsProvider.ts
@@ -197,11 +197,6 @@ export class ZosJobsProvider extends ZoweTreeProvider implements IZoweTree<IZowe
                 const favsForProfile = this.loadProfilesForFavorites(this.log, element);
                 return favsForProfile;
             }
-            const validationStatus = await Profiles.getInstance().checkCurrentProfile(element.getProfile());
-
-            if (SettingsConfig.getDirectValue(globals.SETTINGS_AUTOMATIC_PROFILE_VALIDATION) && validationStatus.status === "unverified") {
-                return [];
-            }
             return element.getChildren();
         }
         return this.mSessionNodes;

--- a/packages/zowe-explorer/src/uss/USSTree.ts
+++ b/packages/zowe-explorer/src/uss/USSTree.ts
@@ -567,7 +567,7 @@ export class USSTree extends ZoweTreeProvider implements IZoweTree<IZoweUSSTreeN
             ZoweLogger.debug(localize("filterPrompt.log.debug.promptUSSPath", "Prompting the user for a USS path"));
         }
         await this.checkCurrentProfile(node);
-        if (Profiles.getInstance().validProfile === ValidProfileEnum.VALID || !contextually.isValidationEnabled(node)) {
+        if (Profiles.getInstance().validProfile !== ValidProfileEnum.INVALID) {
             let sessionNode;
             let remotepath: string;
             if (contextually.isSessionNotFav(node)) {

--- a/packages/zowe-explorer/src/uss/USSTree.ts
+++ b/packages/zowe-explorer/src/uss/USSTree.ts
@@ -297,7 +297,7 @@ export class USSTree extends ZoweTreeProvider implements IZoweTree<IZoweUSSTreeN
                 return favsForProfile;
             }
             const validationStatus = await Profiles.getInstance().checkCurrentProfile(element.getProfile());
-            if (validationStatus.status === "unverified") {
+            if (SettingsConfig.getDirectValue(globals.SETTINGS_AUTOMATIC_PROFILE_VALIDATION) && validationStatus.status === "unverified") {
                 return [];
             }
             return element.getChildren();

--- a/packages/zowe-explorer/src/uss/USSTree.ts
+++ b/packages/zowe-explorer/src/uss/USSTree.ts
@@ -296,10 +296,6 @@ export class USSTree extends ZoweTreeProvider implements IZoweTree<IZoweUSSTreeN
                 const favsForProfile = await this.loadProfilesForFavorites(this.log, element);
                 return favsForProfile;
             }
-            const validationStatus = await Profiles.getInstance().checkCurrentProfile(element.getProfile());
-            if (SettingsConfig.getDirectValue(globals.SETTINGS_AUTOMATIC_PROFILE_VALIDATION) && validationStatus.status === "unverified") {
-                return [];
-            }
             return element.getChildren();
         }
         return this.mSessionNodes;


### PR DESCRIPTION
## Proposed changes

This PR fixes the following bug: when "Automatic Profile Validation" is disabled, the search prompts do not appear after clicking on the search icon for all 3 trees.

This was resolved for the jobs tree as a part of #2440, but the issue remained for the data set and USS trees.

Fixes #2454, #2344 

## Release Notes

Milestone: 2.11.0

Changelog:

- Fixed issue where disabling "Automatic Profile Validation" caused the search prompts to stop appearing for all tree views. #2454 

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found