### PR TITLE
fix(sort/ds): Coerce invalid PDS date values to `null` during parsing

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Update when the option to submit local file as JCL will be displayed in context menus. [#2541](https://github.com/zowe/vscode-extension-for-zowe/issues/2541)
 - Solved issue with shortcut for `Edit History` view overlapping `Redo` shortcut [#2543](https://github.com/zowe/vscode-extension-for-zowe/issues/2543)
 - Removed duplicate buttons displayed on USS view that now exist on `Manage Profile` view [#2547](https://github.com/zowe/vscode-extension-for-zowe/issues/2547)
+- Fixed issue where sort PDS feature applied the date description to members without a valid date [#2552](https://github.com/zowe/vscode-extension-for-zowe/issues/2552)
 
 ## `2.12.0`
 

--- a/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
@@ -346,8 +346,8 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
             }
 
             if (sort.method === DatasetSortOpts.LastModified) {
-                const dateA = dayjs(a.stats?.modifiedDate);
-                const dateB = dayjs(b.stats?.modifiedDate);
+                const dateA = dayjs(a.stats?.modifiedDate ?? null);
+                const dateB = dayjs(b.stats?.modifiedDate ?? null);
 
                 a.description = dateA.isValid() ? dateA.format("YYYY/MM/DD HH:mm:ss") : undefined;
                 b.description = dateB.isValid() ? dateB.format("YYYY/MM/DD HH:mm:ss") : undefined;

--- a/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
@@ -349,8 +349,19 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
                 const dateA = dayjs(a.stats?.modifiedDate ?? null);
                 const dateB = dayjs(b.stats?.modifiedDate ?? null);
 
-                a.description = dateA.isValid() ? dateA.format("YYYY/MM/DD HH:mm:ss") : undefined;
-                b.description = dateB.isValid() ? dateB.format("YYYY/MM/DD HH:mm:ss") : undefined;
+                const aValid = dateA.isValid();
+                const bValid = dateB.isValid();
+
+                a.description = aValid ? dateA.format("YYYY/MM/DD HH:mm:ss") : undefined;
+                b.description = bValid ? dateB.format("YYYY/MM/DD HH:mm:ss") : undefined;
+
+                if (!aValid) {
+                    return sortGreaterThan;
+                }
+
+                if (!bValid) {
+                    return sortLessThan;
+                }
 
                 // for dates that are equal down to the second, fallback to sorting by name
                 if (dateA.isSame(dateB, "second")) {


### PR DESCRIPTION
## Proposed changes

This PR fixes a bug where Day.js interpreted an `undefined` value as a valid date (same behavior as `dayjs()` or `Date.now()`) instead of coercing the invalid/missing date parameter to null.

![image](https://github.com/zowe/vscode-extension-for-zowe/assets/86500639/d45520a6-0b39-4393-972f-83aae90c3ce7)

Fixes #2552 

## Release Notes

Milestone: 2.12.1

Changelog:
- Fixed issue where sort PDS feature applied the date description to members without a valid date. #2552 

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)
