### PR TITLE
Fix etag not updated for USS files on overwrite

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.12.2-SNAPSHOT",
+  "version": "2.12.2",
   "command": {
     "version": {
       "forcePublish": true,

--- a/packages/eslint-plugin-zowe-explorer/CHANGELOG.md
+++ b/packages/eslint-plugin-zowe-explorer/CHANGELOG.md
@@ -2,10 +2,6 @@ All notable changes to the "eslint-plugin-zowe-explorer" package will be documen
 
 ## TBD Release
 
-### New features and enhancements
-
-### Bug fixes
-
 ## `2.12.1`
 
 ## `2.12.0`

--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -4,10 +4,6 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 ## TBD Release
 
-### New features and enhancements
-
-### Bug fixes
-
 ## `2.12.1`
 
 ## `2.12.0`

--- a/packages/zowe-explorer-ftp-extension/CHANGELOG.md
+++ b/packages/zowe-explorer-ftp-extension/CHANGELOG.md
@@ -2,10 +2,6 @@ All notable changes to the "zowe-explorer-ftp-extension" extension will be docum
 
 ## TBD Release
 
-### New features and enhancements
-
-### Bug fixes
-
 ## `2.12.1`
 
 ### Bug fixes

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ## TBD Release
 
-### New features and enhancements
-
 ### Bug fixes
 
 - Fixed issue where etag was not updated for USS files after conflict is detected and user selects Overwrite option.

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
+- Fixed issue where etag was not updated for USS files after conflict is detected and user selects Overwrite option.
+
 ## `2.12.1`
 
 ### Bug fixes

--- a/packages/zowe-explorer/__tests__/__unit__/shared/utils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/shared/utils.unit.test.ts
@@ -239,7 +239,12 @@ describe("Test uploadContents", () => {
             {
                 fileName: "whatever",
             } as any,
-            null
+            null,
+            {
+                profile: {
+                    encoding: 123,
+                },
+            } as any
         );
         expect(ZoweExplorerApiRegister.getUssApi(null).putContents).toBeCalled();
     });
@@ -264,7 +269,12 @@ describe("Test uploadContents", () => {
             {
                 fileName: "whatever",
             } as any,
-            null
+            null,
+            {
+                profile: {
+                    encoding: codepage,
+                },
+            } as any
         );
         expect(ZoweExplorerApiRegister.getMvsApi(null).putContents).toBeCalled();
     });

--- a/packages/zowe-explorer/__tests__/__unit__/uss/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/actions.unit.test.ts
@@ -23,6 +23,7 @@ import {
     createTextDocument,
     createFileResponse,
     createValidIProfile,
+    createInstanceOfProfile,
 } from "../../../__mocks__/mockCreators/shared";
 import { ZoweExplorerApiRegister } from "../../../src/ZoweExplorerApiRegister";
 import { Profiles } from "../../../src/Profiles";
