### PR TITLE
`BugFix` Issue with duplicate dd names on job output view

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 ### Bug fixes
 
 - Adjusted order of 'Manage Profile' and 'Edit History' in the jobs tree's context menu to match the other trees. [#2670](https://github.com/zowe/vscode-extension-for-zowe/issues/2670)
+- Fixed issue where spools with duplicate DD names would overwrite each other causing less spools in job output view [#2315](https://github.com/zowe/vscode-extension-for-zowe/issues/2315)
 
 ## `2.14.1`
 

--- a/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
@@ -484,11 +484,13 @@ describe("ZoweJobNode unit tests - Function getChildren", () => {
 
     it("Check that jobs with duplicate DD names do not overwrite each other", async () => {
         const globalMocks = await createGlobalMocks();
-        const mockSpoolOne = { ...globalMocks.mockIJobFile, stepname: "SOMEJOB", ddname: "TEST", "record-count": 13 };
-        const mockSpoolTwo = { ...globalMocks.mockIJobFile, stepname: "SOMEJOB", ddname: "TEST", "record-count": 5 };
+        const mockSpoolOne = { ...globalMocks.mockIJobFile, stepname: "JES2", ddname: "JESMSGLG", "record-count": 11 };
+        const mockSpoolTwo = { ...globalMocks.mockIJobFile, stepname: "SOMEJOB", ddname: "TEST", "record-count": 13 };
+        const mockSpoolThree = { ...globalMocks.mockIJobFile, stepname: "SOMEJOB", ddname: "TEST", "record-count": 5 };
 
-        mockSpoolOne.id = 12;
-        mockSpoolTwo.id = 13;
+        mockSpoolOne.procstep = "TEST";
+        mockSpoolTwo.id = 12;
+        mockSpoolThree.id = 13;
 
         globalMocks.testJobsProvider.mSessionNodes[1]._owner = null;
         globalMocks.testJobsProvider.mSessionNodes[1]._prefix = "*";
@@ -496,17 +498,17 @@ describe("ZoweJobNode unit tests - Function getChildren", () => {
         globalMocks.testJobNode.session.ISession = globalMocks.testSessionNoCred;
         jest.spyOn(ZoweExplorerApiRegister, "getJesApi").mockReturnValueOnce({
             getSpoolFiles: jest.fn().mockReturnValueOnce([
-                { ...globalMocks.mockIJobFile, stepname: "JES2", ddname: "JESMSGLG", "record-count": 11 },
+                mockSpoolOne
                 { ...globalMocks.mockIJobFile, stepname: "JES2", ddname: "JESJCL", "record-count": 21 },
                 { ...globalMocks.mockIJobFile, stepname: "JES2", ddname: "JESYSMSG", "record-count": 6 },
-                mockSpoolOne,
-                mockSpoolTwo
+                mockSpoolTwo,
+                mockSpoolThree
             ]),
         } as any);
         jest.spyOn(contextually, "isSession").mockReturnValueOnce(false);
         const spoolFiles = await globalMocks.testJobNode.getChildren();
         expect(spoolFiles.length).toBe(5);
-        expect(spoolFiles[0].label).toBe("101 - JES2:JESMSGLG");
+        expect(spoolFiles[0].label).toBe("101 - JES2:JESMSGLG - TEST");
         expect(spoolFiles[1].label).toBe("101 - JES2:JESJCL");
         expect(spoolFiles[2].label).toBe("101 - JES2:JESYSMSG");
         expect(spoolFiles[3].label).toBe("12 - SOMEJOB:TEST");

--- a/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
@@ -498,7 +498,7 @@ describe("ZoweJobNode unit tests - Function getChildren", () => {
         globalMocks.testJobNode.session.ISession = globalMocks.testSessionNoCred;
         jest.spyOn(ZoweExplorerApiRegister, "getJesApi").mockReturnValueOnce({
             getSpoolFiles: jest.fn().mockReturnValueOnce([
-                mockSpoolOne
+                mockSpoolOne,
                 { ...globalMocks.mockIJobFile, stepname: "JES2", ddname: "JESJCL", "record-count": 21 },
                 { ...globalMocks.mockIJobFile, stepname: "JES2", ddname: "JESYSMSG", "record-count": 6 },
                 mockSpoolTwo,

--- a/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
@@ -497,13 +497,15 @@ describe("ZoweJobNode unit tests - Function getChildren", () => {
         globalMocks.testJobsProvider.mSessionNodes[1]._searchId = "";
         globalMocks.testJobNode.session.ISession = globalMocks.testSessionNoCred;
         jest.spyOn(ZoweExplorerApiRegister, "getJesApi").mockReturnValueOnce({
-            getSpoolFiles: jest.fn().mockReturnValueOnce([
-                mockSpoolOne,
-                { ...globalMocks.mockIJobFile, stepname: "JES2", ddname: "JESJCL", "record-count": 21 },
-                { ...globalMocks.mockIJobFile, stepname: "JES2", ddname: "JESYSMSG", "record-count": 6 },
-                mockSpoolTwo,
-                mockSpoolThree
-            ]),
+            getSpoolFiles: jest
+                .fn()
+                .mockReturnValueOnce([
+                    mockSpoolOne,
+                    { ...globalMocks.mockIJobFile, stepname: "JES2", ddname: "JESJCL", "record-count": 21 },
+                    { ...globalMocks.mockIJobFile, stepname: "JES2", ddname: "JESYSMSG", "record-count": 6 },
+                    mockSpoolTwo,
+                    mockSpoolThree,
+                ]),
         } as any);
         jest.spyOn(contextually, "isSession").mockReturnValueOnce(false);
         const spoolFiles = await globalMocks.testJobNode.getChildren();

--- a/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
@@ -345,7 +345,7 @@ describe("ZoweJobNode unit tests - Function getChildren", () => {
 
         const spoolFiles = await globalMocks.testJobNode.getChildren();
         expect(spoolFiles.length).toBe(1);
-        expect(spoolFiles[0].label).toEqual("101 - STEP:STDOUT");
+        expect(spoolFiles[0].label).toEqual("STEP:STDOUT(101)");
         expect(spoolFiles[0].owner).toEqual("fake");
     });
 
@@ -354,7 +354,7 @@ describe("ZoweJobNode unit tests - Function getChildren", () => {
 
         const spoolFiles = await globalMocks.testJobNode.getChildren();
         expect(spoolFiles.length).toBe(1);
-        expect(spoolFiles[0].label).toEqual("101 - STEP:STDOUT");
+        expect(spoolFiles[0].label).toEqual("STEP:STDOUT(101)");
         expect(spoolFiles[0].owner).toEqual("fake");
 
         jest.spyOn(ZoweExplorerApiRegister, "getJesApi").mockReturnValueOnce({
@@ -363,7 +363,7 @@ describe("ZoweJobNode unit tests - Function getChildren", () => {
         globalMocks.testJobNode.dirty = true;
         const spoolFilesAfter = await globalMocks.testJobNode.getChildren();
         expect(spoolFilesAfter.length).toBe(1);
-        expect(spoolFilesAfter[0].label).toEqual("101 - STEP:STDOUT");
+        expect(spoolFilesAfter[0].label).toEqual("STEP:STDOUT(101)");
         expect(spoolFilesAfter[0].owner).toEqual("fake");
     });
 
@@ -388,7 +388,7 @@ describe("ZoweJobNode unit tests - Function getChildren", () => {
         globalMocks.testJobNode.session.ISession = globalMocks.testSessionNoCred;
         const spoolFiles = await globalMocks.testJobNode.getChildren();
         expect(spoolFiles.length).toBe(1);
-        expect(spoolFiles[0].label).toEqual("101 - STEP:STDOUT");
+        expect(spoolFiles[0].label).toEqual("STEP:STDOUT(101)");
         expect(spoolFiles[0].owner).toEqual("*");
     });
 
@@ -477,9 +477,9 @@ describe("ZoweJobNode unit tests - Function getChildren", () => {
         jest.spyOn(contextually, "isSession").mockReturnValueOnce(false);
         const spoolFiles = await globalMocks.testJobNode.getChildren();
         expect(spoolFiles.length).toBe(3);
-        expect(spoolFiles[0].label).toBe("101 - JES2:JESMSGLG");
-        expect(spoolFiles[1].label).toBe("101 - JES2:JESJCL");
-        expect(spoolFiles[2].label).toBe("101 - JES2:JESYSMSG");
+        expect(spoolFiles[0].label).toBe("JES2:JESMSGLG(101)");
+        expect(spoolFiles[1].label).toBe("JES2:JESJCL(101)");
+        expect(spoolFiles[2].label).toBe("JES2:JESYSMSG(101)");
     });
 
     it("Check that jobs with duplicate DD names do not overwrite each other", async () => {
@@ -510,11 +510,11 @@ describe("ZoweJobNode unit tests - Function getChildren", () => {
         jest.spyOn(contextually, "isSession").mockReturnValueOnce(false);
         const spoolFiles = await globalMocks.testJobNode.getChildren();
         expect(spoolFiles.length).toBe(5);
-        expect(spoolFiles[0].label).toBe("101 - JES2:JESMSGLG - TEST");
-        expect(spoolFiles[1].label).toBe("101 - JES2:JESJCL");
-        expect(spoolFiles[2].label).toBe("101 - JES2:JESYSMSG");
-        expect(spoolFiles[3].label).toBe("12 - SOMEJOB:TEST");
-        expect(spoolFiles[4].label).toBe("13 - SOMEJOB:TEST");
+        expect(spoolFiles[0].label).toBe("JES2:JESMSGLG(101) - TEST");
+        expect(spoolFiles[1].label).toBe("JES2:JESJCL(101)");
+        expect(spoolFiles[2].label).toBe("JES2:JESYSMSG(101)");
+        expect(spoolFiles[3].label).toBe("SOMEJOB:TEST(12)");
+        expect(spoolFiles[4].label).toBe("SOMEJOB:TEST(13)");
     });
 });
 

--- a/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/ZoweJobNode.unit.test.ts
@@ -345,7 +345,7 @@ describe("ZoweJobNode unit tests - Function getChildren", () => {
 
         const spoolFiles = await globalMocks.testJobNode.getChildren();
         expect(spoolFiles.length).toBe(1);
-        expect(spoolFiles[0].label).toEqual("STEP:STDOUT - 1");
+        expect(spoolFiles[0].label).toEqual("101 - STEP:STDOUT");
         expect(spoolFiles[0].owner).toEqual("fake");
     });
 
@@ -354,7 +354,7 @@ describe("ZoweJobNode unit tests - Function getChildren", () => {
 
         const spoolFiles = await globalMocks.testJobNode.getChildren();
         expect(spoolFiles.length).toBe(1);
-        expect(spoolFiles[0].label).toEqual("STEP:STDOUT - 1");
+        expect(spoolFiles[0].label).toEqual("101 - STEP:STDOUT");
         expect(spoolFiles[0].owner).toEqual("fake");
 
         jest.spyOn(ZoweExplorerApiRegister, "getJesApi").mockReturnValueOnce({
@@ -363,7 +363,7 @@ describe("ZoweJobNode unit tests - Function getChildren", () => {
         globalMocks.testJobNode.dirty = true;
         const spoolFilesAfter = await globalMocks.testJobNode.getChildren();
         expect(spoolFilesAfter.length).toBe(1);
-        expect(spoolFilesAfter[0].label).toEqual("STEP:STDOUT - 2");
+        expect(spoolFilesAfter[0].label).toEqual("101 - STEP:STDOUT");
         expect(spoolFilesAfter[0].owner).toEqual("fake");
     });
 
@@ -388,7 +388,7 @@ describe("ZoweJobNode unit tests - Function getChildren", () => {
         globalMocks.testJobNode.session.ISession = globalMocks.testSessionNoCred;
         const spoolFiles = await globalMocks.testJobNode.getChildren();
         expect(spoolFiles.length).toBe(1);
-        expect(spoolFiles[0].label).toEqual("STEP:STDOUT - 1");
+        expect(spoolFiles[0].label).toEqual("101 - STEP:STDOUT");
         expect(spoolFiles[0].owner).toEqual("*");
     });
 
@@ -477,9 +477,40 @@ describe("ZoweJobNode unit tests - Function getChildren", () => {
         jest.spyOn(contextually, "isSession").mockReturnValueOnce(false);
         const spoolFiles = await globalMocks.testJobNode.getChildren();
         expect(spoolFiles.length).toBe(3);
-        expect(spoolFiles[0].label).toBe("JES2:JESMSGLG - 11");
-        expect(spoolFiles[1].label).toBe("JES2:JESJCL - 21");
-        expect(spoolFiles[2].label).toBe("JES2:JESYSMSG - 6");
+        expect(spoolFiles[0].label).toBe("101 - JES2:JESMSGLG");
+        expect(spoolFiles[1].label).toBe("101 - JES2:JESJCL");
+        expect(spoolFiles[2].label).toBe("101 - JES2:JESYSMSG");
+    });
+
+    it("Check that jobs with duplicate DD names do not overwrite each other", async () => {
+        const globalMocks = await createGlobalMocks();
+        const mockSpoolOne = { ...globalMocks.mockIJobFile, stepname: "SOMEJOB", ddname: "TEST", "record-count": 13 };
+        const mockSpoolTwo = { ...globalMocks.mockIJobFile, stepname: "SOMEJOB", ddname: "TEST", "record-count": 5 };
+
+        mockSpoolOne.id = 12;
+        mockSpoolTwo.id = 13;
+
+        globalMocks.testJobsProvider.mSessionNodes[1]._owner = null;
+        globalMocks.testJobsProvider.mSessionNodes[1]._prefix = "*";
+        globalMocks.testJobsProvider.mSessionNodes[1]._searchId = "";
+        globalMocks.testJobNode.session.ISession = globalMocks.testSessionNoCred;
+        jest.spyOn(ZoweExplorerApiRegister, "getJesApi").mockReturnValueOnce({
+            getSpoolFiles: jest.fn().mockReturnValueOnce([
+                { ...globalMocks.mockIJobFile, stepname: "JES2", ddname: "JESMSGLG", "record-count": 11 },
+                { ...globalMocks.mockIJobFile, stepname: "JES2", ddname: "JESJCL", "record-count": 21 },
+                { ...globalMocks.mockIJobFile, stepname: "JES2", ddname: "JESYSMSG", "record-count": 6 },
+                mockSpoolOne,
+                mockSpoolTwo
+            ]),
+        } as any);
+        jest.spyOn(contextually, "isSession").mockReturnValueOnce(false);
+        const spoolFiles = await globalMocks.testJobNode.getChildren();
+        expect(spoolFiles.length).toBe(5);
+        expect(spoolFiles[0].label).toBe("101 - JES2:JESMSGLG");
+        expect(spoolFiles[1].label).toBe("101 - JES2:JESJCL");
+        expect(spoolFiles[2].label).toBe("101 - JES2:JESYSMSG");
+        expect(spoolFiles[3].label).toBe("12 - SOMEJOB:TEST");
+        expect(spoolFiles[4].label).toBe("13 - SOMEJOB:TEST");
     });
 });
 

--- a/packages/zowe-explorer/src/job/ZoweJobNode.ts
+++ b/packages/zowe-explorer/src/job/ZoweJobNode.ts
@@ -143,9 +143,9 @@ export class ZoweJobNode extends ZoweTreeNode implements IZoweJobTreeNode {
                 const procstep = spool.procstep ? spool.procstep : undefined;
                 let newLabel: string;
                 if (procstep) {
-                    newLabel = `${spool.stepname}:${spool.ddname} - ${procstep}`;
+                    newLabel = `${spool["id"]} - ${spool.stepname}:${spool.ddname} - ${procstep}`;
                 } else {
-                    newLabel = `${spool.stepname}:${spool.ddname} - ${spool["record-count"]}`;
+                    newLabel = `${spool["id"]} - ${spool.stepname}:${spool.ddname}`;
                 }
 
                 // Only look for existing node w/ procstep if spool file has a procstep,

--- a/packages/zowe-explorer/src/job/ZoweJobNode.ts
+++ b/packages/zowe-explorer/src/job/ZoweJobNode.ts
@@ -143,9 +143,9 @@ export class ZoweJobNode extends ZoweTreeNode implements IZoweJobTreeNode {
                 const procstep = spool.procstep ? spool.procstep : undefined;
                 let newLabel: string;
                 if (procstep) {
-                    newLabel = `${spool["id"]} - ${spool.stepname}:${spool.ddname} - ${procstep}`;
+                    newLabel = `${spool.id} - ${spool.stepname}:${spool.ddname} - ${procstep}`;
                 } else {
-                    newLabel = `${spool["id"]} - ${spool.stepname}:${spool.ddname}`;
+                    newLabel = `${spool.id} - ${spool.stepname}:${spool.ddname}`;
                 }
 
                 // Only look for existing node w/ procstep if spool file has a procstep,

--- a/packages/zowe-explorer/src/job/ZoweJobNode.ts
+++ b/packages/zowe-explorer/src/job/ZoweJobNode.ts
@@ -143,9 +143,9 @@ export class ZoweJobNode extends ZoweTreeNode implements IZoweJobTreeNode {
                 const procstep = spool.procstep ? spool.procstep : undefined;
                 let newLabel: string;
                 if (procstep) {
-                    newLabel = `${spool.id} - ${spool.stepname}:${spool.ddname} - ${procstep}`;
+                    newLabel = `${spool.stepname}:${spool.ddname}(${spool.id}) - ${procstep}`;
                 } else {
-                    newLabel = `${spool.id} - ${spool.stepname}:${spool.ddname}`;
+                    newLabel = `${spool.stepname}:${spool.ddname}(${spool.id})`;
                 }
 
                 // Only look for existing node w/ procstep if spool file has a procstep,


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

Solves #2315 

Solve an issue where duplicate dd names in a spool file inside of a job would get overwritten by the last ocurrence. e.g for job:

MyJob Spools:
- Spool1 - `record-count`
- Spool2 - `record-count`
- Spool3 - `record-count`
- Spool3 - `record-count`

Spool 3 will only appear once in the output, now we will append the ID of the spool at the start to provide uniqueness to each spool (as well as prevent real duplicates) and remain consistent to how the CLI also outputs these spools by putting the `id` in the head instead of the `record-count` property at the tail of the label which is not always unique for each spool.

MyJob Spools:
- `id` - Spool1
- `id` - Spool2
- `id` - Spool3
- `id` - Spool3

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog -->
<!-- If there is a linked issue, it should have the same milestone as this PR -->

Milestone: `v2.15.0`

Changelog: Fixed issue where spools with duplicate DD names would overwrite each other causing less spools in job output view

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [x] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [x] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
