### PR TITLE
fix(v3): include protocol in `zosmf` session objects

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the "zowe-explorer-api" extension will be documented in this file.
 
+## TBD Release
+
+### New features and enhancements
+
+### Bug fixes
+
+- Fixed issue where `zosmf` profiles did not respect the `protocol` property [#2703](https://github.com/zowe/vscode-extension-for-zowe/issues/2703).
+
 ## `3.0.0-next.202402142205`
 
 ### New features and enhancements

--- a/packages/zowe-explorer-api/__tests__/__unit__/profiles/ZoweExplorerZosmfApi.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/profiles/ZoweExplorerZosmfApi.unit.test.ts
@@ -98,7 +98,7 @@ describe("ZosmfUssApi", () => {
         } as zowe.imperative.IProfileLoaded;
 
         it("should include profile properties in the built session object", () => {
-            const api = new ZosmfUssApi();
+            const api = new ZoweExplorerZosmf.UssApi();
 
             const transformedProps = { ...exampleProfile.profile, hostname: exampleProfile.profile?.host };
             delete transformedProps["host"];

--- a/packages/zowe-explorer-api/__tests__/__unit__/profiles/ZoweExplorerZosmfApi.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/profiles/ZoweExplorerZosmfApi.unit.test.ts
@@ -83,6 +83,26 @@ describe("ZosmfUssApi", () => {
         jest.clearAllMocks();
     });
 
+    describe("_getSession", () => {
+        const exampleProfile = {
+            message: "",
+            type: "zosmf",
+            failNotFound: false,
+            name: "test.zosmf",
+            profile: {
+                host: "localhost",
+                password: "password",
+                protocol: "http",
+                user: "aZosmfUser",
+            },
+        } as zowe.imperative.IProfileLoaded;
+
+        it("should include protocol in the built session object", () => {
+            const api = new ZosmfUssApi();
+            expect((api as any)._getSession(exampleProfile).mISession.protocol).toBe("http");
+        });
+    });
+
     describe("updateAttributes", () => {
         const ussApi = new ZoweExplorerZosmf.UssApi();
         const getSessionMock = jest.spyOn(ussApi, "getSession").mockReturnValue(fakeSession);

--- a/packages/zowe-explorer-api/__tests__/__unit__/profiles/ZoweExplorerZosmfApi.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/profiles/ZoweExplorerZosmfApi.unit.test.ts
@@ -97,9 +97,12 @@ describe("ZosmfUssApi", () => {
             },
         } as zowe.imperative.IProfileLoaded;
 
-        it("should include protocol in the built session object", () => {
+        it("should include profile properties in the built session object", () => {
             const api = new ZosmfUssApi();
-            expect((api as any)._getSession(exampleProfile).mISession.protocol).toBe("http");
+
+            const transformedProps = { ...exampleProfile.profile, hostname: exampleProfile.profile?.host };
+            delete transformedProps["host"];
+            expect((api as any)._getSession(exampleProfile).mISession).toMatchObject(transformedProps);
         });
     });
 

--- a/packages/zowe-explorer-api/src/profiles/ZoweExplorerZosmfApi.ts
+++ b/packages/zowe-explorer-api/src/profiles/ZoweExplorerZosmfApi.ts
@@ -58,6 +58,7 @@ export namespace ZoweExplorerZosmf {
                 _: [""],
                 host: serviceProfile.profile.host as string,
                 port: serviceProfile.profile.port as number,
+                protocol: serviceProfile.profile.protocol as string,
                 basePath: serviceProfile.profile.basePath as string,
                 rejectUnauthorized: serviceProfile.profile.rejectUnauthorized as boolean,
             };


### PR DESCRIPTION
## Proposed changes

This is a port of #2705 for the `next` branch.

## Release Notes

Milestone:

Changelog: 

- Fixed issue where `zosmf` profiles did not respect the `protocol` property [#2703](https://github.com/zowe/vscode-extension-for-zowe/issues/2703).

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [x] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
