### PR TITLE
Add workflow to update issue and PR status on GH project board

### DIFF
--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -8,6 +8,9 @@ on:
 
 env:
   PROJECT_NUMBER: 15
+  ISSUE_STATUSES: '{"priority-high": "High Priority", "priority-medium": "Medium Priority", "priority-low": "Low Priority", "Epic": "Epics"}'
+  PR_STATUS_DRAFT: 'In Progress'
+  PR_STATUS_READY: 'Review/QA'
 
 jobs:
   update-project:
@@ -15,37 +18,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: zowe-actions/shared-actions/project-move-item@main
+      if: ${{ github.event.issue && fromJSON(env.ISSUE_STATUSES)[github.event.label.name] }}
+      with:
+        item-status: ${{ fromJSON(env.ISSUE_STATUSES)[github.event.label.name] }}
+        project-number: ${{ env.PROJECT_NUMBER }}
+        project-token: ${{ secrets.ZOWE_ROBOT_TOKEN }}
+
+    - uses: zowe-actions/shared-actions/project-move-item@main
       if: ${{ github.event.pull_request }}
       with:
         assign-author: true
-        item-status: ${{ github.event.action == 'ready_for_review' && 'Review/QA' || 'In Progress' }}
-        project-number: ${{ env.PROJECT_NUMBER }}
-        project-token: ${{ secrets.ZOWE_ROBOT_TOKEN }}
-
-    - uses: zowe-actions/shared-actions/project-move-item@main
-      if: ${{ github.event.issue && github.event.label.name == 'priority-high' }}
-      with:
-        item-status: High Priority
-        project-number: ${{ env.PROJECT_NUMBER }}
-        project-token: ${{ secrets.ZOWE_ROBOT_TOKEN }}
-
-    - uses: zowe-actions/shared-actions/project-move-item@main
-      if: ${{ github.event.issue && github.event.label.name == 'priority-medium' }}
-      with:
-        item-status: Medium Priority
-        project-number: ${{ env.PROJECT_NUMBER }}
-        project-token: ${{ secrets.ZOWE_ROBOT_TOKEN }}
-
-    - uses: zowe-actions/shared-actions/project-move-item@main
-      if: ${{ github.event.issue && github.event.label.name == 'priority-low' }}
-      with:
-        item-status: Low Priority
-        project-number: ${{ env.PROJECT_NUMBER }}
-        project-token: ${{ secrets.ZOWE_ROBOT_TOKEN }}
-
-    - uses: zowe-actions/shared-actions/project-move-item@main
-      if: ${{ github.event.issue && github.event.label.name == 'Epic' }}
-      with:
-        item-status: Epics
+        item-status: ${{ github.event.action == 'ready_for_review' && env.PR_STATUS_READY || env.PR_STATUS_DRAFT }}
         project-number: ${{ env.PROJECT_NUMBER }}
         project-token: ${{ secrets.ZOWE_ROBOT_TOKEN }}

--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -14,7 +14,7 @@ jobs:
     name: Move project item
     runs-on: ubuntu-latest
     steps:
-    - uses: zowe-actions/shared-actions/project-move-item@actions/project-move-item
+    - uses: zowe-actions/shared-actions/project-move-item@main
       if: ${{ github.event.pull_request }}
       with:
         assign-author: true
@@ -22,28 +22,28 @@ jobs:
         project-number: ${{ env.PROJECT_NUMBER }}
         project-token: ${{ secrets.ZOWE_ROBOT_TOKEN }}
 
-    - uses: zowe-actions/shared-actions/project-move-item@actions/project-move-item
+    - uses: zowe-actions/shared-actions/project-move-item@main
       if: ${{ github.event.issue && github.event.label.name == 'priority-high' }}
       with:
         item-status: High Priority
         project-number: ${{ env.PROJECT_NUMBER }}
         project-token: ${{ secrets.ZOWE_ROBOT_TOKEN }}
 
