### PR TITLE
feat(uss,mvs): Add required API `uploadFromBuffer` for use with FileSystemProvider

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,4 @@ results
 scripts
 node_modules
 pnpm-lock.yaml
+bundle.l10n.json

--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the "zowe-explorer-api" extension will be documented in this file.
 
+## TBD Release
+
+### New features and enhancements
+
+- **Breaking:** Added the following **required** API: `uploadFromBuffer`
+  - This API will be used for uploading contents in v3 instead of `putContent(s)`. Extenders must implement this API to continue supporting Zowe Explorer upload operations.
+
+### Bug fixes
+
 ## `3.0.0-next.202402142205`
 
 ### New features and enhancements

--- a/packages/zowe-explorer-api/__tests__/__unit__/profiles/ZoweExplorerZosmfApi.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/profiles/ZoweExplorerZosmfApi.unit.test.ts
@@ -176,6 +176,14 @@ describe("ZosmfUssApi", () => {
         });
     });
 
+    it("uploads a file from buffer", async () => {
+        const uploadFileSpy = jest.spyOn(zowe.Upload, "bufferToUssFile").mockImplementation();
+        const zosmfApi = new ZoweExplorerZosmf.UssApi();
+        const buf = Buffer.from("123abc");
+        await zosmfApi.uploadFromBuffer(buf, "/some/uss/path");
+        expect(uploadFileSpy).toHaveBeenCalledWith(zosmfApi.getSession(), "/some/uss/path", buf, undefined);
+    });
+
     it("constants should be unchanged", () => {
         const zosmfApi = new ZoweExplorerZosmf.UssApi();
         expect(zosmfApi.getProfileTypeName()).toMatchSnapshot();
@@ -464,6 +472,14 @@ describe("ZosmfMvsApi", () => {
         it(`${mvsApi?.name} should inject session into Zowe API`, async () => {
             await expectApiWithSession(mvsApi, new ZoweExplorerZosmf.MvsApi());
         });
+    });
+
+    it("uploads a data set from buffer", async () => {
+        const uploadFileSpy = jest.spyOn(zowe.Upload, "bufferToDataSet").mockImplementation();
+        const zosmfApi = new ZoweExplorerZosmf.MvsApi();
+        const buf = Buffer.from("123abc");
+        await zosmfApi.uploadFromBuffer(buf, "SOME.DS(MEMB)");
+        expect(uploadFileSpy).toHaveBeenCalledWith(zosmfApi.getSession(), buf, "SOME.DS(MEMB)", undefined);
     });
 });
 

