### PR TITLE
Bug: Order of Spool files reverses when the job is Expanded and Collapsed

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed issue with `Submit JCL` losing focus on JCL being submitted, causing the wrong job submission. [#2616](https://github.com/zowe/vscode-extension-for-zowe/issues/2616)
 - Fixed issue where USS file tag could get overwritten when changes to file are uploaded. [#2576](https://github.com/zowe/vscode-extension-for-zowe/issues/2576)
 - Fixed failure to refresh token value after user logs in to authentication. [#2638](https://github.com/zowe/vscode-extension-for-zowe/issues/2638)
+- Fixed order of spool files reverses when the Job is expanded and collapsed. [#2644](https://github.com/zowe/vscode-extension-for-zowe/pull/2644)
 
 ## `2.13.0`
 

--- a/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
@@ -460,6 +460,27 @@ describe("ZoweJobNode unit tests - Function getChildren", () => {
         const jobs = await globalMocks.testJobsProvider.mSessionNodes[1].getChildren();
         expect(jobs[0].label).toEqual("TESTJOB(JOB1234) - ACTIVE");
     });
+
+    it("To check Order of Spool files don't reverse when the job is Expanded and Collapsed", async () => {
+        const globalMocks = await createGlobalMocks();
+        globalMocks.testJobsProvider.mSessionNodes[1]._owner = null;
+        globalMocks.testJobsProvider.mSessionNodes[1]._prefix = "*";
+        globalMocks.testJobsProvider.mSessionNodes[1]._searchId = "";
+        globalMocks.testJobNode.session.ISession = globalMocks.testSessionNoCred;
+        jest.spyOn(ZoweExplorerApiRegister, "getJesApi").mockReturnValueOnce({
+            getSpoolFiles: jest.fn().mockReturnValueOnce([
+                { ...globalMocks.mockIJobFile, stepname: "JES2", ddname: "JESMSGLG", "record-count": 11 },
+                { ...globalMocks.mockIJobFile, stepname: "JES2", ddname: "JESJCL", "record-count": 21 },
+                { ...globalMocks.mockIJobFile, stepname: "JES2", ddname: "JESYSMSG", "record-count": 6 },
+            ]),
+        } as any);
+        jest.spyOn(contextually, "isSession").mockReturnValueOnce(false);
+        const spoolFiles = await globalMocks.testJobNode.getChildren();
+        expect(spoolFiles.length).toBe(3);
+        expect(spoolFiles[0].label).toBe("JES2:JESMSGLG - 11");
+        expect(spoolFiles[1].label).toBe("JES2:JESJCL - 21");
+        expect(spoolFiles[2].label).toBe("JES2:JESYSMSG - 6");
+    });
 });
 
 describe("ZoweJobNode unit tests - Function flipState", () => {

--- a/packages/zowe-explorer/src/job/ZoweJobNode.ts
+++ b/packages/zowe-explorer/src/job/ZoweJobNode.ts
@@ -239,8 +239,8 @@ export class ZoweJobNode extends ZoweTreeNode implements IZoweJobTreeNode {
         // Remove any children that are no longer present in the built record
         this.children = this.children
             .concat(newChildren)
-            .filter((ch) => Object.values(elementChildren).find((recordCh) => recordCh.label === ch.label) != null)
-            .sort(ZoweJobNode.sortJobs(sortMethod));
+            .filter((ch) => Object.values(elementChildren).find((recordCh) => recordCh.label === ch.label) != null);
+        if (contextually.isSession(this)) this.children = this.children.sort(ZoweJobNode.sortJobs(sortMethod));
         this.dirty = false;
         return this.children;
     }

--- a/packages/zowe-explorer/src/job/ZoweJobNode.ts
+++ b/packages/zowe-explorer/src/job/ZoweJobNode.ts
@@ -237,12 +237,14 @@ export class ZoweJobNode extends ZoweTreeNode implements IZoweJobTreeNode {
 
         const sortMethod = contextually.isSession(this) ? this.sort : { method: JobSortOpts.Id, direction: SortDirection.Ascending };
         // Remove any children that are no longer present in the built record
-        this.children = this.children
-            .concat(newChildren)
-            .filter((ch) => Object.values(elementChildren).find((recordCh) => recordCh.label === ch.label) != null);
-        if (contextually.isSession(this)) {
-            this.children = this.children.sort(ZoweJobNode.sortJobs(sortMethod));
-        }
+        this.children = contextually.isSession(this)
+            ? this.children
+                  .concat(newChildren)
+                  .filter((ch) => Object.values(elementChildren).find((recordCh) => recordCh.label === ch.label) != null)
+                  .sort(ZoweJobNode.sortJobs(sortMethod))
+            : this.children
+                  .concat(newChildren)
+                  .filter((ch) => Object.values(elementChildren).find((recordCh) => recordCh.label === ch.label) != null);
         this.dirty = false;
         return this.children;
     }

--- a/packages/zowe-explorer/src/job/ZoweJobNode.ts
+++ b/packages/zowe-explorer/src/job/ZoweJobNode.ts
@@ -240,7 +240,9 @@ export class ZoweJobNode extends ZoweTreeNode implements IZoweJobTreeNode {
         this.children = this.children
             .concat(newChildren)
             .filter((ch) => Object.values(elementChildren).find((recordCh) => recordCh.label === ch.label) != null);
-        if (contextually.isSession(this)) this.children = this.children.sort(ZoweJobNode.sortJobs(sortMethod));
+        if (contextually.isSession(this)) {
+            this.children = this.children.sort(ZoweJobNode.sortJobs(sortMethod));
+        }
         this.dirty = false;
         return this.children;
     }


### PR DESCRIPTION
## Proposed changes
To make spools files order doesn't reverse when the job is expanded and collapsed.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog -->
<!-- If there is a linked issue, it should have the same milestone as this PR -->

Milestone:

Changelog:

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [x] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
