### PR TITLE
1.22.5 Release

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.22.4-SNAPSHOT",
+  "version": "1.22.5",
   "command": {
     "version": {
       "forcePublish": true,


### PR DESCRIPTION
## Proposed changes

This is the PR for the upcoming 1.22.5 release. Code freeze is next week (9/19, I believe)

## Release Notes

Milestone: 1.22.5

There's only one change for this release:
- Replaced `keytar` dependency with `keyring` module from [`@zowe/secrets-for-zowe-sdk`](https://github.com/zowe/zowe-cli/tree/master/packages/secrets). [#2358](https://github.com/zowe/vscode-extension-for-zowe/issues/2358)