--- a/packages/zowe-explorer-api/src/extend/MainframeInteraction.ts
+++ b/packages/zowe-explorer-api/src/extend/MainframeInteraction.ts
@@ -117,6 +117,11 @@ export namespace MainframeInteraction {
         getContents(ussFilePath: string, options: zowe.IDownloadOptions): Promise<zowe.IZosFilesResponse>;
 
         /**
+         * Uploads a given buffer as the contents of a file on USS.
+         */
+        uploadFromBuffer(buffer: Buffer, filePath: string, options?: zowe.IUploadOptions): Promise<string | zowe.IZosFilesResponse>;
+
+        /**
          * Uploads the file at the given path. Use for Save.
          *
          * @param {string} inputFilePath
@@ -214,6 +219,16 @@ export namespace MainframeInteraction {
          * @returns {Promise<zowe.IZosFilesResponse>}
          */
         getContents(dataSetName: string, options?: zowe.IDownloadOptions): Promise<zowe.IZosFilesResponse>;
+
+        /**
+         * Uploads a given buffer as the contents of a file to a data set or member.
+         *
+         * @param {Buffer} buffer
+         * @param {string} dataSetName
+         * @param {zowe.IUploadOptions} [options]
+         * @returns {Promise<zowe.IZosFilesResponse>}
+         */
+        uploadFromBuffer(buffer: Buffer, dataSetName: string, options?: zowe.IUploadOptions): Promise<zowe.IZosFilesResponse>;
 
         /**
          * Upload the content of a file to a data set or member.

--- a/packages/zowe-explorer-api/src/profiles/ZoweExplorerZosmfApi.ts
+++ b/packages/zowe-explorer-api/src/profiles/ZoweExplorerZosmfApi.ts
@@ -126,6 +126,14 @@ export namespace ZoweExplorerZosmf {
             return zowe.Utilities.putUSSPayload(this.getSession(), outputPath, { ...(options ?? {}), request: "copy" });
         }
 
+        public uploadFromBuffer(buffer: Buffer, filePath: string, options?: zowe.IUploadOptions): Promise<string> {
+            // for z/OSMF this is always an empty string, this is because bufferToUssFile in zos-files SDK returns
+            // the data string - but, the API returns a 204 No Content when successful, so the response data will always be empty
+
+            // Once bufferToUssFile is updated to use putExpectJSON, we can also get the e-tag from the response headers.
+            return zowe.Upload.bufferToUssFile(this.getSession(), filePath, buffer, options);
+        }
+
         public putContent(inputFilePath: string, ussFilePath: string, options: zowe.IUploadOptions): Promise<zowe.IZosFilesResponse> {
             return zowe.Upload.fileToUssFile(this.getSession(), inputFilePath, ussFilePath, options);
         }
@@ -221,6 +229,14 @@ export namespace ZoweExplorerZosmf {
 
         public getContents(dataSetName: string, options?: zowe.IDownloadOptions): Promise<zowe.IZosFilesResponse> {
             return zowe.Download.dataSet(this.getSession(), dataSetName, options);
+        }
+
+        public uploadFromBuffer(buffer: Buffer, dataSetName: string, options?: zowe.IUploadOptions): Promise<zowe.IZosFilesResponse> {
+            // for z/OSMF this is always an empty string, this is because bufferToDataSet in zos-files SDK returns
+            // the data string - but, the API returns a 204 No Content when successful, so the response data will always be empty
+
+            // Once bufferToDataSet is updated to use putExpectJSON, we can also get the e-tag from the response headers.
+            return zowe.Upload.bufferToDataSet(this.getSession(), buffer, dataSetName, options);
         }
 
         public putContents(inputFilePath: string, dataSetName: string, options?: zowe.IUploadOptions): Promise<zowe.IZosFilesResponse> {

--- a/packages/zowe-explorer-ftp-extension/CHANGELOG.md
+++ b/packages/zowe-explorer-ftp-extension/CHANGELOG.md
@@ -1,17 +1,26 @@
 All notable changes to the "zowe-explorer-ftp-extension" extension will be documented in this file.
 
+## TBD Release
+
+### New features and enhancements
+
+- Added the following API: `uploadFromBuffer`
+  - This API will be used for uploading contents in v3 instead of `putContent(s)`.
+
+### Bug fixes
+
 ## `3.0.0-next.202402142205`
 
-## New features and enhancements
+### New features and enhancements
 
-## Bug fixes
+### Bug fixes
 
 - Fix Windows-specific hangs when saving members that contain JCL via the FTP extension. Thanks @tiantn & @std4lqi. [#2533](https://github.com/zowe/vscode-extension-for-zowe/issues/2533)
 - Updated dependencies for technical currency purposes.
 
 ## `3.0.0-next.202402071248`
 
-## New features and enhancements
+### New features and enhancements
 
 - Adapted to new API changes from grouping of common methods into singleton classes [#2109](https://github.com/zowe/vscode-extension-for-zowe/issues/2109)
 - Migrated to webpack v5 [#2214](https://github.com/zowe/vscode-extension-for-zowe/issues/2214)

--- a/packages/zowe-explorer-ftp-extension/__tests__/__unit__/Mvs/ZoweExplorerFtpMvsApi.unit.test.ts
+++ b/packages/zowe-explorer-ftp-extension/__tests__/__unit__/Mvs/ZoweExplorerFtpMvsApi.unit.test.ts
@@ -17,6 +17,7 @@ import { FtpMvsApi } from "../../../src/ZoweExplorerFtpMvsApi";
 import { DataSetUtils } from "@zowe/zos-ftp-for-zowe-cli";
 import TestUtils from "../utils/TestUtils";
 import * as tmp from "tmp";
+import * as zowe from "@zowe/cli";
 import { Gui } from "@zowe/zowe-explorer-api";
 import * as globals from "../../../src/globals";
 import { ZoweFtpExtensionError } from "../../../src/ZoweFtpExtensionError";
@@ -440,5 +441,37 @@ describe("FtpMvsApi", () => {
         await expect(async () => {
             await MvsApi.deleteDataSet("IBMUSER.DS");
         }).rejects.toThrow(ZoweFtpExtensionError);
+    });
+
+    describe("uploadFromBuffer", () => {
+        function getBlockMocks(): Record<string, jest.SpyInstance> {
+            return {
+                processNewlinesSpy: jest.spyOn(zowe.imperative.IO, "processNewlines"),
+                putContents: jest.spyOn(MvsApi, "putContents").mockImplementation(),
+                tmpFileSyncMock: jest.spyOn(tmp, "fileSync").mockReturnValueOnce({ fd: 12345 } as any),
+                writeSyncMock: jest.spyOn(fs, "writeSync").mockImplementation(),
+            };
+        }
+
+        it("should upload file from buffer", async () => {
+            const buf = Buffer.from("abc123");
+            const blockMocks = getBlockMocks();
+
+            await MvsApi.uploadFromBuffer(buf, "SOME.DS(MEMB)");
+            expect(blockMocks.tmpFileSyncMock).toHaveBeenCalled();
+            expect(blockMocks.writeSyncMock).toHaveBeenCalled();
+            expect(blockMocks.processNewlinesSpy).toHaveBeenCalled();
+        });
+
+        it("should not process new lines when uploading buffer as binary", async () => {
+            const buf = Buffer.from("abc123");
+            const blockMocks = getBlockMocks();
+            blockMocks.processNewlinesSpy.mockImplementation();
+
+            await MvsApi.uploadFromBuffer(buf, "SOME.DS(MEMB)", { binary: true });
+            expect(blockMocks.tmpFileSyncMock).toHaveBeenCalled();
+            expect(blockMocks.writeSyncMock).toHaveBeenCalled();
+            expect(blockMocks.processNewlinesSpy).not.toHaveBeenCalled();
+        });
     });
 });

--- a/packages/zowe-explorer-ftp-extension/src/ZoweExplorerFtpMvsApi.ts
+++ b/packages/zowe-explorer-ftp-extension/src/ZoweExplorerFtpMvsApi.ts
@@ -111,6 +111,19 @@ export class FtpMvsApi extends AbstractFtpApi implements MainframeInteraction.IM
         }
     }
 
+    public async uploadFromBuffer(buffer: Buffer, dataSetName: string, options?: zowe.IUploadOptions): Promise<zowe.IZosFilesResponse> {
+        const tempFile = tmp.fileSync();
+        if (options?.binary) {
+            fs.writeSync(tempFile.fd, buffer);
+        } else {
+            const text = zowe.imperative.IO.processNewlines(buffer.toString());
+            fs.writeSync(tempFile.fd, text);
+        }
+
+        const result = await this.putContents(tempFile.name, dataSetName, options);
+        return result;
+    }
+
     public async putContents(inputFilePath: string, dataSetName: string, options: IUploadOptions): Promise<zowe.IZosFilesResponse> {
         const file = path.basename(inputFilePath).replace(/[^a-z0-9]+/gi, "");
         const member = file.substr(0, MAX_MEMBER_NAME_LEN);

--- a/packages/zowe-explorer-ftp-extension/src/ZoweExplorerFtpUssApi.ts
+++ b/packages/zowe-explorer-ftp-extension/src/ZoweExplorerFtpUssApi.ts
@@ -88,6 +88,19 @@ export class FtpUssApi extends AbstractFtpApi implements MainframeInteraction.IU
         }
     }
 
+    public async uploadFromBuffer(buffer: Buffer, filePath: string, options?: zowe.IUploadOptions): Promise<zowe.IZosFilesResponse> {
+        const tempFile = tmp.fileSync();
+        if (options?.binary) {
+            fs.writeSync(tempFile.fd, buffer);
+        } else {
+            const text = zowe.imperative.IO.processNewlines(buffer.toString());
+            fs.writeSync(tempFile.fd, text);
+        }
+
+        const result = await this.putContent(tempFile.name, filePath, options);
+        return result;
+    }
+
     /**
      * Upload a file (located at the input path) to the destination path.
      * @param inputFilePath The input file path

--- a/packages/zowe-explorer/__tests__/__unit__/command/unixCommandHandler.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/command/unixCommandHandler.unit.test.ts
@@ -538,31 +538,31 @@ describe("UnixCommand Actions Unit Testing", () => {
         expect(showInformationMessage.mock.calls[0][0]).toEqual("Operation Cancelled");
     });
 
-    it("Not able to issue the command", async () =>{
-        Object.defineProperty(ZoweExplorerApiRegister,"getInstance",{
-            value: jest.fn(()=>{
-                return{
-                getCommandApi: jest.fn(()=>undefined),
-                }
-            })
-        })
-        await unixActions.issueUnixCommand(session,null as any,testNode);
+    it("Not able to issue the command", async () => {
+        Object.defineProperty(ZoweExplorerApiRegister, "getInstance", {
+            value: jest.fn(() => {
+                return {
+                    getCommandApi: jest.fn(() => undefined),
+                };
+            }),
+        });
+        await unixActions.issueUnixCommand(session, null as any, testNode);
         expect(showErrorMessage.mock.calls[0][0]).toEqual("Issuing Commands is not supported for this profile.");
-    })
+    });
 
-    it("Not yet implemented for specific profile", async ()=>{
-        Object.defineProperty(ZoweExplorerApiRegister,"getInstance",{
-            value: jest.fn(()=>{
-                return{
-                getCommandApi: jest.fn(()=> ({
-                    return : {
-                    issueUnixCommand: jest.fn()
-                    }
-                })),
-                }
-            })
-        })
-        await unixActions.issueUnixCommand(session,null as any,testNode);
+    it("Not yet implemented for specific profile", async () => {
+        Object.defineProperty(ZoweExplorerApiRegister, "getInstance", {
+            value: jest.fn(() => {
+                return {
+                    getCommandApi: jest.fn(() => ({
+                        return: {
+                            issueUnixCommand: jest.fn(),
+                        },
+                    })),
+                };
+            }),
+        });
+        await unixActions.issueUnixCommand(session, null as any, testNode);
         expect(showErrorMessage.mock.calls[0][0]).toEqual("Not implemented yet for profile of type: zosmf");
-    })
+    });
 });

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -2041,7 +2041,7 @@
     ]
   },
   "scripts": {
-    "build": "pnpm clean:bundle && pnpm license && webpack --mode development",
+    "build": "pnpm clean:bundle && (pnpm madge || true) && pnpm license && webpack --mode development",
     "build:integration": "pnpm createTestProfileData && pnpm license && tsc --pretty --project tsconfig-tests.json",
     "test:unit": "jest \".*__tests__.*\\.unit\\.test\\.ts\" --coverage",
     "test:theia": "mocha ./out/__tests__/__theia__/*.theia.test.js --timeout 50000 --reporter mocha-multi-reporters --reporter-options configFile=.mocharc.json",
@@ -2062,7 +2062,7 @@
     "clean:bundle": "rimraf out || true",
     "clean:dependencies": "rimraf node_modules || true",
     "fresh-clone": "pnpm clean:bundle && pnpm clean:dependencies",
-    "madge": "madge -c --no-color --no-spinner --exclude __mocks__ --extensions js,ts src/ || true",
+    "madge": "madge -c --no-color --no-spinner --exclude __mocks__ --extensions js,ts src/",
     "pretty": "prettier --write .",
     "createTestProfileData": "ts-node ./scripts/createTestProfileData.ts",
     "createDemoNodes": "ts-node ./scripts/createDemoNodes.ts",


### PR DESCRIPTION
## Proposed changes

This PR implements the single breaking change from the FileSystemProvider: the required `uploadFromBuffer` API.
This branch has implementations for the z/OSMF MVS, USS, and z/FTP APIs.

## Release Notes

Milestone:

Changelog:

- Added the following API: `uploadFromBuffer`
  - This API will be used for uploading contents in v3 instead of `putContent(s)`.

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)