### PR TITLE
fix(v3): Make `getJobsByParameters` required and fix "Allocate Like" placeholder text

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 ### New features and enhancements
 
+- **Breaking:** Made `MainframeInteraction.IJes.getJobsByParameters` a required function now that `getJobsByOwnerAndPrefix` has been removed.
+
 ### Bug fixes
 
 ## `3.0.0-next.202403051607`

--- a/packages/zowe-explorer-api/src/extend/MainframeInteraction.ts
+++ b/packages/zowe-explorer-api/src/extend/MainframeInteraction.ts
@@ -372,7 +372,7 @@ export namespace MainframeInteraction {
          * @param {string} owner
          * @returns {Promise<zosjobs.IJob[]>} an array if IJob
          */
-        getJobsByParameters?(params: zosjobs.IGetJobsParms): Promise<zosjobs.IJob[]>;
+        getJobsByParameters(params: zosjobs.IGetJobsParms): Promise<zosjobs.IJob[]>;
 
         /**
          * Returns meta-data for one specific job identified by id.

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
+- Fixed issue where "Allocate Like" input box placeholder was showing a localization ID instead of the intended message ("Enter a name for the new data set"). [#2759](https://github.com/zowe/vscode-extension-for-zowe/issues/2759)
+
 ## `3.0.0-next.202403051607`
 
 ### New features and enhancements

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -125,7 +125,7 @@ export async function allocateLike(datasetProvider: Types.IZoweDatasetTreeType, 
     // Get new data set name
     const options: vscode.InputBoxOptions = {
         ignoreFocusOut: true,
-        placeHolder: vscode.l10n.t("allocateLike.inputBox.placeHolder", "Enter a name for the new data set"),
+        placeHolder: vscode.l10n.t("Enter a name for the new data set"),
         validateInput: (text) => {
             return dsUtils.validateDataSetName(text) === true ? null : vscode.l10n.t("Enter a valid data set name.");
         },


### PR DESCRIPTION
## Proposed changes

- **Breaking:** Made `getJobsByParameters` required now that `getJobsByOwnerAndPrefix` has been removed
- Fixed the issue where the "Allocate Like" placeholder contained an old ID from the previously used i18n localization.

_Before:_
![image](https://github.com/zowe/vscode-extension-for-zowe/assets/86500639/70052515-65a0-44db-8ce2-8ceda116c2c5)

_After:_
![image](https://github.com/zowe/vscode-extension-for-zowe/assets/86500639/825dde8c-418d-4830-ab50-a666804a478b)

## Release Notes

Milestone: v3

Changelog: 
- **Breaking:** Made `MainframeInteraction.IJes.getJobsByParameters` a required function now that `getJobsByOwnerAndPrefix` has been removed.
- Fixed issue where "Allocate Like" input box placeholder was showing a localization ID instead of the intended message ("Enter a name for the new data set"). [#2759](https://github.com/zowe/vscode-extension-for-zowe/issues/2759)

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [x] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)