### PR TITLE
Fix bug for Unix command to work with profile that doesn't require ssh

### DIFF
--- a/packages/zowe-explorer/__tests__/__unit__/command/unixCommandHandler.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/command/unixCommandHandler.unit.test.ts
@@ -135,7 +135,7 @@ describe("UnixCommand Actions Unit Testing", () => {
         } as imperative.IProfileLoaded,
     ];
 
-    let profilefromConfig = {
+    const profilefromConfig = {
         isDefaultProfile: false,
         profLoc: { osLoc: ["/user/configpath"] },
     };
@@ -170,11 +170,6 @@ describe("UnixCommand Actions Unit Testing", () => {
 
     Object.defineProperty(ZoweLogger, "error", { value: jest.fn(), configurable: true });
     Object.defineProperty(ZoweLogger, "trace", { value: jest.fn(), configurable: true });
-    Object.defineProperty(imperative.ConnectionPropsForSessCfg, "addPropsOrPrompt", {
-        value: jest.fn(() => {
-            return { privateKey: undefined, keyPassphrase: undefined, handshakeTimeout: undefined, type: "basic", port: 22 };
-        }),
-    });
 
     Object.defineProperty(profileLoader.Profiles, "getInstance", {
         value: jest.fn(() => {

--- a/packages/zowe-explorer/__tests__/__unit__/command/unixCommandHandler.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/command/unixCommandHandler.unit.test.ts
@@ -242,7 +242,7 @@ describe("UnixCommand Actions Unit Testing", () => {
         });
         expect(showInputBox.mock.calls.length).toBe(2);
         expect(appendLine.mock.calls.length).toBe(2);
-        expect(appendLine.mock.calls[0][0]).toBe("> testuser@ssh:/u/directorypath$ d iplinfo1");
+        expect(appendLine.mock.calls[0][0]).toBe("> firstName@ssh:/u/directorypath$ d iplinfo1");
         expect(appendLine.mock.calls[1][0]["commandResponse"]).toBe("iplinfo1");
         expect(showInformationMessage.mock.calls.length).toBe(0);
     });
@@ -277,7 +277,7 @@ describe("UnixCommand Actions Unit Testing", () => {
         });
         expect(showInputBox.mock.calls.length).toBe(1);
         expect(appendLine.mock.calls.length).toBe(2);
-        expect(appendLine.mock.calls[0][0]).toBe("> testuser@ssh:/u/directorypath$ d iplinfo0");
+        expect(appendLine.mock.calls[0][0]).toBe("> firstName@ssh:/u/directorypath$ d iplinfo0");
         expect(appendLine.mock.calls[1][0]["commandResponse"]).toBe("iplinfo0");
         expect(showInformationMessage.mock.calls.length).toBe(0);
     });
@@ -538,31 +538,31 @@ describe("UnixCommand Actions Unit Testing", () => {
         expect(showInformationMessage.mock.calls[0][0]).toEqual("Operation Cancelled");
     });
 
-    it("Not able to issue the command", async () =>{
-        Object.defineProperty(ZoweExplorerApiRegister,"getInstance",{
-            value: jest.fn(()=>{
-                return{
-                getCommandApi: jest.fn(()=>undefined),
-                }
-            })
-        })
-        await unixActions.issueUnixCommand(session,null as any,testNode);
+    it("Not able to issue the command", async () => {
+        Object.defineProperty(ZoweExplorerApiRegister, "getInstance", {
+            value: jest.fn(() => {
+                return {
+                    getCommandApi: jest.fn(() => undefined),
+                };
+            }),
+        });
+        await unixActions.issueUnixCommand(session, null as any, testNode);
         expect(showErrorMessage.mock.calls[0][0]).toEqual("Issuing Commands is not supported for this profile.");
-    })
+    });
 
-    it("Not yet implemented for specific profile", async ()=>{
-        Object.defineProperty(ZoweExplorerApiRegister,"getInstance",{
-            value: jest.fn(()=>{
-                return{
-                getCommandApi: jest.fn(()=> ({
-                    return : {
-                    issueUnixCommand: jest.fn()
-                    }
-                })),
-                }
-            })
-        })
-        await unixActions.issueUnixCommand(session,null as any,testNode);
+    it("Not yet implemented for specific profile", async () => {
+        Object.defineProperty(ZoweExplorerApiRegister, "getInstance", {
+            value: jest.fn(() => {
+                return {
+                    getCommandApi: jest.fn(() => ({
+                        return: {
+                            issueUnixCommand: jest.fn(),
+                        },
+                    })),
+                };
+            }),
+        });
+        await unixActions.issueUnixCommand(session, null as any, testNode);
         expect(showErrorMessage.mock.calls[0][0]).toEqual("Not implemented yet for profile of type: zosmf");
-    })
+    });
 });

--- a/packages/zowe-explorer/src/command/UnixCommandHandler.ts
+++ b/packages/zowe-explorer/src/command/UnixCommandHandler.ts
@@ -333,8 +333,12 @@ export class UnixCommandHandler extends ZoweCommandProvider {
                 if (command.startsWith("/")) {
                     command = command.substring(1);
                 }
-                const user: string = this.sshprofile.profile.user;
-                this.outputChannel.appendLine(`> ${user}@${this.sshprofile.name}:${cwd ? cwd : "~"}$ ${command}`);
+                const user: string = profile.profile.user;
+                if (this.sshprofile) {
+                    this.outputChannel.appendLine(`> ${user}@${this.sshprofile.name}:${cwd ? cwd : "~"}$ ${command}`);
+                } else {
+                    this.outputChannel.appendLine(`> ${user}:${cwd ? cwd : "~"}$ ${command}`);
+                }
                 const submitResponse = await Gui.withProgress(
                     {
                         location: vscode.ProgressLocation.Notification,


### PR DESCRIPTION
## Proposed changes

As RSE profiles do not require ssh profile for issuing unix commands. Fixing the bug for the line of code  https://github.com/zowe/vscode-extension-for-zowe/blob/e07d93405327995fd83c15622cfb0e7e9633c608/packages/zowe-explorer/src/command/UnixCommandHandler.ts#L336 so that it would work with RSE profiles too.
## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog -->
<!-- If there is a linked issue, it should have the same milestone as this PR -->

Milestone:

Changelog:

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [ ] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [ ] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
