### PR TITLE
fix(ds): Sort dataset list by label after adding new children

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
+- Fixed submitting local JCL using command pallet option `Zowe Explorer: Submit JCL` by adding a check for chosen profile returned to continue the action. [#1625](https://github.com/zowe/vscode-extension-for-zowe/issues/1625)
+- Fixed bug where the list of datasets from a filter search was not re-sorted after a new data set was created in Zowe Explorer. [#2473](https://github.com/zowe/vscode-extension-for-zowe/issues/2473)
+
 ## `2.11.0`
 
 ### New features and enhancements

--- a/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
@@ -253,11 +253,13 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
             ];
         } else {
             const newChildren = Object.keys(elementChildren)
-                .sort()
                 .filter((label) => this.children.find((c) => (c.label as string) === label) == null)
                 .map((label) => elementChildren[label]);
 
-            this.children = this.children.concat(newChildren).filter((c) => (c.label as string) in elementChildren);
+            this.children = this.children
+                .concat(newChildren)
+                .filter((c) => (c.label as string) in elementChildren)
+                .sort((a, b) => ((a.label as string) < (b.label as string) ? -1 : 1));
         }
 
         return this.children;


### PR DESCRIPTION
## Proposed changes

This PR fixes the bug where new data sets created in Zowe Explorer were added to the bottom of the list, rather than re-sorting the list by name.

This sorting logic matches the sorting logic for the USS tree.

To test, create a new data set member with a name that comes before another data set alphabetically. Notice that the new data set member will appear above the existing data set as intended, rather than at the bottom of the list (current behavior in v2.11)

## Release Notes

Milestone: 2.11.1 ?

Changelog:

- Fixed bug where the list of datasets from a filter search was not re-sorted after a new data set was created in Zowe Explorer. #2473 

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found