-    - uses: zowe-actions/shared-actions/project-move-item@actions/project-move-item
+    - uses: zowe-actions/shared-actions/project-move-item@main
       if: ${{ github.event.issue && github.event.label.name == 'priority-medium' }}
       with:
         item-status: Medium Priority
         project-number: ${{ env.PROJECT_NUMBER }}
         project-token: ${{ secrets.ZOWE_ROBOT_TOKEN }}
 
-    - uses: zowe-actions/shared-actions/project-move-item@actions/project-move-item
+    - uses: zowe-actions/shared-actions/project-move-item@main
       if: ${{ github.event.issue && github.event.label.name == 'priority-low' }}
       with:
         item-status: Low Priority
         project-number: ${{ env.PROJECT_NUMBER }}
         project-token: ${{ secrets.ZOWE_ROBOT_TOKEN }}
 
-    - uses: zowe-actions/shared-actions/project-move-item@actions/project-move-item
+    - uses: zowe-actions/shared-actions/project-move-item@main
       if: ${{ github.event.issue && github.event.label.name == 'Epic' }}
       with:
         item-status: Epics

--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -1,0 +1,51 @@
+name: Update GitHub Project
+
+on:
+  issues:
+    types: [labeled]
+  pull_request_target:
+    types: [opened, reopened, converted_to_draft, ready_for_review]
+
+env:
+  PROJECT_NUMBER: 15
+
+jobs:
+  update-project:
+    name: Move project item
+    runs-on: ubuntu-latest
+    steps:
+    - uses: zowe-actions/shared-actions/project-move-item@actions/project-move-item
+      if: ${{ github.event.pull_request }}
+      with:
+        assign-author: true
+        item-status: ${{ github.event.action == 'ready_for_review' && 'Review/QA' || 'In Progress' }}
+        project-number: ${{ env.PROJECT_NUMBER }}
+        project-token: ${{ secrets.ZOWE_ROBOT_TOKEN }}
+
+    - uses: zowe-actions/shared-actions/project-move-item@actions/project-move-item
+      if: ${{ github.event.issue && github.event.label.name == 'priority-high' }}
+      with:
+        item-status: High Priority
+        project-number: ${{ env.PROJECT_NUMBER }}
+        project-token: ${{ secrets.ZOWE_ROBOT_TOKEN }}
+
+    - uses: zowe-actions/shared-actions/project-move-item@actions/project-move-item
+      if: ${{ github.event.issue && github.event.label.name == 'priority-medium' }}
+      with:
+        item-status: Medium Priority
+        project-number: ${{ env.PROJECT_NUMBER }}
+        project-token: ${{ secrets.ZOWE_ROBOT_TOKEN }}
+
+    - uses: zowe-actions/shared-actions/project-move-item@actions/project-move-item
+      if: ${{ github.event.issue && github.event.label.name == 'priority-low' }}
+      with:
+        item-status: Low Priority
+        project-number: ${{ env.PROJECT_NUMBER }}
+        project-token: ${{ secrets.ZOWE_ROBOT_TOKEN }}
+
+    - uses: zowe-actions/shared-actions/project-move-item@actions/project-move-item
+      if: ${{ github.event.issue && github.event.label.name == 'Epic' }}
+      with:
+        item-status: Epics
+        project-number: ${{ env.PROJECT_NUMBER }}
+        project-token: ${{ secrets.ZOWE_ROBOT_TOKEN }}


### PR DESCRIPTION
### Problem
GitHub Projects doesn't let us choose different columns for new issues vs pull requests, so they both end up in "New Issues":
![image](https://github.com/zowe/zowe-cli/assets/22344007/96bad6c9-c8c4-4f4e-9998-f9e3a309d2a4)

### Solution
This PR adds a GitHub workflow that is triggered on PR and issue events, which will update the column/status of that item in the GitHub project.
* When PR is opened or re-opened: "New Issues" -> "In Progress"
* When PR is converted to draft: "Review/QA" -> "In Progress"
* When PR is marked ready for review: "In Progress" -> "Review/QA"
* When issue is labelled with "priority-`X`" or "Epic": "New Issues" -> "`X` Priority" or "Epics"

**Note:** If we want this behavior across all Explorer repos, we need to add this workflow to each one.