### PR TITLE
Remove extra call and register before for theia = false

### DIFF
--- a/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
@@ -453,6 +453,7 @@ describe("Extension Unit Tests", () => {
     let globalMocks;
     beforeAll(async () => {
         globalMocks = await createGlobalMocks();
+        jest.spyOn(fs, "readFileSync").mockReturnValue(Buffer.from(JSON.stringify({ overrides: { credentialManager: "@zowe/cli" } }), "utf-8"));
         Object.defineProperty(zowe.imperative, "ProfileInfo", {
             value: globalMocks.mockImperativeProfileInfo,
             configurable: true,

--- a/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
@@ -140,6 +140,7 @@ async function createGlobalMocks() {
         appName: vscode.env.appName,
         uriScheme: vscode.env.uriScheme,
         expectedCommands: [
+            "zowe.updateSecureCredentials",
             "zowe.extRefresh",
             "zowe.all.config.init",
             "zowe.ds.addSession",
@@ -244,7 +245,6 @@ async function createGlobalMocks() {
             "zowe.jobs.sortBy",
             "zowe.manualPoll",
             "zowe.editHistory",
-            "zowe.updateSecureCredentials",
             "zowe.promptCredentials",
             "zowe.profileManagement",
             "zowe.openRecentMember",

--- a/packages/zowe-explorer/__tests__/__unit__/shared/init.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/shared/init.unit.test.ts
@@ -377,4 +377,22 @@ describe("Test src/shared/extension", () => {
             expect(spyExpand).not.toHaveBeenCalled();
         });
     });
+
+    describe("registerCredentialManager", () => {
+        let context: any;
+
+        beforeEach(() => {
+            context = { subscriptions: [] };
+            jest.clearAllMocks();
+        });
+        afterAll(() => {
+            jest.restoreAllMocks();
+        });
+
+        it("should register command for updating credentials", () => {
+            const registerCommandSpy = jest.spyOn(vscode.commands, "registerCommand");
+            sharedExtension.registerCredentialManager(context);
+            expect(registerCommandSpy).toBeCalledWith("zowe.updateSecureCredentials", expect.any(Function));
+        });
+    });
 });

--- a/packages/zowe-explorer/__tests__/__unit__/shared/init.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/shared/init.unit.test.ts
@@ -53,13 +53,6 @@ describe("Test src/shared/extension", () => {
                 mock: [],
             },
             {
-                name: "zowe.updateSecureCredentials",
-                mock: [
-                    { spy: jest.spyOn(globals, "setGlobalSecurityValue"), arg: [test.value] },
-                    { spy: jest.spyOn(profUtils.ProfilesUtils, "writeOverridesFile"), arg: [] },
-                ],
-            },
-            {
                 name: "zowe.editHistory",
                 mock: [{ spy: jest.spyOn(HistoryView, "HistoryView"), arg: [test.context, test.value.providers] }],
             },

--- a/packages/zowe-explorer/__tests__/__unit__/utils/ProfilesUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/ProfilesUtils.unit.test.ts
@@ -473,12 +473,6 @@ describe("ProfilesUtils unit tests", () => {
     describe("initializeZoweFolder", () => {
         it("should create directories and files that do not exist", async () => {
             const blockMocks = createBlockMocks();
-            jest.spyOn(fs, "readFileSync").mockReturnValueOnce("");
-            jest.spyOn(JSON, "parse").mockReturnValueOnce({
-                overrides: {
-                    credentialManager: "@zowe/cli",
-                },
-            });
             blockMocks.mockGetDirectValue.mockReturnValue(true);
             blockMocks.mockExistsSync.mockReturnValue(false);
             const createFileSpy = jest.spyOn(profUtils.ProfilesUtils, "writeOverridesFile");
@@ -490,7 +484,6 @@ describe("ProfilesUtils unit tests", () => {
 
         it("should skip creating directories and files that already exist", async () => {
             const blockMocks = createBlockMocks();
-            jest.spyOn(profUtils.ProfilesUtils, "getCredentialManagerOverride").mockReturnValueOnce("@zowe/cli");
             blockMocks.mockGetDirectValue.mockReturnValue("@zowe/cli");
             blockMocks.mockExistsSync.mockReturnValue(true);
             const fileJson = blockMocks.mockFileRead;

--- a/packages/zowe-explorer/__tests__/__unit__/utils/ProfilesUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/ProfilesUtils.unit.test.ts
@@ -475,6 +475,7 @@ describe("ProfilesUtils unit tests", () => {
             const blockMocks = createBlockMocks();
             blockMocks.mockGetDirectValue.mockReturnValue(true);
             blockMocks.mockExistsSync.mockReturnValue(false);
+            jest.spyOn(fs, "readFileSync").mockReturnValue(Buffer.from(JSON.stringify({ overrides: { credentialManager: "@zowe/cli" } }), "utf-8"));
             const createFileSpy = jest.spyOn(profUtils.ProfilesUtils, "writeOverridesFile");
             await profUtils.ProfilesUtils.initializeZoweFolder();
             expect(globals.PROFILE_SECURITY).toBe(globals.ZOWE_CLI_SCM);
@@ -487,6 +488,7 @@ describe("ProfilesUtils unit tests", () => {
             blockMocks.mockGetDirectValue.mockReturnValue("@zowe/cli");
             blockMocks.mockExistsSync.mockReturnValue(true);
             const fileJson = blockMocks.mockFileRead;
+            jest.spyOn(fs, "readFileSync").mockReturnValue(Buffer.from(JSON.stringify({ overrides: { credentialManager: "@zowe/cli" } }), "utf-8"));
             blockMocks.mockReadFileSync.mockReturnValueOnce(JSON.stringify(fileJson, null, 2));
             await profUtils.ProfilesUtils.initializeZoweFolder();
             expect(globals.PROFILE_SECURITY).toBe("@zowe/cli");
@@ -498,11 +500,11 @@ describe("ProfilesUtils unit tests", () => {
     describe("writeOverridesFile", () => {
         it("should have file exist", () => {
             const blockMocks = createBlockMocks();
-            const fileJson = { overrides: { CredentialManager: "@zowe/cli", testValue: true } };
-            const content = JSON.stringify(fileJson, null, 2);
-            blockMocks.mockReadFileSync.mockReturnValueOnce(JSON.stringify({ overrides: { CredentialManager: false, testValue: true } }, null, 2));
+            blockMocks.mockReadFileSync.mockReturnValueOnce(
+                JSON.stringify({ overrides: { CredentialManager: "@zowe/cli", testValue: true } }, null, 2)
+            );
             profUtils.ProfilesUtils.writeOverridesFile();
-            expect(blockMocks.mockWriteFileSync).toBeCalledWith(blockMocks.zoweDir, content, { encoding: "utf-8", flag: "w" });
+            expect(blockMocks.mockWriteFileSync).toBeCalledTimes(0);
         });
 
         it("should return and have no change to the existing file if PROFILE_SECURITY matches file", () => {

--- a/packages/zowe-explorer/src/extension.ts
+++ b/packages/zowe-explorer/src/extension.ts
@@ -19,7 +19,7 @@ import { ProfilesUtils } from "./utils/ProfilesUtils";
 import { initializeSpoolProvider } from "./SpoolProvider";
 import { cleanTempDir, hideTempFolder } from "./utils/TempFolder";
 import { SettingsConfig } from "./utils/SettingsConfig";
-import { registerCommonCommands, registerRefreshCommand, watchConfigProfile } from "./shared/init";
+import { registerCommonCommands, registerCredentialManager, registerRefreshCommand, watchConfigProfile } from "./shared/init";
 import { ZoweLogger } from "./utils/LoggerUtils";
 import { ZoweSaveQueue } from "./abstract/ZoweSaveQueue";
 import { PollDecorator } from "./utils/DecorationProviders";
@@ -43,6 +43,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<ZoweEx
     globals.defineGlobals(tempPath);
 
     await hideTempFolder(getZoweDir());
+    await registerCredentialManager(context);
     await ProfilesUtils.initializeZoweProfiles();
     ProfilesUtils.initializeZoweTempFolder();
 

--- a/packages/zowe-explorer/src/extension.ts
+++ b/packages/zowe-explorer/src/extension.ts
@@ -43,7 +43,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<ZoweEx
     globals.defineGlobals(tempPath);
 
     await hideTempFolder(getZoweDir());
-    await registerCredentialManager(context);
+    registerCredentialManager(context);
     await ProfilesUtils.initializeZoweProfiles();
     ProfilesUtils.initializeZoweTempFolder();
 

--- a/packages/zowe-explorer/src/shared/init.ts
+++ b/packages/zowe-explorer/src/shared/init.ts
@@ -87,14 +87,6 @@ export function registerCommonCommands(context: vscode.ExtensionContext, provide
         })
     );
 
-    // Update imperative.json to false only when VS Code setting is set to false
-    context.subscriptions.push(
-        vscode.commands.registerCommand("zowe.updateSecureCredentials", async (customCredentialManager?: string) => {
-            await globals.setGlobalSecurityValue(customCredentialManager);
-            ProfilesUtils.writeOverridesFile();
-        })
-    );
-
     context.subscriptions.push(
         vscode.commands.registerCommand("zowe.promptCredentials", async (node: IZoweTreeNode) => {
             await ProfilesUtils.promptCredentials(node);
@@ -216,6 +208,16 @@ export function registerCommonCommands(context: vscode.ExtensionContext, provide
             })
         );
     }
+}
+
+export function registerCredentialManager(context: vscode.ExtensionContext): void {
+    // Update imperative.json to false only when VS Code setting is set to false
+    context.subscriptions.push(
+        vscode.commands.registerCommand("zowe.updateSecureCredentials", async (customCredentialManager?: string) => {
+            await globals.setGlobalSecurityValue(customCredentialManager);
+            ProfilesUtils.writeOverridesFile();
+        })
+    );
 }
 
 export function watchConfigProfile(context: vscode.ExtensionContext, providers: IZoweProviders): void {

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -555,10 +555,10 @@ export class ProfilesUtils {
         if (!fs.existsSync(settingsPath)) {
             fs.mkdirSync(settingsPath);
         }
+        ProfilesUtils.writeOverridesFile();
         // set global variable of security value to existing override
         // this will later get reverted to default in getProfilesInfo.ts if user chooses to
         await ProfilesUtils.updateCredentialManagerSetting(ProfilesUtils.getCredentialManagerOverride());
-        ProfilesUtils.writeOverridesFile();
         // If not using team config, ensure that the ~/.zowe/profiles directory
         // exists with appropriate types within
         if (!imperative.ImperativeConfig.instance.config?.exists) {
@@ -595,7 +595,7 @@ export class ProfilesUtils {
                     ZoweLogger.error(errorMsg);
                     ZoweLogger.debug(fileContent.toString());
                     settings = { ...defaultImperativeJson };
-                    fs.writeFileSync(settingsFile, JSON.stringify(settings, null, 2), {
+                    return fs.writeFileSync(settingsFile, JSON.stringify(settings, null, 2), {
                         encoding: "utf-8",
                         flag: "w",
                     });
@@ -610,12 +610,11 @@ export class ProfilesUtils {
         } else {
             settings = { ...defaultImperativeJson };
         }
-        settings.overrides.CredentialManager = globals.PROFILE_SECURITY;
         const newData = JSON.stringify(settings, null, 2);
         ZoweLogger.debug(
             localize("writeOverridesFile.updateFile", "Updating imperative.json Credential Manager to {0}.\n{1}", globals.PROFILE_SECURITY, newData)
         );
-        fs.writeFileSync(settingsFile, newData, {
+        return fs.writeFileSync(settingsFile, newData, {
             encoding: "utf-8",
             flag: "w",
         });

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -543,10 +543,6 @@ export class ProfilesUtils {
 
     public static async initializeZoweFolder(): Promise<void> {
         ZoweLogger.trace("ProfilesUtils.initializeZoweFolder called.");
-        // ensure the Secure Credentials Enabled value is read
-        // set globals.PROFILE_SECURITY value accordingly
-        const credentialManagerOverride = ProfilesUtils.getCredentialManagerOverride();
-        await globals.setGlobalSecurityValue(credentialManagerOverride ?? globals.ZOWE_CLI_SCM);
         // Ensure that ~/.zowe folder exists
         // Ensure that the ~/.zowe/settings/imperative.json exists
         // TODO: update code below once this imperative issue is resolved.

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -555,6 +555,9 @@ export class ProfilesUtils {
         if (!fs.existsSync(settingsPath)) {
             fs.mkdirSync(settingsPath);
         }
+        // set global variable of security value to existing override
+        // this will later get reverted to default in getProfilesInfo.ts if user chooses to
+        await ProfilesUtils.updateCredentialManagerSetting(ProfilesUtils.getCredentialManagerOverride());
         ProfilesUtils.writeOverridesFile();
         // If not using team config, ensure that the ~/.zowe/profiles directory
         // exists with appropriate types within


### PR DESCRIPTION
Here is a solution that registers a setting that would set false for Theia env before handling cred manager. Also removes new dup calls since calls are made in following code if needed 