### PR TITLE
Fix undefined etag for dataset nodes

### DIFF
--- a/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
@@ -3435,20 +3435,20 @@ describe("Dataset Actions Unit Tests - Function openPS", () => {
         expect(mocked(Gui.errorMessage)).toBeCalledWith("Error: testError");
     });
 
-    it("Check for invalid/null response without supporting ongoing actions", async () => {
+    it("Check for invalid/null response when contents are already fetched", async () => {
         globals.defineGlobals("");
         const globalMocks = createGlobalMocks();
         const blockMocks = createBlockMocks();
-        globalMocks.getContentsSpy.mockResolvedValueOnce(null);
+        globalMocks.getContentsSpy.mockClear();
+        mocked(fs.existsSync).mockReturnValueOnce(true);
         mocked(Profiles.getInstance).mockReturnValue(blockMocks.profileInstance);
-        const node = new ZoweDatasetNode("node", vscode.TreeItemCollapsibleState.None, blockMocks.datasetSessionNode, null);
+        const node = new ZoweDatasetNode("node", vscode.TreeItemCollapsibleState.None, blockMocks.datasetSessionNode, null, null, "abc");
         node.ongoingActions = undefined as any;
 
-        try {
-            await dsActions.openPS(node, true, blockMocks.testDatasetTree);
-        } catch (err) {
-            expect(err.message).toBe("Response was null or invalid.");
-        }
+        await dsActions.openPS(node, true, blockMocks.testDatasetTree);
+
+        expect(globalMocks.getContentsSpy).not.toHaveBeenCalled();
+        expect(node.getEtag()).toBe("abc");
     });
 
     it("Checking of opening for PDS Member", async () => {

--- a/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
@@ -3418,6 +3418,28 @@ describe("Dataset Actions Unit Tests - Function openPS", () => {
         expect(mocked(vscode.workspace.openTextDocument)).toBeCalledWith(sharedUtils.getDocumentFilePath(node.label.toString(), node));
     });
 
+    it("Checking of opening for common dataset without supporting ongoing actions", async () => {
+        globals.defineGlobals("");
+        createGlobalMocks();
+        const blockMocks = createBlockMocks();
+
+        mocked(blockMocks.mvsApi.getContents).mockResolvedValueOnce({
+            success: true,
+            commandResponse: "",
+            apiResponse: {
+                etag: "123",
+            },
+        });
+        mocked(Profiles.getInstance).mockReturnValue(blockMocks.profileInstance);
+        const node = new ZoweDatasetNode("node", vscode.TreeItemCollapsibleState.None, blockMocks.datasetSessionNode, null);
+        node.ongoingActions = undefined as any;
+
+        await dsActions.openPS(node, true, blockMocks.testDatasetTree);
+
+        expect(mocked(fs.existsSync)).toBeCalledWith(path.join(globals.DS_DIR, node.getSessionNode().label.toString(), node.label.toString()));
+        expect(mocked(vscode.workspace.openTextDocument)).toBeCalledWith(sharedUtils.getDocumentFilePath(node.label.toString(), node));
+    });
+
     it("Checking of failed attempt to open dataset", async () => {
         globals.defineGlobals("");
         const globalMocks = createGlobalMocks();

--- a/packages/zowe-explorer/__tests__/__unit__/shared/utils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/shared/utils.unit.test.ts
@@ -376,7 +376,7 @@ describe("Test force upload", () => {
         );
     });
 
-    it("should show error message if file failed to upload", async () => {
+    it("should show error message if file fails to upload", async () => {
         const blockMocks = await createBlockMocks();
         blockMocks.showInformationMessage.mockResolvedValueOnce("Yes");
         blockMocks.withProgress.mockResolvedValueOnce({ ...blockMocks.fileResponse, success: false });
@@ -389,6 +389,22 @@ describe("Test force upload", () => {
             expect.any(Function)
         );
         expect(blockMocks.showErrorMessage.mock.calls[0][0]).toBe(blockMocks.fileResponse.commandResponse);
+    });
+
+    it("should show error message if upload throws an error", async () => {
+        const blockMocks = await createBlockMocks();
+        blockMocks.showInformationMessage.mockResolvedValueOnce("Yes");
+        const testError = new Error("Task failed successfully");
+        blockMocks.withProgress.mockRejectedValueOnce(testError);
+        await sharedUtils.willForceUpload(blockMocks.ussNode, blockMocks.mockDoc, null, { name: "fakeProfile" } as any);
+        expect(blockMocks.withProgress).toBeCalledWith(
+            {
+                location: vscode.ProgressLocation.Notification,
+                title: "Saving file...",
+            },
+            expect.any(Function)
+        );
+        expect(blockMocks.showErrorMessage.mock.calls[0][0]).toBe(`Error: ${testError.message}`);
     });
 });
 

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -497,8 +497,8 @@ export async function openPS(
 
             const documentFilePath = getDocumentFilePath(label, node);
             let responsePromise = node.ongoingActions ? node.ongoingActions[api.NodeAction.Download] : null;
-            // If the local copy does not exist, fetch contents
-            if (!fs.existsSync(documentFilePath)) {
+            // If there is no ongoing action and the local copy does not exist, fetch contents
+            if (responsePromise == null && !fs.existsSync(documentFilePath)) {
                 const prof = node.getProfile();
                 ZoweLogger.info(localize("openPS.openDataSet", "Opening {0}", label));
                 if (node.ongoingActions) {
@@ -519,8 +519,10 @@ export async function openPS(
                 }
             }
 
-            const response = await responsePromise;
-            node.setEtag(response?.apiResponse?.etag);
+            if (responsePromise != null) {
+                const response = await responsePromise;
+                node.setEtag(response.apiResponse.etag);
+            }
             statusMsg.dispose();
             const document = await vscode.workspace.openTextDocument(getDocumentFilePath(label, node));
             await api.Gui.showTextDocument(document, { preview: node.wasDoubleClicked != null ? !node.wasDoubleClicked : shouldPreview });

--- a/packages/zowe-explorer/src/shared/actions.ts
+++ b/packages/zowe-explorer/src/shared/actions.ts
@@ -273,7 +273,7 @@ export function resolveFileConflict(
             }
             case overwriteBtn: {
                 ZoweLogger.info(`${overwriteBtn} chosen.`);
-                willForceUpload(node, doc, label, profile, binary, true);
+                await willForceUpload(node, doc, label, profile, binary, true);
                 break;
             }
             default: {

--- a/packages/zowe-explorer/src/shared/actions.ts
+++ b/packages/zowe-explorer/src/shared/actions.ts
@@ -273,7 +273,7 @@ export function resolveFileConflict(
             }
             case overwriteBtn: {
                 ZoweLogger.info(`${overwriteBtn} chosen.`);
-                willForceUpload(node, doc, docName, profile, binary, true);
+                willForceUpload(node, doc, label, profile, binary, true);
                 break;
             }
             default: {

--- a/packages/zowe-explorer/src/shared/utils.ts
+++ b/packages/zowe-explorer/src/shared/utils.ts
@@ -299,6 +299,9 @@ export function willForceUpload(
                 if (node) {
                     node.setEtag(uploadResponse.apiResponse[0].etag);
                 }
+            } else {
+                await markDocumentUnsaved(doc);
+                Gui.errorMessage(uploadResponse.commandResponse);
             }
         } else {
             Gui.showMessage(localize("uploadContent.cancelled", "Upload cancelled."));

--- a/packages/zowe-explorer/src/shared/utils.ts
+++ b/packages/zowe-explorer/src/shared/utils.ts
@@ -264,7 +264,7 @@ export function willForceUpload(
     profile?: imperative.IProfileLoaded,
     binary?: boolean,
     returnEtag?: boolean
-): void {
+): Thenable<void> {
     // setup to handle both cases (dataset & USS)
     let title: string;
     if (isZoweDatasetTreeNode(node)) {
@@ -281,7 +281,7 @@ export function willForceUpload(
         );
     }
     // Don't wait for prompt to return since this would block the save queue
-    Gui.infoMessage(localize("saveFile.info.confirmUpload", "Would you like to overwrite the remote file?"), {
+    return Gui.infoMessage(localize("saveFile.info.confirmUpload", "Would you like to overwrite the remote file?"), {
         items: [localize("saveFile.overwriteConfirmation.yes", "Yes"), localize("saveFile.overwriteConfirmation.no", "No")],
     }).then(async (selection) => {
         if (selection === localize("saveFile.overwriteConfirmation.yes", "Yes")) {


### PR DESCRIPTION
## Proposed changes

Fixes race condition where etag might be set to undefined on dataset node, resulting in changes being overwritten if there is a conflict.

Also fixes an issue found during testing where `willForceUpload` tried to upload dataset with extension.

## How to test

Unfortunately since this is a race condition, I can't provide consistent steps to reproduce. Try to repeat the following steps several times:
1. Open a data set in the tree in different ways: single-click to preview it, double-click quickly, double-click slowly, etc
    After trying this several times myself I think you need to have a fast connection and double-click as slowly as possible, so that the data set downloads in between clicks, but it still registers as a double-click.
2. Make changes to the data set on the mainframe
3. Make changes to the data set locally in ZE
4. Save the changes and see if a conflict is detected

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog -->
<!-- If there is a linked issue, it should have the same milestone as this PR -->

Milestone: 2.12.1

Changelog: N/A

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [ ] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [ ] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [ ] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [x] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
