### PR TITLE
Local filtering of Jobs with exec-member field

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed issue where USS file tag could get overwritten when changes to file are uploaded. [#2576](https://github.com/zowe/vscode-extension-for-zowe/issues/2576)
 - Fixed failure to refresh token value after user logs in to authentication. [#2638](https://github.com/zowe/vscode-extension-for-zowe/issues/2638)
 - Fixed order of spool files reverses when the Job is expanded and collapsed. [#2644](https://github.com/zowe/vscode-extension-for-zowe/pull/2644)
+- Fixed local filtering of jobs to work with SMFID (exec-member field). [#2651](https://github.com/zowe/vscode-extension-for-zowe/pull/2651)
 
 ## `2.13.0`
 

--- a/packages/zowe-explorer/__tests__/__unit__/job/ZosJobsProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/ZosJobsProvider.unit.test.ts
@@ -69,10 +69,11 @@ const mockInputBox: vscode.InputBox = {
     ignoreFocusOut: false,
     onDidHide: jest.fn(),
 };
-function setJobObjects(job: zowe.IJob, newJobName: string, newJobId: string, newRetCode: string) {
+function setJobObjects(job: zowe.IJob, newJobName: string, newJobId: string, newRetCode: string, newExecMember: string | undefined) {
     job.jobname = newJobName;
     job.jobid = newJobId;
     job.retcode = newRetCode;
+    job["exec-member"] = newExecMember;
     return job;
 }
 
@@ -1036,19 +1037,19 @@ describe("getFavorites", () => {
 
 describe("ZosJobsProvider Unit Test - Filter Jobs", () => {
     const node1: IZoweJobTreeNode = new ZoweJobNode({
-        label: "jobnew",
+        label: "node1",
         collapsibleState: vscode.TreeItemCollapsibleState.None,
-        job: setJobObjects(createIJobObject(), "ZOWEUSR1", "JOB04945", "CC 0000"),
+        job: setJobObjects(createIJobObject(), "ZOWEUSR1", "JOB04945", "CC 0000", "IPO1"),
     });
     const node2: IZoweJobTreeNode = new ZoweJobNode({
-        label: "jobnew",
+        label: "node2",
         collapsibleState: vscode.TreeItemCollapsibleState.None,
-        job: setJobObjects(createIJobObject(), "ZOWEUSR2", "JOB05037", "CC 0000"),
+        job: setJobObjects(createIJobObject(), "ZOWEUSR2", "JOB05037", "CC 0000", undefined),
     });
     const node3: IZoweJobTreeNode = new ZoweJobNode({
-        label: "jobnew",
+        label: "node3",
         collapsibleState: vscode.TreeItemCollapsibleState.None,
-        job: setJobObjects(createIJobObject(), "ZOWEUSR3", "TSU07707", "ABEND S222"),
+        job: setJobObjects(createIJobObject(), "ZOWEUSR3", "TSU07707", "ABEND S222", "IPO3"),
     });
 
     let globalMocks;
@@ -1086,6 +1087,7 @@ describe("ZosJobsProvider Unit Test - Filter Jobs", () => {
         await testTree.filterJobsDialog(node1);
         expect(filterJobsSpy).toHaveBeenCalled();
         expect(filterJobsSpy).toBeCalledWith(node1);
+        expect(filterJobsSpy.mock.calls[0][0].children[0].job.jobname).toBe("ZOWEUSR2");
     });
 
     it("To check Clear filter for profile", async () => {

--- a/packages/zowe-explorer/src/job/ZosJobsProvider.ts
+++ b/packages/zowe-explorer/src/job/ZosJobsProvider.ts
@@ -1183,7 +1183,7 @@ export class ZosJobsProvider extends ZoweTreeProvider implements IZoweTree<IZowe
         inputBox.onDidChangeValue((query) => {
             query = query.toUpperCase();
             job["children"] = actual_jobs.filter((item) =>
-                item["job"]["exec-member"] !== undefined && item["job"]["exec-member"] !== ""
+                item["job"]["exec-member"]
                     ? `${item["job"].jobname}(${item["job"].jobid}) - ${item["job"]["exec-member"] as string} - ${item["job"].retcode}`.includes(
                           query
                       )

--- a/packages/zowe-explorer/src/job/ZosJobsProvider.ts
+++ b/packages/zowe-explorer/src/job/ZosJobsProvider.ts
@@ -1182,7 +1182,13 @@ export class ZosJobsProvider extends ZoweTreeProvider implements IZoweTree<IZowe
         inputBox.placeholder = localize("filterJobs.prompt.message", "Enter local filter...");
         inputBox.onDidChangeValue((query) => {
             query = query.toUpperCase();
-            job["children"] = actual_jobs.filter((item) => `${item["job"].jobname}(${item["job"].jobid}) - ${item["job"].retcode}`.includes(query));
+            job["children"] = actual_jobs.filter((item) =>
+                item["job"]["exec-member"] !== undefined && item["job"]["exec-member"] !== ""
+                    ? `${item["job"].jobname}(${item["job"].jobid}) - ${item["job"]["exec-member"] as string} - ${item["job"].retcode}`.includes(
+                          query
+                      )
+                    : `${item["job"].jobname}(${item["job"].jobid}) - ${item["job"].retcode}`.includes(query)
+            );
             TreeProviders.job.refresh();
             this.updateFilterForJob(job, query, isSession);
             Gui.setStatusBarMessage(localize("filter.updated", "$(check) Filter updated for {0}", job.label as string), globals.MS_PER_SEC * 4);


### PR DESCRIPTION
## Proposed changes
Currently, the Local Filtering of Jobs is based on jobid, jobname and return code. With these proposed changes filtering of jobs is even possible with exec-member field.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog -->
<!-- If there is a linked issue, it should have the same milestone as this PR -->

Milestone:

Changelog:

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [x] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
