### PR TITLE
Fix Coverity issue and use local ZE API in samples

### DIFF
--- a/.github/workflows/zowe-explorer-samples.yml
+++ b/.github/workflows/zowe-explorer-samples.yml
@@ -41,5 +41,7 @@ jobs:
       # install yarn
       - run: npm install -g yarn
 
+      - run: yarn config set network-timeout 60000 && yarn install --frozen-lockfile
+
       - run: for dir in samples/*; do pushd $dir && yarn && yarn run compile && popd; done
         shell: bash

--- a/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
@@ -305,7 +305,7 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
                 ),
             ];
             const mvsApi = ZoweExplorerApiRegister.getMvsApi(cachedProfile);
-            if (!mvsApi.getSession(mvsApi?.profile)) {
+            if (!mvsApi.getSession(cachedProfile)) {
                 throw new zowe.imperative.ImperativeError({
                     msg: localize("getDataSets.error.sessionMissing", "Profile auth error"),
                     additionalDetails: localize("getDataSets.error.additionalDetails", "Profile is not authenticated, please log in to continue"),

--- a/samples/menu-item-sample/package.json
+++ b/samples/menu-item-sample/package.json
@@ -46,7 +46,7 @@
     "watch": "tsc -watch -p ./"
   },
   "dependencies": {
-    "@zowe/zowe-explorer-api": "^2.10.0"
+    "@zowe/zowe-explorer-api": "file:../../packages/zowe-explorer-api"
   },
   "devDependencies": {
     "@types/node": "^16.18.34",

--- a/samples/menu-item-sample/yarn.lock
+++ b/samples/menu-item-sample/yarn.lock
@@ -356,10 +356,10 @@
   resolved "https://registry.npmjs.org/@zowe/secrets-for-zowe-sdk/-/secrets-for-zowe-sdk-7.18.0.tgz#d7974ac234e79ce220e15fc4f7f17d880754b739"
   integrity sha512-lWs7oVjXpotWw8bu4NxPszu+MiTJgzdiYgj/0q0OBYLJdoZtKBTGRSohtoLZWpu6mfObiEICI1k8UDE8v7xbPw==
 
-"@zowe/secrets-for-zowe-sdk@7.18.1":
-  version "7.18.1"
-  resolved "https://registry.npmjs.org/@zowe/secrets-for-zowe-sdk/-/secrets-for-zowe-sdk-7.18.1.tgz#546a63f5ed880418f0e0496d0218c284c815c3ee"
-  integrity sha512-bcAnauDpTQXCPT8rMx2wrZwhg6xih1lDujG20h1sUGJC5eqvsNCq6gvpOtcahEpUF25oBJ931dKlIu1T99LQ7w==
+"@zowe/secrets-for-zowe-sdk@7.18.4":
+  version "7.18.4"
+  resolved "https://registry.npmjs.org/@zowe/secrets-for-zowe-sdk/-/secrets-for-zowe-sdk-7.18.4.tgz#b755a063217a45bdffffb8d21c30afaad136b08c"
+  integrity sha512-eeVYZ+s9OlgqnHVVopJj3Bz4Ir6gDos5ZiT9Zf+gB6DQaeHFyvC4a2JZrLu9bEMAiVyiCTJydRaspcN4xoEi9Q==
 
 "@zowe/zos-console-for-zowe-sdk@7.18.0":
   version "7.18.0"
@@ -412,14 +412,12 @@
   resolved "https://registry.npmjs.org/@zowe/zosmf-for-zowe-sdk/-/zosmf-for-zowe-sdk-7.18.0.tgz#1d7be74dae8a7844386a50b3b581046dd8febe2c"
   integrity sha512-rrk/fQEOb7izgZnlsxFcniuY+NZaDZPDI90/ePzdWSQZPeA1lzq42Wzww9KXMpnZa3sliXXe9qfLBnrCnZYCbg==
 
-"@zowe/zowe-explorer-api@^2.10.0":
-  version "2.10.0"
-  resolved "https://registry.npmjs.org/@zowe/zowe-explorer-api/-/zowe-explorer-api-2.10.0.tgz#a015dfb5dfb47549b86fc13359e9116cd150f39a"
-  integrity sha512-wx/IikaoMYWD/MCkSlSAGcDVC9JopF7jh321cTNRn/sAWpvBxVywaQ9YQniKZ9ADy6FyDIOR8/gTWLb47TElrQ==
+"@zowe/zowe-explorer-api@file:../../packages/zowe-explorer-api":
+  version "2.12.0-SNAPSHOT"
   dependencies:
     "@types/vscode" "^1.53.2"
     "@zowe/cli" "^7.18.0"
-    "@zowe/secrets-for-zowe-sdk" "7.18.1"
+    "@zowe/secrets-for-zowe-sdk" "7.18.4"
     handlebars "^4.7.7"
     semver "^7.5.3"
 

--- a/samples/tree-view-sample/package.json
+++ b/samples/tree-view-sample/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@zowe/imperative": "^5.18.0",
-    "@zowe/zowe-explorer-api": "^2.10.0"
+    "@zowe/zowe-explorer-api": "file:../../packages/zowe-explorer-api"
   },
   "devDependencies": {
     "@types/node": "^16.18.34",

--- a/samples/tree-view-sample/yarn.lock
+++ b/samples/tree-view-sample/yarn.lock
@@ -356,10 +356,10 @@
   resolved "https://registry.npmjs.org/@zowe/secrets-for-zowe-sdk/-/secrets-for-zowe-sdk-7.18.0.tgz#d7974ac234e79ce220e15fc4f7f17d880754b739"
   integrity sha512-lWs7oVjXpotWw8bu4NxPszu+MiTJgzdiYgj/0q0OBYLJdoZtKBTGRSohtoLZWpu6mfObiEICI1k8UDE8v7xbPw==
 
-"@zowe/secrets-for-zowe-sdk@7.18.1":
-  version "7.18.1"
-  resolved "https://registry.npmjs.org/@zowe/secrets-for-zowe-sdk/-/secrets-for-zowe-sdk-7.18.1.tgz#546a63f5ed880418f0e0496d0218c284c815c3ee"
-  integrity sha512-bcAnauDpTQXCPT8rMx2wrZwhg6xih1lDujG20h1sUGJC5eqvsNCq6gvpOtcahEpUF25oBJ931dKlIu1T99LQ7w==
+"@zowe/secrets-for-zowe-sdk@7.18.4":
+  version "7.18.4"
+  resolved "https://registry.npmjs.org/@zowe/secrets-for-zowe-sdk/-/secrets-for-zowe-sdk-7.18.4.tgz#b755a063217a45bdffffb8d21c30afaad136b08c"
+  integrity sha512-eeVYZ+s9OlgqnHVVopJj3Bz4Ir6gDos5ZiT9Zf+gB6DQaeHFyvC4a2JZrLu9bEMAiVyiCTJydRaspcN4xoEi9Q==
 
 "@zowe/zos-console-for-zowe-sdk@7.18.0":
   version "7.18.0"
@@ -412,14 +412,12 @@
   resolved "https://registry.npmjs.org/@zowe/zosmf-for-zowe-sdk/-/zosmf-for-zowe-sdk-7.18.0.tgz#1d7be74dae8a7844386a50b3b581046dd8febe2c"
   integrity sha512-rrk/fQEOb7izgZnlsxFcniuY+NZaDZPDI90/ePzdWSQZPeA1lzq42Wzww9KXMpnZa3sliXXe9qfLBnrCnZYCbg==
 
-"@zowe/zowe-explorer-api@^2.10.0":
-  version "2.10.0"
-  resolved "https://registry.npmjs.org/@zowe/zowe-explorer-api/-/zowe-explorer-api-2.10.0.tgz#a015dfb5dfb47549b86fc13359e9116cd150f39a"
-  integrity sha512-wx/IikaoMYWD/MCkSlSAGcDVC9JopF7jh321cTNRn/sAWpvBxVywaQ9YQniKZ9ADy6FyDIOR8/gTWLb47TElrQ==
+"@zowe/zowe-explorer-api@file:../../packages/zowe-explorer-api":
+  version "2.12.0-SNAPSHOT"
   dependencies:
     "@types/vscode" "^1.53.2"
     "@zowe/cli" "^7.18.0"
-    "@zowe/secrets-for-zowe-sdk" "7.18.1"
+    "@zowe/secrets-for-zowe-sdk" "7.18.4"
     handlebars "^4.7.7"
     semver "^7.5.3"
 

--- a/samples/uss-profile-sample/package.json
+++ b/samples/uss-profile-sample/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@zowe/cli": "^7.18.0",
-    "@zowe/zowe-explorer-api": "^2.10.0",
+    "@zowe/zowe-explorer-api": "file:../../packages/zowe-explorer-api",
     "ssh2-sftp-client": "^9.1.0"
   },
   "devDependencies": {

--- a/samples/uss-profile-sample/yarn.lock
+++ b/samples/uss-profile-sample/yarn.lock
@@ -375,10 +375,10 @@
   resolved "https://registry.npmjs.org/@zowe/secrets-for-zowe-sdk/-/secrets-for-zowe-sdk-7.18.0.tgz#d7974ac234e79ce220e15fc4f7f17d880754b739"
   integrity sha512-lWs7oVjXpotWw8bu4NxPszu+MiTJgzdiYgj/0q0OBYLJdoZtKBTGRSohtoLZWpu6mfObiEICI1k8UDE8v7xbPw==
 
-"@zowe/secrets-for-zowe-sdk@7.18.1":
-  version "7.18.1"
-  resolved "https://registry.npmjs.org/@zowe/secrets-for-zowe-sdk/-/secrets-for-zowe-sdk-7.18.1.tgz#546a63f5ed880418f0e0496d0218c284c815c3ee"
-  integrity sha512-bcAnauDpTQXCPT8rMx2wrZwhg6xih1lDujG20h1sUGJC5eqvsNCq6gvpOtcahEpUF25oBJ931dKlIu1T99LQ7w==
+"@zowe/secrets-for-zowe-sdk@7.18.4":
+  version "7.18.4"
+  resolved "https://registry.npmjs.org/@zowe/secrets-for-zowe-sdk/-/secrets-for-zowe-sdk-7.18.4.tgz#b755a063217a45bdffffb8d21c30afaad136b08c"
+  integrity sha512-eeVYZ+s9OlgqnHVVopJj3Bz4Ir6gDos5ZiT9Zf+gB6DQaeHFyvC4a2JZrLu9bEMAiVyiCTJydRaspcN4xoEi9Q==
 
 "@zowe/zos-console-for-zowe-sdk@7.18.0":
   version "7.18.0"
@@ -431,14 +431,12 @@
   resolved "https://registry.npmjs.org/@zowe/zosmf-for-zowe-sdk/-/zosmf-for-zowe-sdk-7.18.0.tgz#1d7be74dae8a7844386a50b3b581046dd8febe2c"
   integrity sha512-rrk/fQEOb7izgZnlsxFcniuY+NZaDZPDI90/ePzdWSQZPeA1lzq42Wzww9KXMpnZa3sliXXe9qfLBnrCnZYCbg==
 
-"@zowe/zowe-explorer-api@^2.10.0":
-  version "2.10.0"
-  resolved "https://registry.npmjs.org/@zowe/zowe-explorer-api/-/zowe-explorer-api-2.10.0.tgz#a015dfb5dfb47549b86fc13359e9116cd150f39a"
-  integrity sha512-wx/IikaoMYWD/MCkSlSAGcDVC9JopF7jh321cTNRn/sAWpvBxVywaQ9YQniKZ9ADy6FyDIOR8/gTWLb47TElrQ==
+"@zowe/zowe-explorer-api@file:../../packages/zowe-explorer-api":
+  version "2.12.0-SNAPSHOT"
   dependencies:
     "@types/vscode" "^1.53.2"
     "@zowe/cli" "^7.18.0"
-    "@zowe/secrets-for-zowe-sdk" "7.18.1"
+    "@zowe/secrets-for-zowe-sdk" "7.18.4"
     handlebars "^4.7.7"
     semver "^7.5.3"
 

--- a/samples/vue-webview-sample/package.json
+++ b/samples/vue-webview-sample/package.json
@@ -27,7 +27,7 @@
     "watch": "npx tsc -watch -p ./"
   },
   "dependencies": {
-    "@zowe/zowe-explorer-api": "^2.10.0"
+    "@zowe/zowe-explorer-api": "file:../../packages/zowe-explorer-api"
   },
   "devDependencies": {
     "@types/node": "^16.18.41",

--- a/samples/vue-webview-sample/yarn.lock
+++ b/samples/vue-webview-sample/yarn.lock
@@ -434,10 +434,10 @@
   resolved "https://registry.npmjs.org/@zowe/secrets-for-zowe-sdk/-/secrets-for-zowe-sdk-7.18.0.tgz#d7974ac234e79ce220e15fc4f7f17d880754b739"
   integrity sha512-lWs7oVjXpotWw8bu4NxPszu+MiTJgzdiYgj/0q0OBYLJdoZtKBTGRSohtoLZWpu6mfObiEICI1k8UDE8v7xbPw==
 
-"@zowe/secrets-for-zowe-sdk@7.18.1":
-  version "7.18.1"
-  resolved "https://registry.npmjs.org/@zowe/secrets-for-zowe-sdk/-/secrets-for-zowe-sdk-7.18.1.tgz#546a63f5ed880418f0e0496d0218c284c815c3ee"
-  integrity sha512-bcAnauDpTQXCPT8rMx2wrZwhg6xih1lDujG20h1sUGJC5eqvsNCq6gvpOtcahEpUF25oBJ931dKlIu1T99LQ7w==
+"@zowe/secrets-for-zowe-sdk@7.18.4":
+  version "7.18.4"
+  resolved "https://registry.npmjs.org/@zowe/secrets-for-zowe-sdk/-/secrets-for-zowe-sdk-7.18.4.tgz#b755a063217a45bdffffb8d21c30afaad136b08c"
+  integrity sha512-eeVYZ+s9OlgqnHVVopJj3Bz4Ir6gDos5ZiT9Zf+gB6DQaeHFyvC4a2JZrLu9bEMAiVyiCTJydRaspcN4xoEi9Q==
 
 "@zowe/zos-console-for-zowe-sdk@7.18.0":
   version "7.18.0"
@@ -490,14 +490,12 @@
   resolved "https://registry.npmjs.org/@zowe/zosmf-for-zowe-sdk/-/zosmf-for-zowe-sdk-7.18.0.tgz#1d7be74dae8a7844386a50b3b581046dd8febe2c"
   integrity sha512-rrk/fQEOb7izgZnlsxFcniuY+NZaDZPDI90/ePzdWSQZPeA1lzq42Wzww9KXMpnZa3sliXXe9qfLBnrCnZYCbg==
 
-"@zowe/zowe-explorer-api@^2.10.0":
-  version "2.10.0"
-  resolved "https://registry.npmjs.org/@zowe/zowe-explorer-api/-/zowe-explorer-api-2.10.0.tgz#a015dfb5dfb47549b86fc13359e9116cd150f39a"
-  integrity sha512-wx/IikaoMYWD/MCkSlSAGcDVC9JopF7jh321cTNRn/sAWpvBxVywaQ9YQniKZ9ADy6FyDIOR8/gTWLb47TElrQ==
+"@zowe/zowe-explorer-api@file:../../packages/zowe-explorer-api":
+  version "2.12.0-SNAPSHOT"
   dependencies:
     "@types/vscode" "^1.53.2"
     "@zowe/cli" "^7.18.0"
-    "@zowe/secrets-for-zowe-sdk" "7.18.1"
+    "@zowe/secrets-for-zowe-sdk" "7.18.4"
     handlebars "^4.7.7"
     semver "^7.5.3"
 


### PR DESCRIPTION
* Fixes a code smell flagged by Coverity in `ZoweDatasetNode.ts`
* Updates samples to reference ZE API with a symlink, so that Samples CI workflow will test for breaking changes to API