### PR TITLE
fix(USS): Use `path.sep` when splitting path to fix saves on Windows

### DIFF
--- a/packages/zowe-explorer/src/uss/actions.ts
+++ b/packages/zowe-explorer/src/uss/actions.ts
@@ -276,7 +276,7 @@ export async function saveUSSFile(doc: vscode.TextDocument, ussFileProvider: IZo
     const ending = doc.fileName.substring(start);
     const sesName = ending.substring(0, ending.indexOf(path.sep));
     const remote = ending.substring(sesName.length).replace(/\\/g, "/");
-    const directories = doc.fileName.split("/").splice(doc.fileName.split("/").indexOf("_U_") + 1);
+    const directories = doc.fileName.split(path.sep).splice(doc.fileName.split(path.sep).indexOf("_U_") + 1);
     directories.splice(1, 2);
     const profileSesnode: IZoweUSSTreeNode = ussFileProvider.mSessionNodes.find((child) => child.label.toString().trim() === sesName);
     const etagProfiles = findEtag(profileSesnode, directories, 0);


### PR DESCRIPTION
## Proposed changes

This PR resolves an issue where the document path was being split by "/" instead of using `path.sep`. This caused save actions to stop working on Windows.

To test: save a USS file on a Windows machine, using the VSIX for this PR.

## Release Notes

Milestone: 2.12.1

Changelog:

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
