### PR TITLE
Update when clause of Submit as JCL for when to show option

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
+- Update when the option to submit local file as JCL will be displayed in context menus. [#2541](https://github.com/zowe/vscode-extension-for-zowe/issues/2541)
+
 ## `2.12.0`
 
 ### New features and enhancements

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -809,14 +809,14 @@
     "menus": {
       "editor/context": [
         {
-          "when": "editorFocus",
+          "when": "editorFocus && focusedView != 'workbench.panel.output'",
           "command": "zowe.ds.submitJcl",
           "group": "000_zowe_dsMainframeInteraction@1"
         }
       ],
       "explorer/context": [
         {
-          "when": "!explorerResourceIsFolder",
+          "when": "!explorerResourceIsFolder && !listMultiSelection",
           "command": "zowe.ds.submitJcl",
           "group": "000_zowe_dsMainframeInteraction@1"
         }


### PR DESCRIPTION
## Proposed changes

`Submit as JCL` option should not show in the context menu of the Output Channel and shouldn't be offered with multi-selection of files

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog -->
<!-- If there is a linked issue, it should have the same milestone as this PR -->

Milestone: 2.12.1

Changelog: Update when the option to submit local file as JCL will be displayed in context menus. [#2541](https://github.com/zowe/vscode-extension-for-zowe/issues/2541)

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
