### PR TITLE
fix(ds/sort): Fallback to sorting by name when values are equal

### DIFF
--- a/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
@@ -183,7 +183,8 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
 
             // Loops through all the returned dataset members and creates nodes for them
             for (const item of response.apiResponse.items ?? response.apiResponse) {
-                const existing = this.children.find((element) => element.label.toString() === item.dsname);
+                const dsEntry = item.dsname ?? item.member;
+                const existing = this.children.find((element) => element.label.toString() === dsEntry);
                 if (existing) {
                     existing.updateStats(item);
                     elementChildren[existing.label.toString()] = existing;

--- a/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
@@ -343,8 +343,8 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
                 const dateA = dayjs(a.stats?.modifiedDate);
                 const dateB = dayjs(b.stats?.modifiedDate);
 
-                a.description = dateA.format("YYYY/MM/DD HH:mm:ss");
-                b.description = dateB.format("YYYY/MM/DD HH:mm:ss");
+                a.description = dateA.isValid() ? dateA.format("YYYY/MM/DD HH:mm:ss") : undefined;
+                b.description = dateB.isValid() ? dateB.format("YYYY/MM/DD HH:mm:ss") : undefined;
 
                 // for dates that are equal down to the second, fallback to sorting by name
                 if (dateA.isSame(dateB, "second")) {

--- a/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
@@ -155,6 +155,22 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
             return;
         }
 
+        const updateStats = (node: IZoweDatasetTreeNode, item: any): void => {
+            if ("m4date" in item) {
+                const { m4date, mtime, msec }: { m4date: string; mtime: string; msec: string } = item;
+                node.stats = {
+                    user: item.user,
+                    modifiedDate: dayjs(`${m4date} ${mtime}:${msec}`).toDate(),
+                };
+            } else if ("id" in item || "changed" in item) {
+                // missing keys from API response; check for FTP keys
+                node.stats = {
+                    user: item.id,
+                    modifiedDate: item.changed ? dayjs(item.changed).toDate() : undefined,
+                };
+            }
+        };
+
         // push nodes to an object with property names to avoid duplicates
         const elementChildren: { [k: string]: ZoweDatasetNode } = {};
         for (const response of responses) {
@@ -169,6 +185,7 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
             for (const item of response.apiResponse.items ?? response.apiResponse) {
                 const existing = this.children.find((element) => element.label.toString() === item.dsname);
                 if (existing) {
+                    updateStats(existing, item);
                     elementChildren[existing.label.toString()] = existing;
                     // Creates a ZoweDatasetNode for a PDS
                 } else if (item.dsorg === "PO" || item.dsorg === "PO-E") {
@@ -262,19 +279,7 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
                     }
 
                     // get user and last modified date for sorting, if available
-                    if ("m4date" in item) {
-                        const { m4date, mtime, msec }: { m4date: string; mtime: string; msec: string } = item;
-                        temp.stats = {
-                            user: item.user,
-                            modifiedDate: dayjs(`${m4date} ${mtime}:${msec}`).toDate(),
-                        };
-                    } else if ("id" in item || "changed" in item) {
-                        // missing keys from API response; check for FTP keys
-                        temp.stats = {
-                            user: item.id,
-                            modifiedDate: item.changed ? dayjs(item.changed).toDate() : undefined,
-                        };
-                    }
+                    updateStats(temp, item);
                     elementChildren[temp.label.toString()] = temp;
                 }
             }

--- a/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
@@ -358,14 +358,17 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
 
                 return dateA.isBefore(dateB, "second") ? sortLessThan : sortGreaterThan;
             } else if (sort.method === DatasetSortOpts.UserId) {
-                a.description = a.stats?.user;
-                b.description = b.stats?.user;
+                const userA = a.stats?.user ?? "";
+                const userB = b.stats?.user ?? "";
 
-                if (a.stats?.user === b.stats?.user) {
+                a.description = userA;
+                b.description = userB;
+
+                if (userA === userB) {
                     return sortByName(a, b);
                 }
 
-                return a.stats?.user < b.stats?.user ? sortLessThan : sortGreaterThan;
+                return userA < userB ? sortLessThan : sortGreaterThan;
             }
 
             return sortByName(a, b);


### PR DESCRIPTION
_If we would prefer to keep this for a potential 2.12.1 release, then I will add a changelog. Otherwise, I think we can keep this as `no-changelog` as the feature will be released with 2.12._

---

## Proposed changes

I've cleaned up the sorting function a bit so that it falls back to sorting by name when 2 node values are equal.

In addition, I've adjusted the date checks slightly to also use Day.js (consistent with the rest of the date processing for this feature) for easier date comparison.

## Release Notes

Milestone: 2.12.0 (or 2.12.1)

Changelog:

- Fixed an issue where sorting functionality did not consider the sort direction when values were equal.

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [x] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