@@ -427,6 +428,7 @@ describe("USS Action Unit Tests - Function saveUSSFile", () => {
         const newMocks = {
             node: null,
             mockGetEtag: null,
+            profileInstance: createInstanceOfProfile(globalMocks.testProfile),
             testUSSTree: null,
             testResponse: createFileResponse({ items: [] }),
             testDoc: createTextDocument(path.join(globals.USS_DIR, "usstest", "u", "myuser", "testFile")),
@@ -527,6 +529,20 @@ describe("USS Action Unit Tests - Function saveUSSFile", () => {
         expect(globalMocks.showErrorMessage.mock.calls.length).toBe(1);
         expect(globalMocks.showErrorMessage.mock.calls[0][0]).toBe("Error: Test Error");
         expect(mocked(vscode.workspace.applyEdit)).toHaveBeenCalledTimes(2);
+    });
+
+    it("Tests that saveUSSFile fails when session cannot be located", async () => {
+        const globalMocks = createGlobalMocks();
+        const blockMocks = await createBlockMocks(globalMocks);
+
+        blockMocks.profileInstance.loadNamedProfile.mockReturnValueOnce(undefined);
+        mocked(Profiles.getInstance).mockReturnValue(blockMocks.profileInstance);
+        const testDocument = createTextDocument("u/myuser/testFile", blockMocks.node);
+        (testDocument as any).fileName = path.join(globals.USS_DIR, testDocument.fileName);
+
+        await ussNodeActions.saveUSSFile(testDocument, blockMocks.testUSSTree);
+        expect(globalMocks.showErrorMessage.mock.calls.length).toBe(1);
+        expect(globalMocks.showErrorMessage.mock.calls[0][0]).toBe("Could not locate session when saving USS file.");
     });
 });
 

--- a/packages/zowe-explorer/i18n/sample/src/uss/actions.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/uss/actions.i18n.json
@@ -7,6 +7,7 @@
   "uploadFile.putContents": "Uploading USS file",
   "copyPath.infoMessage": "Copy Path is not yet supported in Theia.",
   "saveUSSFile.log.debug.saveRequest": "save requested for USS file ",
+  "saveUSSFile.session.error": "Could not locate session when saving USS file.",
   "saveUSSFile.response.title": "Saving file...",
   "deleteUssPrompt.confirmation.delete": "Delete",
   "deleteUssPrompt.confirmation.message": "Are you sure you want to delete the following item?\nThis will permanently remove the following file or folder from your system.\n\n{0}",

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -1577,7 +1577,7 @@ export async function saveFile(doc: vscode.TextDocument, datasetProvider: api.IZ
     const ending = doc.fileName.substring(start);
     const sesName = ending.substring(0, ending.indexOf(path.sep));
     const profile = Profiles.getInstance().loadNamedProfile(sesName);
-    const fileLabel = doc.fileName.split("/").slice(-1)[0];
+    const fileLabel = path.basename(doc.fileName);
     const dataSetName = fileLabel.substring(0, fileLabel.indexOf("("));
     const memberName = fileLabel.substring(fileLabel.indexOf("(") + 1, fileLabel.indexOf(")"));
     if (!profile) {

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -25,7 +25,7 @@ import {
     JobSubmitDialogOpts,
     JOB_SUBMIT_DIALOG_OPTS,
     getDefaultUri,
-    compareFileContent,
+    uploadContent,
 } from "../shared/utils";
 import { ZoweExplorerApiRegister } from "../ZoweExplorerApiRegister";
 import { Profiles } from "../Profiles";
@@ -1652,13 +1652,7 @@ export async function saveFile(doc: vscode.TextDocument, datasetProvider: api.IZ
                 title: localize("saveFile.progress.title", "Saving data set..."),
             },
             () => {
-                if (prof.profile?.encoding) {
-                    uploadOptions.encoding = prof.profile.encoding;
-                }
-                return ZoweExplorerApiRegister.getMvsApi(prof).putContents(doc.fileName, label, {
-                    ...uploadOptions,
-                    responseTimeout: prof.profile?.responseTimeout,
-                });
+                return uploadContent(node, doc, label, prof, null, uploadOptions.etag, uploadOptions.returnEtag);
             }
         );
         if (uploadResponse.success) {
@@ -1669,7 +1663,7 @@ export async function saveFile(doc: vscode.TextDocument, datasetProvider: api.IZ
                 setFileSaved(true);
             }
         } else if (!uploadResponse.success && uploadResponse.commandResponse.includes("Rest API failure with HTTP(S) status 412")) {
-            resolveFileConflict(node, profile, doc, fileLabel, label);
+            resolveFileConflict(node, prof, doc, fileLabel, label);
         } else {
             await markDocumentUnsaved(doc);
             api.Gui.errorMessage(uploadResponse.commandResponse);

--- a/packages/zowe-explorer/src/uss/actions.ts
+++ b/packages/zowe-explorer/src/uss/actions.ts
@@ -351,8 +351,7 @@ export async function saveUSSFile(doc: vscode.TextDocument, ussFileProvider: IZo
         // TODO: error handling must not be zosmf specific
         const errorMessage = err ? err.message : err.toString();
         if (errorMessage.includes("Rest API failure with HTTP(S) status 412")) {
-            const fileLabel = doc.fileName.split("/").slice(-1)[0];
-            resolveFileConflict(node, prof, doc, fileLabel, remote, binary);
+            resolveFileConflict(node, prof, doc, path.basename(doc.fileName), remote, binary);
         } else {
             await markDocumentUnsaved(doc);
             await errorHandling(err, sesName);


### PR DESCRIPTION
## Proposed changes

The important part of this PR that fixes the issue is:
https://github.com/zowe/vscode-extension-for-zowe/blob/b7065698f5b22e7a4df3e2a1f26fb58d6e691c4f/packages/zowe-explorer/src/shared/utils.ts#L292-L293

The other changes in this PR are just to make the save and diff handling more consistent between data sets and USS files.

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog -->
<!-- If there is a linked issue, it should have the same milestone as this PR -->

Milestone: 2.12.2

Changelog: Fixed issue where etag was not updated for USS files after conflict is detected and user selects Overwrite option.

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [ ] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [ ] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
