### PR TITLE
fix(job,uss): Remove extra 'delete job' msg; add check for paste APIs & fix refresh

### DIFF
--- a/packages/zowe-explorer-api/__tests__/__unit__/globals/Gui.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/globals/Gui.unit.test.ts
@@ -22,7 +22,7 @@ function createGlobalMocks() {
         showWarningMessage: jest.fn(),
         createOutputChannel: jest.fn(),
         createQuickPick: jest.fn(),
-        createTreeView: jest.fn(),
+        createTreeView: jest.fn().mockReturnValue({ onDidCollapseElement: jest.fn() }),
         createWebviewPanel: jest.fn(),
         withProgress: jest.fn(),
         showTextDocument: jest.fn(),

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed issue where USS nodes were not removed from tree during deletion. [#2479](https://github.com/zowe/vscode-extension-for-zowe/issues/2479)
 - Fixed issue where new USS nodes from a paste operation were not shown in tree until refreshed. [#2479](https://github.com/zowe/vscode-extension-for-zowe/issues/2479)
 - Fixed issue where the "Delete Job" action showed a successful deletion message, even if the API returned an error.
-- USS directories and sessions now update with their respective "collapsed icon" when collapsed.
+- USS directories, PDS nodes, job nodes and session nodes now update with their respective "collapsed icon" when collapsed.
 
 ## `2.11.0`
 

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 ### Bug fixes
 
 - Fixed submitting local JCL using command pallet option `Zowe Explorer: Submit JCL` by adding a check for chosen profile returned to continue the action. [#1625](https://github.com/zowe/vscode-extension-for-zowe/issues/1625)
+- Fixed issue where USS nodes were not removed from tree during deletion. [#2479](https://github.com/zowe/vscode-extension-for-zowe/issues/2479)
+- Fixed issue where new USS nodes from a paste operation were not shown in tree until refreshed. [#2479](https://github.com/zowe/vscode-extension-for-zowe/issues/2479)
+- Fixed issue where the "Delete Job" action showed a successful deletion message, even if the API returned an error.
 
 ## `2.11.0`
 

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed issue where USS nodes were not removed from tree during deletion. [#2479](https://github.com/zowe/vscode-extension-for-zowe/issues/2479)
 - Fixed issue where new USS nodes from a paste operation were not shown in tree until refreshed. [#2479](https://github.com/zowe/vscode-extension-for-zowe/issues/2479)
 - Fixed issue where the "Delete Job" action showed a successful deletion message, even if the API returned an error.
+- USS directories and sessions now update with their respective "collapsed icon" when collapsed.
 
 ## `2.11.0`
 

--- a/packages/zowe-explorer/__mocks__/vscode.ts
+++ b/packages/zowe-explorer/__mocks__/vscode.ts
@@ -144,7 +144,12 @@ export namespace extensions {
         };
     }
 }
-
+export interface TreeViewExpansionEvent<T> {
+    /**
+     * Element that is expanded or collapsed.
+     */
+    readonly element: T;
+}
 export interface TreeView<T> {
     /**
      * An optional human-readable message that will be rendered in the view.
@@ -177,6 +182,8 @@ export interface TreeView<T> {
      * **NOTE:** The {@link TreeDataProvider} that the `TreeView` {@link window.createTreeView is registered with} with must implement {@link TreeDataProvider.getParent getParent} method to access this API.
      */
     reveal(element: T, options?: { select?: boolean; focus?: boolean; expand?: boolean | number }): Thenable<void>;
+
+    onDidCollapseElement: Event<TreeViewExpansionEvent<T>>;
 }
 
 export class FileDecoration {

--- a/packages/zowe-explorer/__tests__/__unit__/Profiles.extended.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/Profiles.extended.unit.test.ts
@@ -112,7 +112,10 @@ async function createGlobalMocks() {
         configurable: true,
     });
     Object.defineProperty(globals, "ISTHEIA", { get: () => false, configurable: true });
-    Object.defineProperty(vscode.window, "createTreeView", { value: jest.fn(), configurable: true });
+    Object.defineProperty(vscode.window, "createTreeView", {
+        value: jest.fn().mockReturnValue({ onDidCollapseElement: jest.fn() }),
+        configurable: true,
+    });
     Object.defineProperty(vscode.workspace, "getConfiguration", {
         value: newMocks.mockGetConfiguration,
         configurable: true,

--- a/packages/zowe-explorer/__tests__/__unit__/ZoweExplorerExtender.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/ZoweExplorerExtender.unit.test.ts
@@ -53,7 +53,10 @@ describe("ZoweExplorerExtender unit tests", () => {
                 })
                 .mockReturnValue(newMocks.profiles),
         });
-        Object.defineProperty(vscode.window, "createTreeView", { value: jest.fn(), configurable: true });
+        Object.defineProperty(vscode.window, "createTreeView", {
+            value: jest.fn().mockReturnValue({ onDidCollapseElement: jest.fn() }),
+            configurable: true,
+        });
         Object.defineProperty(vscode.window, "showErrorMessage", {
             value: newMocks.mockErrorMessage,
             configurable: true,

--- a/packages/zowe-explorer/__tests__/__unit__/abstract/TreeProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/abstract/TreeProvider.unit.test.ts
@@ -37,7 +37,7 @@ async function createGlobalMocks() {
         mockLoadNamedProfile: jest.fn(),
         mockDefaultProfile: jest.fn(),
         withProgress: jest.fn(),
-        createTreeView: jest.fn(),
+        createTreeView: jest.fn().mockReturnValue({ onDidCollapseElement: jest.fn() }),
         mockAffects: jest.fn(),
         mockEditSession: jest.fn(),
         mockCheckCurrentProfile: jest.fn(),

--- a/packages/zowe-explorer/__tests__/__unit__/abstract/ZoweSaveQueue.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/abstract/ZoweSaveQueue.unit.test.ts
@@ -20,6 +20,7 @@ import { ZoweLogger } from "../../../src/utils/LoggerUtils";
 
 describe("ZoweSaveQueue - unit tests", () => {
     const createGlobalMocks = () => {
+        jest.spyOn(Gui, "createTreeView").mockReturnValue({ onDidCollapseElement: jest.fn() } as any);
         const globalMocks = {
             errorMessageSpy: jest.spyOn(Gui, "errorMessage"),
             markDocumentUnsavedSpy: jest.spyOn(workspaceUtils, "markDocumentUnsaved"),

--- a/packages/zowe-explorer/__tests__/__unit__/dataset/DatasetTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/dataset/DatasetTree.unit.test.ts
@@ -59,7 +59,10 @@ function createGlobalMocks() {
 
     globalMocks.mockProfileInstance = createInstanceOfProfile(globalMocks.testProfileLoaded);
 
-    Object.defineProperty(vscode.window, "createTreeView", { value: jest.fn(), configurable: true });
+    Object.defineProperty(vscode.window, "createTreeView", {
+        value: jest.fn().mockReturnValue({ onDidCollapseElement: jest.fn() }),
+        configurable: true,
+    });
     Object.defineProperty(Gui, "showMessage", { value: jest.fn(), configurable: true });
     Object.defineProperty(Gui, "setStatusBarMessage", { value: jest.fn().mockReturnValue({ dispose: jest.fn() }), configurable: true });
     Object.defineProperty(vscode.window, "showTextDocument", { value: jest.fn(), configurable: true });

--- a/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
@@ -45,7 +45,7 @@ async function createGlobalMocks() {
         mockMoveSync: jest.fn(),
         mockGetAllProfileNames: jest.fn(),
         mockReveal: jest.fn(),
-        mockCreateTreeView: jest.fn(),
+        mockCreateTreeView: jest.fn().mockReturnValue({ onDidCollapseElement: jest.fn() }),
         mockExecuteCommand: jest.fn(),
         mockRegisterCommand: jest.fn(),
         mockOnDidSaveTextDocument: jest.fn(),

--- a/packages/zowe-explorer/__tests__/__unit__/generators/icons.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/generators/icons.unit.test.ts
@@ -19,7 +19,7 @@ import * as vscode from "vscode";
 
 describe("Checking icon generator's basics", () => {
     const setGlobalMocks = () => {
-        const createTreeView = jest.fn();
+        const createTreeView = jest.fn().mockReturnValue({ onDidCollapseElement: jest.fn() });
         const getConfiguration = jest.fn();
 
         Object.defineProperty(vscode.window, "createTreeView", { value: createTreeView });

--- a/packages/zowe-explorer/__tests__/__unit__/generators/messages.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/generators/messages.unit.test.ts
@@ -19,7 +19,7 @@ jest.mock("vscode");
 
 describe("Checking message generator's basics", () => {
     const setGlobalMocks = () => {
-        const createTreeView = jest.fn();
+        const createTreeView = jest.fn().mockReturnValue({ onDidCollapseElement: jest.fn() });
         const getConfiguration = jest.fn();
 
         Object.defineProperty(vscode.window, "createTreeView", { value: createTreeView });

--- a/packages/zowe-explorer/__tests__/__unit__/job/ZosJobsProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/ZosJobsProvider.unit.test.ts
@@ -45,7 +45,7 @@ async function createGlobalMocks() {
         mockGetJob: jest.fn(),
         mockRefresh: jest.fn(),
         mockAffectsConfig: jest.fn(),
-        createTreeView: jest.fn(),
+        createTreeView: jest.fn().mockReturnValue({ onDidCollapseElement: jest.fn() }),
         mockGetSpoolFiles: jest.fn(),
         mockDeleteJobs: jest.fn(),
         mockShowInputBox: jest.fn(),
@@ -85,7 +85,7 @@ async function createGlobalMocks() {
             };
         }),
     };
-
+    jest.spyOn(Gui, "createTreeView").mockImplementation(globalMocks.createTreeView);
     Object.defineProperty(ProfilesCache, "getConfigInstance", {
         value: jest.fn(() => {
             return {
@@ -173,7 +173,6 @@ async function createGlobalMocks() {
     Object.defineProperty(ZoweLogger, "warn", { value: jest.fn(), configurable: true });
     Object.defineProperty(ZoweLogger, "info", { value: jest.fn(), configurable: true });
     Object.defineProperty(ZoweLogger, "trace", { value: jest.fn(), configurable: true });
-    globalMocks.createTreeView.mockReturnValue("testTreeView");
     globalMocks.testSessionNode = createJobSessionNode(globalMocks.testSession, globalMocks.testProfile);
     globalMocks.mockGetJob.mockReturnValue(globalMocks.testIJob);
     globalMocks.mockGetJobsByOwnerAndPrefix.mockReturnValue([globalMocks.testIJob, globalMocks.testIJobComplete]);

--- a/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
@@ -40,6 +40,7 @@ async function createGlobalMocks() {
         mockAffectsConfig: jest.fn(),
         createTreeView: jest.fn(() => ({
             reveal: jest.fn(),
+            onDidCollapseElement: jest.fn(),
         })),
         mockCreateSessCfgFromArgs: jest.fn(),
         mockGetSpoolFiles: jest.fn(),

--- a/packages/zowe-explorer/__tests__/__unit__/job/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/actions.unit.test.ts
@@ -46,6 +46,7 @@ import { ZosJobsProvider } from "../../../src/job/ZosJobsProvider";
 const activeTextEditorDocument = jest.fn();
 
 function createGlobalMocks() {
+    jest.spyOn(Gui, "createTreeView").mockReturnValue({ onDidCollapseElement: jest.fn() } as any);
     Object.defineProperty(vscode.workspace, "getConfiguration", {
         value: jest.fn().mockImplementation(() => new Map([["zowe.jobs.confirmSubmission", false]])),
         configurable: true,

--- a/packages/zowe-explorer/__tests__/__unit__/shared/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/shared/actions.unit.test.ts
@@ -69,7 +69,10 @@ async function createGlobalMocks() {
         }),
         configurable: true,
     });
-    Object.defineProperty(vscode.window, "createTreeView", { value: jest.fn(), configurable: true });
+    Object.defineProperty(vscode.window, "createTreeView", {
+        value: jest.fn().mockReturnValue({ onDidCollapseElement: jest.fn() }),
+        configurable: true,
+    });
     Object.defineProperty(vscode.workspace, "getConfiguration", { value: jest.fn(), configurable: true });
     Object.defineProperty(vscode.window, "showInformationMessage", { value: jest.fn(), configurable: true });
     Object.defineProperty(vscode.window, "showInputBox", { value: jest.fn(), configurable: true });

--- a/packages/zowe-explorer/__tests__/__unit__/shared/refresh.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/shared/refresh.unit.test.ts
@@ -31,7 +31,7 @@ import { ZoweLogger } from "../../../src/utils/LoggerUtils";
 function createGlobalMocks() {
     const globalMocks = {
         session: createISessionWithoutCredentials(),
-        createTreeView: jest.fn(),
+        createTreeView: jest.fn().mockReturnValue({ onDidCollapseElement: jest.fn() }),
         mockLog: jest.fn(),
         mockDebug: jest.fn(),
         mockError: jest.fn(),

--- a/packages/zowe-explorer/__tests__/__unit__/uss/USSTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/USSTree.unit.test.ts
@@ -47,7 +47,7 @@ async function createGlobalMocks() {
         showInputBox: jest.fn(),
         filters: jest.fn(),
         getFilters: jest.fn(),
-        createTreeView: jest.fn(),
+        createTreeView: jest.fn().mockReturnValue({ onDidCollapseElement: jest.fn() }),
         createQuickPick: jest.fn(),
         getConfiguration: jest.fn(),
         ZosmfSession: jest.fn(),

--- a/packages/zowe-explorer/__tests__/__unit__/uss/ZoweUSSNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/ZoweUSSNode.unit.test.ts
@@ -137,7 +137,10 @@ async function createGlobalMocks() {
         configurable: true,
     });
     Object.defineProperty(vscode.window, "showInputBox", { value: globalMocks.showInputBox, configurable: true });
-    Object.defineProperty(vscode.window, "createTreeView", { value: jest.fn(), configurable: true });
+    Object.defineProperty(vscode.window, "createTreeView", {
+        value: jest.fn().mockReturnValue({ onDidCollapseElement: jest.fn() }),
+        configurable: true,
+    });
     Object.defineProperty(zowe, "ZosmfSession", { value: globalMocks.ZosmfSession, configurable: true });
     Object.defineProperty(globalMocks.ZosmfSession, "createSessCfgFromArgs", {
         value: globalMocks.createSessCfgFromArgs,

--- a/packages/zowe-explorer/__tests__/__unit__/uss/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/actions.unit.test.ts
@@ -891,9 +891,7 @@ describe("USS Action Unit Tests - copy file / directory", () => {
     it("tests pasteUssFile executed successfully with selected nodes", async () => {
         const globalMocks = createGlobalMocks();
         const blockMocks = await createBlockMocks(globalMocks);
-        const parent = blockMocks.treeNodes.testUSSTree.getTreeView();
-        parent.selection = blockMocks.nodes[0];
-        await ussNodeActions.pasteUssFile(blockMocks.treeNodes.testUSSTree, undefined);
+        await ussNodeActions.pasteUssFile(blockMocks.treeNodes.testUSSTree, blockMocks.nodes[0]);
         expect(sharedUtils.getSelectedNodeList(blockMocks.treeNodes.ussNode, blockMocks.treeNodes.ussNodes)).toEqual([blockMocks.treeNodes.ussNode]);
     });
     it("tests pasteUssFile executed successfully with one node", async () => {
@@ -904,6 +902,16 @@ describe("USS Action Unit Tests - copy file / directory", () => {
         jest.spyOn(ussNodeActions, "copyUssFilesToClipboard").mockResolvedValueOnce();
         await ussNodeActions.pasteUssFile(blockMocks.treeNodes.testUSSTree, blockMocks.nodes[0]);
         expect(sharedUtils.getSelectedNodeList(blockMocks.treeNodes.ussNode, blockMocks.treeNodes.ussNodes)).toEqual([blockMocks.treeNodes.ussNode]);
+    });
+    it("tests pasteUss returns early if APIs are not supported", async () => {
+        const globalMocks = createGlobalMocks();
+        const blockMocks = await createBlockMocks(globalMocks);
+        const testNode = blockMocks.nodes[0];
+        testNode.copyUssFile = testNode.pasteUssTree = null;
+        const infoMessageSpy = jest.spyOn(Gui, "infoMessage");
+        await ussNodeActions.pasteUss(blockMocks.treeNodes.testUSSTree, testNode);
+        expect(infoMessageSpy).toHaveBeenCalledWith("The paste operation is not supported for this node.");
+        infoMessageSpy.mockRestore();
     });
 });
 

--- a/packages/zowe-explorer/__tests__/__unit__/uss/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/actions.unit.test.ts
@@ -60,7 +60,7 @@ function createGlobalMocks() {
         setStatusBarMessage: jest.fn().mockReturnValue({ dispose: jest.fn() }),
         showWarningMessage: jest.fn(),
         showErrorMessage: jest.fn(),
-        createTreeView: jest.fn(),
+        createTreeView: jest.fn().mockReturnValue({ onDidCollapseElement: jest.fn() }),
         fileToUSSFile: jest.fn(),
         Upload: jest.fn(),
         isBinaryFileSync: jest.fn(),

--- a/packages/zowe-explorer/__tests__/__unit__/utils/SessionUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/SessionUtils.unit.test.ts
@@ -29,7 +29,10 @@ describe("SessionUtils removeSession Unit Tests", () => {
         newMocks.datasetSessionNode = createDatasetSessionNode(newMocks.session, newMocks.imperativeProfile);
         newMocks.testDatasetTree = createDatasetTree(newMocks.datasetSessionNode, newMocks.treeView);
         newMocks.testDatasetTree.addFileHistory("[profile1]: TEST.NODE");
-        Object.defineProperty(vscode.window, "createTreeView", { value: jest.fn(), configurable: true });
+        Object.defineProperty(vscode.window, "createTreeView", {
+            value: jest.fn().mockReturnValue({ onDidCollapseElement: jest.fn() }),
+            configurable: true,
+        });
         Object.defineProperty(vscode, "ConfigurationTarget", { value: jest.fn(), configurable: true });
         newMocks.mockGetConfiguration.mockReturnValue(createPersistentConfig());
         Object.defineProperty(vscode.workspace, "getConfiguration", {

--- a/packages/zowe-explorer/i18n/sample/src/uss/actions.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/uss/actions.i18n.json
@@ -12,5 +12,6 @@
   "deleteUssPrompt.confirmation.message": "Are you sure you want to delete the following item?\nThis will permanently remove the following file or folder from your system.\n\n{0}",
   "deleteUssPrompt.confirmation.cancel.log.debug": "Delete action was canceled.",
   "ZoweUssNode.copyDownload.progress": "Copying file structure...",
-  "ZoweUssNode.copyUpload.progress": "Pasting files..."
+  "ZoweUssNode.copyUpload.progress": "Pasting files...",
+  "uss.paste.apiNotAvailable": "The paste operation is not supported for this node."
 }

--- a/packages/zowe-explorer/src/dataset/DatasetTree.ts
+++ b/packages/zowe-explorer/src/dataset/DatasetTree.ts
@@ -96,6 +96,15 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
             treeDataProvider: this,
             canSelectMany: true,
         });
+        this.treeView.onDidCollapseElement((e) => {
+            const newIcon = getIconByNode(e.element);
+            if (contextually.isPds(e.element) || contextually.isDsSession(e.element)) {
+                if (newIcon) {
+                    e.element.iconPath = newIcon;
+                    this.mOnDidChangeTreeData.fire(e.element);
+                }
+            }
+        });
     }
 
     /**

--- a/packages/zowe-explorer/src/job/ZosJobsProvider.ts
+++ b/packages/zowe-explorer/src/job/ZosJobsProvider.ts
@@ -139,6 +139,15 @@ export class ZosJobsProvider extends ZoweTreeProvider implements IZoweTree<IZowe
             treeDataProvider: this,
             canSelectMany: true,
         });
+        this.treeView.onDidCollapseElement((e) => {
+            const newIcon = getIconByNode(e.element);
+            if (contextually.isJob(e.element) || contextually.isJobsSession(e.element)) {
+                if (newIcon) {
+                    e.element.iconPath = newIcon;
+                    this.mOnDidChangeTreeData.fire(e.element);
+                }
+            }
+        });
     }
 
     public rename(_node: IZoweJobTreeNode): void {

--- a/packages/zowe-explorer/src/job/actions.ts
+++ b/packages/zowe-explorer/src/job/actions.ts
@@ -383,12 +383,10 @@ async function deleteSingleJob(job: IZoweJobTreeNode, jobsProvider: IZoweTree<IZ
 
     try {
         await jobsProvider.delete(job);
-        Gui.infoMessage(localize("deleteCommand.job", "Job {0} was deleted.", jobName));
+        await Gui.infoMessage(localize("deleteCommand.job", "Job {0} was deleted.", jobName));
     } catch (error) {
         await errorHandling(error, job.getProfile().name);
     }
-
-    Gui.showMessage(localize("deleteCommand.job", "Job {0} was deleted.", jobName));
 }
 
 async function deleteMultipleJobs(jobs: ReadonlyArray<IZoweJobTreeNode>, jobsProvider: IZoweTree<IZoweJobTreeNode>): Promise<void> {

--- a/packages/zowe-explorer/src/uss/USSTree.ts
+++ b/packages/zowe-explorer/src/uss/USSTree.ts
@@ -80,6 +80,15 @@ export class USSTree extends ZoweTreeProvider implements IZoweTree<IZoweUSSTreeN
             treeDataProvider: this,
             canSelectMany: true,
         });
+        this.treeView.onDidCollapseElement((e) => {
+            if (contextually.isUssDirectory(e.element)) {
+                const newIcon = getIconByNode(e.element);
+                if (newIcon) {
+                    e.element.iconPath = newIcon;
+                    this.mOnDidChangeTreeData.fire(e.element);
+                }
+            }
+        })
     }
 
     /**

--- a/packages/zowe-explorer/src/uss/USSTree.ts
+++ b/packages/zowe-explorer/src/uss/USSTree.ts
@@ -81,14 +81,14 @@ export class USSTree extends ZoweTreeProvider implements IZoweTree<IZoweUSSTreeN
             canSelectMany: true,
         });
         this.treeView.onDidCollapseElement((e) => {
-            if (contextually.isUssDirectory(e.element)) {
-                const newIcon = getIconByNode(e.element);
+            const newIcon = getIconByNode(e.element);
+            if (contextually.isUssDirectory(e.element) || contextually.isUssSession(e.element)) {
                 if (newIcon) {
                     e.element.iconPath = newIcon;
                     this.mOnDidChangeTreeData.fire(e.element);
                 }
             }
-        })
+        });
     }
 
     /**

--- a/packages/zowe-explorer/src/uss/ZoweUSSNode.ts
+++ b/packages/zowe-explorer/src/uss/ZoweUSSNode.ts
@@ -189,11 +189,16 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
             return this.children;
         }
 
+        // If search path has changed, invalidate all children
+        if (this.fullPath?.length > 0 && this.prevPath !== this.fullPath) {
+            this.children = [];
+        }
+
         // Build a list of nodes based on the API response
         const responseNodes: IZoweUSSTreeNode[] = [];
-        const newNodeCreated: boolean = response.apiResponse.items.reduce((lastResult: boolean, item) => {
+        for (const item of response.apiResponse.items) {
             if (item.name === "." || item.name === "..") {
-                return lastResult || false;
+                continue;
             }
 
             const existing = this.children.find(
@@ -213,7 +218,7 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
                 };
                 responseNodes.push(existing);
                 existing.onUpdateEmitter.fire(existing);
-                return lastResult || false;
+                continue;
             }
 
             if (item.mode.startsWith("d")) {
@@ -253,20 +258,6 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
                 };
                 responseNodes.push(temp);
             }
-
-            return lastResult || true;
-        }, false);
-
-        this.dirty = false;
-
-        // If no new nodes were created, return the cached list of children
-        if (!newNodeCreated) {
-            return this.children;
-        }
-
-        // If search path has changed, invalidate all children
-        if (this.fullPath?.length > 0 && this.prevPath !== this.fullPath) {
-            this.children = [];
         }
 
         const nodesToAdd = responseNodes.filter((c) => !this.children.includes(c));
@@ -277,6 +268,7 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
             .filter((c) => !nodesToRemove.includes(c))
             .sort((a, b) => ((a.label as string) < (b.label as string) ? -1 : 1));
         this.prevPath = this.fullPath;
+        this.dirty = false;
         return this.children;
     }
 
@@ -749,10 +741,9 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
         }
 
         const prof = this.getProfile();
-        const remotePath = this.fullPath;
         try {
+            const fileTreeToPaste: UssFileTree = JSON.parse(clipboardContents);
             const api = ZoweExplorerApiRegister.getUssApi(this.profile);
-            const fileTreeToPaste: UssFileTree = JSON.parse(await vscode.env.clipboard.readText());
             const sessionName = this.getSessionNode().getLabel() as string;
 
             const task: imperative.ITaskWithStatus = {
@@ -767,7 +758,7 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
             };
 
             for (const subnode of fileTreeToPaste.children) {
-                await this.paste(sessionName, remotePath, { api, tree: subnode, options });
+                await this.paste(sessionName, this.fullPath, { api, tree: subnode, options });
             }
         } catch (error) {
             await errorHandling(error, this.label.toString(), localize("copyUssFile.error", "Error uploading files"));

--- a/packages/zowe-explorer/src/uss/actions.ts
+++ b/packages/zowe-explorer/src/uss/actions.ts
@@ -487,21 +487,18 @@ export async function pasteUssFile(ussFileProvider: IZoweTree<IZoweUSSTreeNode>,
  */
 export async function pasteUss(ussFileProvider: IZoweTree<IZoweUSSTreeNode>, node: IZoweUSSTreeNode): Promise<void> {
     ZoweLogger.trace("uss.actions.pasteUss called.");
-    const a = ussFileProvider.getTreeView().selection as IZoweUSSTreeNode[];
-    let selectedNode = node;
-    if (!selectedNode) {
-        selectedNode = a.length > 0 ? a[0] : (a as unknown as IZoweUSSTreeNode);
+    if (node.pasteUssTree == null && node.copyUssFile == null) {
+        await Gui.infoMessage(localize("uss.paste.apiNotAvailable", "The paste operation is not supported for this node."));
+        return;
     }
-
     await Gui.withProgress(
         {
             location: vscode.ProgressLocation.Window,
             title: localize("ZoweUssNode.copyUpload.progress", "Pasting files..."),
         },
         async () => {
-            await (selectedNode.pasteUssTree ? selectedNode.pasteUssTree() : selectedNode.copyUssFile());
+            await (node.pasteUssTree ? node.pasteUssTree() : node.copyUssFile());
         }
     );
-    const nodeToRefresh = node?.contextValue != null && contextually.isUssSession(node) ? selectedNode : selectedNode.getParent();
-    ussFileProvider.refreshElement(nodeToRefresh);
+    ussFileProvider.refreshElement(node);
 }


### PR DESCRIPTION
## Proposed changes

This PR resolves the following issues:
- The "Delete Job" action showed an info message stating that the job was deleted, even in scenarios where an error occurred during deletion
- A check was missing for the optional paste APIs, which allowed the paste operation to run on unsupported nodes
  - Added an info message to inform users if the paste operation is unsupported
- Removed unneeded "node array" from `pasteUss` function, and fixed refresh after paste is complete (nodes now show up as expected)
- Removed check from the USS tree for newly-created nodes so that deleted nodes are removed from the tree
- "Directory nodes" (USS directories, PDS, and Jobs) and session nodes across all trees now update with their respective "collapsed icon" when collapsed.

## Release Notes

Milestone: 2.11.1

Changelog:

- Fixed issue where USS nodes were not removed from tree during deletion. #2479
- Fixed issue where new USS nodes from a paste operation were not shown in tree until refreshed. #2479
- Fixed issue where the "Delete Job" action showed a successful deletion message, even if the API returned an error.
- USS directories, PDS nodes, job nodes and session nodes now update with their respective "collapsed icon" when collapsed.

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found

## Further comments

If possible, please try to break the USS tree when testing this PR 😅 I want to make sure that the nodes are staying up to date, and I'm not sure that I've exhausted all scenarios. Here's what I've tested so far:

- [x] Delete a node in the root level of the USS session
- [x] Delete a node in a sub-folder of the USS session
- [x] Copy multiple files and paste into a folder within the USS session
- [x] Copy multiple files and paste into USS session node

